### PR TITLE
feat: allow disabling flagged file relocation

### DIFF
--- a/docs/tutorials/creating_custom_task.rst
+++ b/docs/tutorials/creating_custom_task.rst
@@ -107,6 +107,10 @@ That's it! AutoClean will automatically find and use your custom task.
 
 Your task configuration controls every aspect of processing. Here are the key sections:
 
+.. note::
+
+   To keep flagged runs in the standard output folders, add ``config['move_flagged_files'] = False`` to your task file. By default, flagged outputs are moved to ``FLAGGED_*`` directories.
+
 **Basic Preprocessing:**
 
 .. code-block:: python

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -406,7 +406,7 @@ class Pipeline:
                     )
 
                 # Copy final files to the dedicated final_files directory
-                if not flagged:  # Only copy if processing was successful
+                if not flagged or not run_dict.get("move_flagged_files", True):
                     copy_final_files(run_dict)
 
             except Exception as e:  # pylint: disable=broad-except

--- a/src/autoclean/core/task.py
+++ b/src/autoclean/core/task.py
@@ -102,6 +102,12 @@ class Task(ABC, *DISCOVERED_MIXINS):
         # Extract EEG system from task settings before validation
         config["eeg_system"] = self._extract_eeg_system()
 
+        # Propagate task-level move_flagged_files setting (default True)
+        if self.settings and "move_flagged_files" in self.settings:
+            config.setdefault("move_flagged_files", self.settings["move_flagged_files"])
+        else:
+            config.setdefault("move_flagged_files", True)
+
         # Configuration must be validated first as other initializations depend on it
         self.config = self.validate_config(config)
 

--- a/src/autoclean/io/export.py
+++ b/src/autoclean/io/export.py
@@ -143,6 +143,8 @@ def save_raw_to_set(
     basename = Path(autoclean_dict["unprocessed_file"]).stem
     stage_num = _get_stage_number(stage, autoclean_dict)
 
+    flagged = flagged and autoclean_dict.get("move_flagged_files", True)
+
     # Save to BIDS-compliant intermediate directory structure
     if flagged:
         output_path = autoclean_dict["stage_dir"]
@@ -237,6 +239,8 @@ def save_epochs_to_set(
     suffix = f"_{stage.replace('post_', '')}"
     basename = Path(autoclean_dict["unprocessed_file"]).stem
     stage_num = _get_stage_number(stage, autoclean_dict)
+
+    flagged = flagged and autoclean_dict.get("move_flagged_files", True)
 
     # Determine output directory based on flagged status - BIDS-compliant structure
     if flagged:

--- a/src/autoclean/templates/custom_task_template.py
+++ b/src/autoclean/templates/custom_task_template.py
@@ -31,6 +31,8 @@ config = {
     #   "input_path": "/path/to/my/data.raw",           # Single file
     #   "input_path": "/path/to/data/directory/",       # Directory
     "input_path": "/path/to/my/data/",  # Uncomment and modify for your data
+    # Optional: keep flagged files in standard output directories
+    # "move_flagged_files": False,
     "resample_step": {"enabled": True, "value": 250},  # Resample to 250 Hz
     "filtering": {
         "enabled": True,


### PR DESCRIPTION
## Summary
- honor `move_flagged_files` from task configs to control relocating flagged results
- prevent export helpers from moving flagged files when relocation is disabled
- copy final files even when flagged if relocation is turned off
- document new `move_flagged_files` option in task template and custom task guide

## Testing
- `pytest -q` *(fails: missing pytest-cov plugin)*
- `pip install pytest-cov` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b4edf25a10832b8afcfbcd73083ea3