### PR TITLE
docs: add MDX pages for pipeline outputs and review tools

### DIFF
--- a/docs/mdx/artifact-steps.mdx
+++ b/docs/mdx/artifact-steps.mdx
@@ -1,0 +1,98 @@
+---
+title: Artifact and Epoching Steps
+description: Functions that label and clean artifacts and create analysis-ready epochs.
+---
+
+# Artifact and Epoching Steps
+
+After basic preprocessing, AutoClean tasks apply a sequence of functions that tag artifacts, run ICA, and prepare epochs for analysis.
+
+## Annotate noisy epochs
+Flags high-variance segments by temporarily epoching the continuous signal and measuring channel standard deviations.
+
+**Technical details:** Custom algorithm that uses an interquartile range (IQR) rule to mark epochs where many channels have outlier variance.
+
+**Parameters**
+- `epoch_duration`, `epoch_overlap` – size and overlap of temporary epochs in seconds.
+- `quantile_k` – IQR multiplier for outlier detection.
+- `quantile_flag_crit` – proportion of channels required to flag an epoch.
+- `annotation_description` – text for added annotations.
+
+## Annotate uncorrelated epochs
+Identifies periods where channels lose spatial correlation with their neighbors.
+
+**Technical details:** Custom routine that computes nearest-neighbor correlations using channel locations; epochs with too many low-correlation channels are annotated.
+
+**Parameters**
+- `epoch_duration`, `epoch_overlap` – epoch size and overlap in seconds.
+- `n_nearest_neighbors` – number of spatial neighbors per channel.
+- `corr_method`, `corr_trim_percent` – aggregation strategy for neighbor correlations.
+- `outlier_k`, `outlier_flag_crit` – thresholds for marking epochs.
+- `annotation_description` – text for added annotations.
+
+## Detect dense oscillatory artifacts
+Looks for short bursts of oscillations that appear across many channels simultaneously.
+
+**Technical details:** Custom sliding-window algorithm counting channels whose peak-to-peak amplitude exceeds a threshold.
+
+**Parameters**
+- `window_size_ms` – window length in milliseconds.
+- `channel_threshold_uv` – per-channel peak-to-peak amplitude threshold (µV).
+- `min_channels` – minimum number of channels exceeding the threshold.
+- `padding_ms` – padding added before/after detected artifacts.
+- `annotation_label` – description for annotations.
+
+## Run ICA
+Decomposes the signal into independent components for later artifact rejection.
+
+**Technical details:** `run_ica` wraps `autoclean.functions.ica.fit_ica`, which uses `mne.preprocessing.ICA` and optional temporary high-pass filtering.
+
+**Parameters**
+- `method`, `n_components`, `fit_params` – passed to MNE's ICA.
+- `temp_highpass_for_ica` – optional high-pass filter applied only for decomposition.
+
+## Classify and reject components
+Labels ICA components as brain or artifact and optionally removes the bad ones.
+
+**Technical details:** `classify_ica_components` calls AutoClean's classifier wrappers (ICLabel or ICVision). `apply_ica_component_rejection` then drops components exceeding an optional probability threshold.
+
+**Parameters**
+- `method` – `'iclabel'` (machine learning) or `'icvision'` (custom template matching).
+- `ic_flags_to_reject` – component labels considered artifacts.
+- `ic_rejection_threshold` – minimum probability for rejection.
+- `psd_fmax` – max frequency in power spectrum plots (ICVision only).
+
+## Create regular epochs
+Splits continuous data into fixed-length segments for analysis.
+
+**Technical details:** Wrapper around `autoclean.functions.epoching.create_regular_epochs`, which builds events and constructs an `mne.Epochs` object while tracking metadata.
+
+**Parameters**
+- `tmin`, `tmax` – epoch boundaries in seconds.
+- `remove_baseline.window` – baseline interval if enabled.
+- `threshold_rejection.volt_threshold` – amplitude rejection threshold.
+- `reject_by_annotation` – drop epochs overlapping bad annotations.
+
+## Detect outlier epochs
+Removes epochs with abnormal amplitude or variance.
+
+**Technical details:** `detect_outlier_epochs` implements a FASTER-inspired z-score approach across mean, variance, maximum, and range metrics.
+
+**Parameters**
+- `threshold` – z-score required to mark an epoch as an outlier.
+
+## GFP clean epochs
+Drops epochs with extreme Global Field Power (GFP) values and optionally subsamples to a fixed count.
+
+**Technical details:** `gfp_clean_epochs` computes GFP across scalp electrodes and removes epochs whose GFP z-score exceeds a threshold.
+
+**Parameters**
+- `gfp_threshold` – z-score cutoff.
+- `number_of_epochs` – randomly retain this many cleaned epochs.
+- `random_seed` – seed used when selecting epochs.
+
+## Generate reports
+Creates before/after visualizations for quality control.
+
+**Technical details:** Combines mixin helpers like `plot_raw_vs_cleaned_overlay` and `step_psd_topo_figure` to save diagnostic figures.
+

