### PR TITLE
Add ASCII icon fallback

### DIFF
--- a/src/autoclean/utils/cli_display.py
+++ b/src/autoclean/utils/cli_display.py
@@ -9,6 +9,8 @@ visually appealing user interactions.
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
+from autoclean.utils.icons import pick_icon
+
 try:
     from rich.align import Align
     from rich.console import Console
@@ -48,13 +50,13 @@ class CLIDisplay:
         except Exception:
             self.console = console or Console()
 
-        # Status indicators
-        self.SUCCESS = "[success]✓[/success]"
-        self.WARNING = "[warning]⚠[/warning]"
-        self.ERROR = "[error]❌[/error]"
-        self.INFO = "[info]ℹ[/info]"
-        self.WORKING = "[accent]🔧[/accent]"
-        self.ARROW = "[muted]→[/muted]"
+        # Status indicators with ASCII fallbacks
+        self.SUCCESS = f"[success]{pick_icon('ok')}[/success]"
+        self.WARNING = f"[warning]{pick_icon('warn')}[/warning]"
+        self.ERROR = f"[error]{pick_icon('err')}[/error]"
+        self.INFO = f"[info]{pick_icon('info')}[/info]"
+        self.WORKING = f"[accent]{pick_icon('work')}[/accent]"
+        self.ARROW = f"[muted]{pick_icon('arrow')}[/muted]"
 
         # Spacing constants
         self.SECTION_SPACING = "\n"

--- a/src/autoclean/utils/icons.py
+++ b/src/autoclean/utils/icons.py
@@ -1,0 +1,47 @@
+"""Utility functions for status icons with ASCII fallbacks.
+
+This module provides small helper functions that return either emoji
+icons or ASCII fallbacks.  Users can force ASCII mode by setting the
+``AUTOCLEAN_ASCII`` or ``APP_ASCII`` environment variable to ``1``.
+If neither variable is set, an automatic check is performed to see if
+Unicode symbols can be encoded on the current stdout stream.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Dict, Tuple
+
+# Map icon keys to (emoji, ascii) pairs
+ICONS: Dict[str, Tuple[str, str]] = {
+    "ok": ("✅", "OK"),
+    "warn": ("⚠️", "!"),
+    "err": ("❌", "X"),
+    "info": ("ℹ️", "i"),
+    "work": ("🔧", "+"),
+    "arrow": ("→", "->"),
+}
+
+
+def _supports_unicode() -> bool:
+    """Return True if the current stdout encoding supports Unicode."""
+    try:
+        test_icon = ICONS["ok"][0]
+        test_icon.encode(sys.stdout.encoding or "utf-8")
+        return True
+    except Exception:
+        return False
+
+
+ASCII_MODE: bool = (
+    os.getenv("AUTOCLEAN_ASCII") == "1"
+    or os.getenv("APP_ASCII") == "1"
+    or not _supports_unicode()
+)
+
+
+def pick_icon(key: str) -> str:
+    """Return the icon for ``key`` using ASCII fallback when needed."""
+    emoji, ascii = ICONS.get(key, ("", ""))
+    return ascii if ASCII_MODE else emoji


### PR DESCRIPTION
## Summary
- add icon utility with automatic ASCII fallback
- use ASCII-aware icons in CLI display

## Testing
- `pre-commit run --files src/autoclean/utils/icons.py src/autoclean/utils/cli_display.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: could not find a version due to proxy 403)*
- `pytest -c /dev/null tests/test_compatibility.py::test_yaml_compatibility -q` *(fails: ModuleNotFoundError: No module named 'autoclean')*
- `pip install -e .` *(fails: could not find build dependency hatchling)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c34d5f84832286e300a071023e4a