### PR TITLE
refactor: replace tight_layout with subplots_adjust

### DIFF
--- a/src/autoclean/mixins/viz/visualization.py
+++ b/src/autoclean/mixins/viz/visualization.py
@@ -943,7 +943,7 @@ class VisualizationMixin:
 
         # Add suptitle and adjust layout
         fig.suptitle(os.path.basename(raw_cleaned.filenames[0]), fontsize=16)
-        plt.tight_layout(rect=[0, 0.03, 1, 0.95])
+        fig.subplots_adjust(top=0.95, bottom=0.03)
 
         # Save and close figure
         fig.savefig(target_figure, dpi=300)


### PR DESCRIPTION
## Summary
- replace `plt.tight_layout` with manual `fig.subplots_adjust` in `step_psd_topo_figure` to prevent layout warnings

## Testing
- `pre-commit run --files src/autoclean/mixins/viz/visualization.py` *(fails: command not found)*
- `pytest` *(fails: unrecognized arguments: --cov=autoclean)*
- custom script exercising `step_psd_topo_figure` on synthetic data

------
https://chatgpt.com/codex/tasks/task_e_68b4bce28dcc832b93b79af7497033d1