--- a/docs/mdx/pipeline-outputs.mdx
+++ b/docs/mdx/pipeline-outputs.mdx
@@ -1,0 +1,54 @@
+---
+title: Pipeline Outputs
+description: Subject- and group-level outputs produced by an AutoClean run.
+---
+
+# Pipeline Outputs
+
+Each AutoClean run creates a structured folder containing everything needed to reproduce and review your results.
+
+<Note>
+The folder name uses the task you executed, allowing multiple tasks to share the same project without overwriting previous runs.
+</Note>
+
+## Subject-level artifacts
+
+### `bids/` – cleaned EEG
+- Cleaned continuous and epoched data in BIDS format
+- Channel metadata and events files
+
+### `derivatives/` – reports and visualizations
+- HTML/PDF processing reports
+- ICA plots, power spectra, and before/after comparisons
+
+### `logs/` – processing logs
+- Step-by-step log of every operation
+- Helpful for debugging failed runs
+
+### `metadata/` – run metadata
+- JSON files describing parameters and quality metrics
+- Links back to the database run record
+
+### `stage_files/` – intermediate exports
+- Optional exports from custom steps
+- Files are numbered in run order (01_, 02_, …)
+
+### `flagged/` – runs requiring review
+- Outputs moved here when quality thresholds are not met
+
+## Group-level artifacts
+
+When multiple subjects are processed, AutoClean can generate group-level summaries:
+
+- **Exported metrics** inside `exported_data/` for downstream analysis
+- **Group analysis** results produced by tools such as `assr_viz.py` that aggregate heatmap data into `group_analysis/`
+- **Combined reports** that collate per-subject quality metrics
+
+<Tip>
+Group folders are safe to delete and regenerate because underlying subject results remain intact.
+</Tip>
+
+## Run record
+
+Every run also writes a JSON run record to the internal database capturing the information above and listing output file names. The run ID connects the filesystem results with tools like the review interface.
+

--- a/docs/mdx/preprocessing-steps.mdx
+++ b/docs/mdx/preprocessing-steps.mdx
@@ -1,0 +1,91 @@
+---
+title: Preprocessing Steps
+description: Functions that prepare EEG recordings before artifact detection.
+---
+
+# Preprocessing Steps
+
+Each task file calls a series of preprocessing functions that prepare the raw EEG signal for later artifact detection and epoching.
+
+## Import raw
+Loads the unprocessed recording from disk.
+
+**Technical details:** Wrapper around MNE's readers via `import_raw`, supporting FIF, EDF and other common formats.
+
+## Resample data
+Adjusts the sampling rate for faster processing or to match analysis requirements.
+
+**Technical details:** `resample_data` wraps `autoclean.functions.preprocessing.resample_data`, which calls `mne.io.Raw.resample` and records metadata.
+
+**Parameters**
+- `target_sfreq` – desired sampling frequency in Hz.
+- `npad`, `window`, `n_jobs`, `pad`, `verbose` – optional resampling controls.
+
+## Filter data
+Applies band-pass and notch filters to isolate frequencies of interest and remove line noise.
+
+**Technical details:** `filter_data` uses AutoClean's wrapper around `mne.filter.filter_data` to log filter settings.
+
+**Parameters**
+- `l_freq`, `h_freq` – high- and low-cutoff frequencies in Hz.
+- `notch_freqs`, `notch_widths` – notch filter settings.
+
+## Drop outer layer
+Removes peripheral electrodes that are prone to noise.
+
+**Technical details:** `drop_outer_layer` is a thin wrapper over `raw.drop_channels` and saves the result.
+
+**Parameters**
+- `value` – list of channel names to drop.
+
+## Assign EOG channels
+Marks specific channels as electrooculogram (EOG) sensors so downstream tools treat them separately.
+
+**Technical details:** `assign_eog_channels` sets channel types using `raw.set_channel_types`.
+
+**Parameters**
+- `value` – channel indices or names corresponding to EOG sensors.
+
+## Trim edges
+Removes a fixed duration from the start and end of the recording.
+
+**Technical details:** `trim_edges` calls `raw.crop` with symmetric time offsets.
+
+**Parameters**
+- `value` – seconds to trim from each edge.
+
+## Crop duration
+Keeps only a specified time window from the recording.
+
+**Technical details:** `crop_duration` uses `raw.crop` with explicit `start` and `end` times.
+
+**Parameters**
+- `start`, `end` – window boundaries in seconds.
+
+## Clean bad channels
+Identifies noisy electrodes and interpolates or drops them.
+
+**Technical details:** `clean_bad_channels` relies on the PyPREP `NoisyChannels` routines via `detect_bad_channels`.
+
+**Parameters**
+- `correlation_thresh`, `deviation_thresh` – statistical thresholds.
+- `ransac_sample_prop`, `ransac_corr_thresh`, `ransac_frac_bad`, `ransac_channel_wise` – RANSAC settings.
+- `cleaning_method` – `'interpolate'`, `'drop'`, or `None`.
+- `reset_bads` – whether to clear the bad list after cleaning.
+
+## Re-reference data
+Recomputes the reference for all channels.
+
+**Technical details:** `rereference_data` wraps `mne.set_eeg_reference` for Raw or Epochs objects.
+
+**Parameters**
+- `value` – reference type or list of channels.
+
+## Montage
+Applies a sensor layout so spatial operations know channel positions.
+
+**Technical details:** wrapper around `raw.set_montage` using MNE's built-in montages.
+
+**Parameters**
+- `value` – name of an MNE montage (e.g., `"GSN-HydroCel-129"`).
+

