### PR TITLE
docs: guide for custom EEG import plugins

### DIFF
--- a/docs/mdx/custom-importer.mdx
+++ b/docs/mdx/custom-importer.mdx
@@ -1,0 +1,76 @@
+---
+title: Adding a Custom EEG Importer
+description: How to create a plugin-style mixin to load new raw formats like BrainVision 32‑channel recordings.
+---
+
+# Adding a Custom EEG Importer
+
+AutoClean loads EEG recordings through a plugin system. Each plugin is a small class that knows how to read a file format and apply the correct montage. When a task calls `import_raw`, AutoClean searches the registered plugins and runs the one that matches your file type and electrode layout.
+
+## 1. Understand the plugin interface
+
+Every importer inherits from `BaseEEGPlugin` and implements two required methods:
+
+- `supports_format_montage(format_id, montage_name)` – declares which combinations the plugin can handle.
+- `import_and_configure(file_path, autoclean_dict, preload)` – loads the data and configures the montage.
+
+```
+from autoclean.io.import_ import BaseEEGPlugin
+
+class ExamplePlugin(BaseEEGPlugin):
+    @classmethod
+    def supports_format_montage(cls, format_id, montage_name):
+        ...
+
+    def import_and_configure(self, file_path, autoclean_dict, preload=True):
+        ...
+```
+
+AutoClean already maps common extensions (like `.vhdr` for BrainVision) to internal format IDs, so you usually only need to supply a plugin class.
+
+## 2. Write the BrainVision 32‑channel plugin
+
+Create `src/autoclean/plugins/eeg_plugins/brainvision_32_plugin.py` and implement the plugin:
+
+```
+from pathlib import Path
+import mne
+from autoclean.io.import_ import BaseEEGPlugin
+from autoclean.utils.logging import message
+
+class BrainVision32Plugin(BaseEEGPlugin):
+    """Import BrainVision files with a 32‑channel 10-20 layout."""
+    VERSION = "1.0.0"
+
+    @classmethod
+    def supports_format_montage(cls, format_id, montage_name):
+        return format_id == "BRAINVISION_VHDR" and montage_name == "standard_1020"
+
+    def import_and_configure(self, file_path: Path, autoclean_dict: dict, preload: bool = True):
+        message("info", f"Loading BrainVision file: {file_path}")
+        raw = mne.io.read_raw_brainvision(file_path, preload=preload)
+        raw.set_montage("standard_1020", match_case=False)
+        raw.pick("eeg")
+        return raw
+```
+
+Optionally override `process_events` or `get_metadata` if the format carries custom annotations.
+
+## 3. Registration and use
+
+Place the file under `src/autoclean/plugins/eeg_plugins/`. During startup AutoClean discovers modules in this package and registers any classes that inherit from `BaseEEGPlugin`.
+
+With the plugin in place, point your configuration at a BrainVision `.vhdr` file and set the montage:
+
+```
+unprocessed_file: data/subject01.vhdr
+montage:
+  enabled: true
+  value: standard_1020
+```
+
+When the task calls `import_raw`, AutoClean loads the recording using your plugin.
+
+<Tip>
+If your format uses a new file extension, register it with `register_format("ext", "MY_FORMAT")` before defining the plugin.
+</Tip>


### PR DESCRIPTION
## Summary
- document how to implement a custom EEG importer plugin
- include BrainVision 32-channel example and config snippet

## Testing
- `pre-commit run --files docs/mdx/custom-importer.mdx` *(fails: Black Formatting, Import Sorting, Ruff Linting)*
- `pytest -q` *(fails: 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a0985408322a71b93c6a50c96cc