### PR TITLE
fix: avoid PyQt5 source build on Linux

### DIFF
--- a/docs/mdx/pyqt5-build-troubleshooting.mdx
+++ b/docs/mdx/pyqt5-build-troubleshooting.mdx
@@ -1,0 +1,29 @@
+import { Steps } from 'nextra/components';
+
+# Troubleshooting PyQt5 Build Issues on Linux
+
+<Steps>
+
+### 1. Diagnose the Hang
+
+PyQt5 version **5.15.2** lacks a pre-built wheel for Python 3.11, causing `uv` to compile from source and appear to hang during installation.
+
+### 2. Pin a Compatible Version
+
+Updated `pyproject.toml` to require `PyQt5>=5.15.11`, ensuring `uv` downloads a pre-built wheel instead of compiling the library.
+
+### 3. Reinstall the Tool
+
+```bash
+uv tool install -e --upgrade .
+```
+
+### 4. Verify the Fix
+
+Installation should now complete without the prolonged build step.
+
+</Steps>
+
+<Callout>
+If the build still compiles from source, confirm Python is 3.11+ and that the package cache is cleared (`uv clean`).
+</Callout>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "autoclean-icvision>=0.1.0",
     "autoclean-eeg2source>=0.1.0",
     # GUI dependencies
-    "PyQt5>=5.15.0",
+    "PyQt5>=5.15.11",
     "mne-qt-browser>=0.3.0",
     # "PySide6>=6.5.0",
     "pymupdf>=1.0.0",


### PR DESCRIPTION
## Summary
- pin PyQt5 to 5.15.11 to use pre-built wheels on Python 3.11+
- add MDX guide explaining how to resolve PyQt5 build hang with `uv`

## Testing
- `SKIP=check-code-quality pre-commit run --files pyproject.toml docs/mdx/pyqt5-build-troubleshooting.mdx`
- `pytest` *(fails: cannot import name 'create_sl_epochs')*
- `uv tool install -e --upgrade .`


------
https://chatgpt.com/codex/tasks/task_e_68c1935298cc8322b02e42836777586e