--- a/docs/mdx/run-records.mdx
+++ b/docs/mdx/run-records.mdx
@@ -1,0 +1,28 @@
+---
+title: Run Records and Database
+description: How AutoClean tracks every pipeline execution.
+---
+
+# Run Records and Database
+
+AutoClean keeps a lightweight SQLite database inside your output directory. Each pipeline execution is assigned a ULID-based `run_id` and a run record that describes the processed file, the task used, and where outputs were written.
+
+```json
+{
+  "run_id": "01HF...",
+  "timestamp": "2025-04-02 10:15:00",
+  "task": "RestingEyesOpen",
+  "unprocessed_file": "/data/sub-01/eeg/rest.fif",
+  "status": "completed",
+  "success": true,
+  "json_file": "sub-01_autoclean_metadata.json",
+  "report_file": "sub-01_autoclean_report.pdf"
+}
+```
+
+<Note>
+Only metadata is stored in the database; the EEG data remains on disk in the run folder.
+</Note>
+
+The pipeline creates the record before processing and updates it as steps finish. Viewer tools query this database to list available runs, open associated files, and display quality metrics.
+

--- a/docs/mdx/viewers.mdx
+++ b/docs/mdx/viewers.mdx
@@ -1,0 +1,38 @@
+---
+title: Reviewing Outputs
+description: Interfaces for exploring AutoClean results.
+---
+
+# Reviewing Outputs
+
+AutoClean supplies multiple interfaces to inspect what the pipeline produced.
+
+## File explorer
+
+The simplest way to browse results. Each run lives in its own task-named folder. Use your operating system's file explorer or the **Select Directory** button in the review tool to navigate through runs and open reports.
+
+## Qt browser – AutoClean view
+
+MNE's Qt browser displays cleaned data with bad segments highlighted.
+
+```python
+import mne
+mne.viz.set_browser_backend("qt")
+raw.plot()
+```
+
+Load continuous or epoched files from the `bids/` folder to scroll through recordings with all AutoClean annotations applied.
+
+## AutoClean review
+
+A dedicated GUI (`autoclean_review`) combines browsing, visualization, and run metadata.
+
+- Tree-based file navigator
+- Report and metadata preview
+- Buttons to open raw or epochs in the Qt browser
+- Optional export to EEGLAB `.set` format
+
+<Tip>
+Install GUI extras with `pip install autocleaneeg-pipeline[gui]` to enable the review interface.
+</Tip>
+


### PR DESCRIPTION
## Summary
- Add MDX docs outlining subject- and group-level pipeline outputs
- Document run records and the internal database used to track runs
- Introduce interfaces for browsing and reviewing results
- Describe preprocessing, artifact rejection, and epoching steps with plain-language and technical details

## Testing
- `pre-commit run --files docs/mdx/preprocessing-steps.mdx docs/mdx/artifact-steps.mdx docs/mdx/pipeline-outputs.mdx docs/mdx/run-records.mdx docs/mdx/viewers.mdx` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: unrecognized arguments: --cov=autoclean)*

------
https://chatgpt.com/codex/tasks/task_e_68b94f196d7c832ba55553f2ffc441a1