### PR TITLE
Include raw files in default glob

### DIFF
--- a/docs/cli-help-backup-20250830_162135.md
+++ b/docs/cli-help-backup-20250830_162135.md
@@ -64,7 +64,7 @@ options:
                         to positional)
   --output OUTPUT       Output directory (default: workspace/output)
   --format FORMAT       File format glob pattern for directory processing
-                        (default: *.set). Examples: '*.raw', '*.edf', '*.set'.
+                        (default: *.{raw,set}). Examples: '*.raw', '*.edf', '*.set'.
                         Note: '.raw' will be auto-corrected to '*.raw'
   --recursive           Search subdirectories recursively
   --dry-run             Show what would be processed without running

--- a/docs/task_generator_wizard.md
+++ b/docs/task_generator_wizard.md
@@ -69,9 +69,9 @@ Use the Task class name shown in `task list` (for the example above it’s likel
 autocleaneeg-pipeline process RestingState /path/to/data.raw
 ```
 
-- Directory of files (example pattern for EEGLAB `.set`):
+- Directory of files (default pattern matches `.raw` and `.set`):
 ```bash
-autocleaneeg-pipeline process RestingState /path/to/dir --format "*.set" --recursive
+autocleaneeg-pipeline process RestingState /path/to/dir --recursive
 ```
 
 - Start the review GUI for your workspace output:
@@ -86,7 +86,7 @@ from autoclean.core.pipeline import Pipeline
 pipeline = Pipeline(output_dir=None)  # default to workspace/output
 pipeline.process_file("/path/to/data.raw", task="RestingState")
 # Or for a directory
-# pipeline.process_directory(directory="/path/to/dir", task="RestingState", pattern="*.set", recursive=True)
+# pipeline.process_directory(directory="/path/to/dir", task="RestingState", pattern="*.{raw,set}", recursive=True)
 ```
 
 ## Helpful Workspace Shortcuts

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -638,8 +638,8 @@ For detailed help on any command: autocleaneeg-pipeline <command> --help
     process_parser.add_argument(
         "--format",
         type=str,
-        default="*.set",
-        help="File format glob pattern for directory processing (default: *.set). Examples: '*.raw', '*.edf', '*.set'. Note: '.raw' will be auto-corrected to '*.raw'",
+        default="*.{raw,set}",
+        help="File format glob pattern for directory processing (default: *.{raw,set}). Examples: '*.raw', '*.edf', '*.set'. Note: '.raw' will be auto-corrected to '*.raw'",
     )
     process_parser.add_argument(
         "--recursive",
@@ -1259,7 +1259,7 @@ def _show_process_guard(args) -> bool:
                 console.print("   Type: [accent]Directory[/accent]")
                 
                 # Count files based on format pattern
-                format_pattern = getattr(args, 'format', '*.set')
+                format_pattern = getattr(args, 'format', '*.{raw,set}')
                 try:
                     if getattr(args, 'recursive', False):
                         files = list(input_path.rglob(format_pattern))
@@ -1349,7 +1349,7 @@ def validate_args(args) -> bool:
                     "dir|--dir", "Directory of EEG files (use --format, --recursive)"
                 )
                 tbl.add_row(
-                    "--format", "Glob pattern (default: *.set; '*.raw', '*.edf', ...)"
+                    "--format", "Glob pattern (default: *.{raw,set}; '*.raw', '*.edf', ...)"
                 )
                 tbl.add_row("--recursive", "Search subdirectories for matching files")
                 tbl.add_row("-p N", "Process N files in parallel (default 3, max 8)")
@@ -1433,7 +1433,7 @@ def validate_args(args) -> bool:
                         )
                         tbl.add_row(
                             "--format",
-                            "Glob pattern (default: *.set; '*.raw', '*.edf', ...)",
+                            "Glob pattern (default: *.{raw,set}; '*.raw', '*.edf', ...)",
                         )
                         tbl.add_row(
                             "--recursive", "Search subdirectories for matching files"

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -621,7 +621,7 @@ class Pipeline:
         self,
         directory: Optional[str | Path] = None,
         task: str = "",
-        pattern: str = "*.set",
+        pattern: str = "*.{raw,set}",
         recursive: bool = False,
     ) -> None:
         """Processes all files matching a pattern within a directory sequentially.
@@ -634,7 +634,7 @@ class Pipeline:
         task : str
             The name of the task to perform (e.g., 'RestingEyesOpen').
         pattern : str, optional
-            Glob pattern to match files within the directory, default is `*.set`.
+            Glob pattern to match files within the directory, default is `*.{raw,set}`.
         recursive : bool, optional
             If True, searches subdirectories recursively, by default False.
 
@@ -653,11 +653,11 @@ class Pipeline:
         >>> pipeline.process_directory(
         ...     directory='data/rest_state/',
         ...     task='rest_eyesopen',
-        ...     pattern='*.raw',
+        ...     pattern='*.{raw,set}',
         ...     recursive=True
         ... )
         >>> # Or use input_path from task config
-        >>> pipeline.process_directory(task='rest_eyesopen', pattern='*.raw')
+        >>> pipeline.process_directory(task='rest_eyesopen', pattern='*.{raw,set}')
         """
         # Use input_path from task config if directory not provided
         if directory is None:
@@ -724,7 +724,7 @@ class Pipeline:
         self,
         directory_path: Optional[str | Path] = None,
         task: str = "",
-        pattern: str = "*.raw",
+        pattern: str = "*.{raw,set}",
         sub_directories: bool = False,
         max_concurrent: int = 3,
     ) -> None:
@@ -738,7 +738,7 @@ class Pipeline:
         task : str
             The name of the task to perform (e.g., 'RestingEyesOpen').
         pattern : str, optional
-            Glob pattern to match files within the directory, default is `*.raw`.
+            Glob pattern to match files within the directory, default is `*.{raw,set}`.
         sub_directories : bool, optional
             If True, searches subdirectories recursively, by default False.
         max_concurrent : int, optional


### PR DESCRIPTION
## Summary
- include `.raw` alongside `.set` in pipeline directory processing
- update CLI `--format` default and help to match the new glob
- document that the default glob now handles both `.raw` and `.set`

## Testing
- `PYTHONPATH=src pytest tests -q -c /dev/null` *(fails: ImportError: cannot import name 'create_sl_epochs')*


------
https://chatgpt.com/codex/tasks/task_e_68b4fbbd34bc832b952c0accebfc2942