### PR TITLE
feat: log to workspace directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A modular framework for automated EEG data processing, built on MNE-Python.
 - BIDS-compatible data organization and comprehensive quality control
 - Extensible plugin system for file formats, montages, and event processing
 - Research-focused workflow: single file testing → parameter tuning → batch processing
-- Detailed output: logs, stage files, metadata, and quality control visualizations
+- Detailed output: logs (stored in your AutoClean workspace), stage files, metadata, and quality control visualizations
 
 ## Installation (uv)
 

--- a/src/autoclean/utils/logging.py
+++ b/src/autoclean/utils/logging.py
@@ -12,6 +12,7 @@ from typing import Optional, Union
 from loguru import logger
 
 from autoclean import __version__
+from autoclean.utils.user_config import UserConfigManager
 
 # Remove default handler
 logger.remove()
@@ -207,7 +208,8 @@ def configure_logger(
         Name of the current task (legacy parameter, used for fallback directory structure)
     logs_dir : str or Path, optional
         Exact path to the logs directory. If provided, this takes precedence over
-        output_dir and task parameters.
+        output_dir and task parameters. If not specified, logs are written to the
+        AutoClean workspace (e.g., ``~/Documents/Autoclean-EEG/logs``).
 
     Returns
     -------
@@ -245,8 +247,8 @@ def configure_logger(
             / "logs"
         )
     else:
-        # Fallback to current working directory if no task-specific path
-        log_dir = Path(os.getcwd()) / "logs"
+        # Default to the AutoClean workspace if no task-specific path is provided
+        log_dir = UserConfigManager().config_dir / "logs"
 
     # Create logs directory
     log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- default log files to the AutoClean workspace instead of the source tree
- document that logs are stored in the workspace

## Testing
- `PYTHONPATH=src pytest tests/unit/utils/test_config.py -q -c /tmp/empty.ini`


------
https://chatgpt.com/codex/tasks/task_e_68ba3e8c1474832287136941919a1aeb