### PR TITLE
fix: remove input subcommands from task help display

### DIFF
--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -386,9 +386,6 @@ def _print_root_help(console, topic: Optional[str] = None) -> None:
             ("🎯 task set [name]", "Set active task (interactive if omitted)"),
             ("🧹 task unset", "Clear the active task"),
             ("👁️  task show", "Show the current active task"),
-            ("📁 input set [path]", "Set active input path (interactive if omitted)"),
-            ("🧹 input unset", "Clear the active input path"),
-            ("👁️  input show", "Show the current active input path"),
         ]
         for c, d in rows:
             tbl.add_row(c, d)


### PR DESCRIPTION
Fixes #67

Remove incorrectly placed input commands (set, unset, show) from the
task help section. These commands now only appear in their proper
input help section, fixing the issue where 'task' subcommands were
showing input-related commands.

## Changes
- Cleaned up task help display to show only task-related commands
- Input commands now properly isolated to input help section

Generated with [Claude Code](https://claude.ai/code)