### PR TITLE
Add wavelet thresholding function mirroring HAPPE pipeline

### DIFF
--- a/docs/mdx/wavelet-thresholding.mdx
+++ b/docs/mdx/wavelet-thresholding.mdx
@@ -1,0 +1,40 @@
+---
+title: Wavelet Thresholding
+description: Remove transient noise using wavelet-based denoising.
+---
+
+# Wavelet Thresholding
+
+Wavelet thresholding attenuates short, high-amplitude artifacts by decomposing each EEG channel into wavelet coefficients and shrinking the noisy components. This mirrors the approach used in the HAPPE MATLAB pipeline.
+
+<Steps>
+<Step title="Run the function">
+```python
+from autoclean import wavelet_threshold
+cleaned = wavelet_threshold(raw)
+```
+</Step>
+<Step title="Verify the effect">
+1. Plot a channel before and after to see artifact reduction.
+2. Inspect summary statistics like peak-to-peak amplitude.
+</Step>
+<Step title="Concern: Over-smoothing">
+<Note>
+Excessive thresholding can remove neural signal. Adjust the `level` or `wavelet` if you notice over-smoothing.
+</Note>
+</Step>
+</Steps>
+
+## Testing
+
+To test the implementation yourself:
+
+```bash
+pytest tests/functions/test_preprocessing.py::TestWaveletThreshold::test_wavelet_threshold_basic
+```
+
+This unit test injects a large transient into synthetic data and confirms the function reduces its amplitude.
+
+<Diagram name="Thresholding flow">
+raw signal -> wavelet transform -> soft thresholding -> reconstructed signal
+</Diagram>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pandas>=1.3.0",
     "matplotlib>=3.4.0",
     "seaborn>=0.13.2",
+    "PyWavelets>=1.5.0",
     # EEG processing core
     "mne>=1.7.0",
     "mne-icalabel>=0.7.0",

--- a/src/autoclean/__init__.py
+++ b/src/autoclean/__init__.py
@@ -47,6 +47,10 @@ def __getattr__(name):
         from .functions.preprocessing import assign_channel_types
 
         return assign_channel_types
+    elif name == "wavelet_threshold":
+        from .functions.preprocessing import wavelet_threshold
+
+        return wavelet_threshold
 
     # Epoching functions
     elif name == "create_regular_epochs":
@@ -138,6 +142,7 @@ __all__ = [
     "crop_data",
     "trim_edges",
     "assign_channel_types",
+    "wavelet_threshold",
     # Epoching functions
     "create_regular_epochs",
     "create_eventid_epochs",

--- a/src/autoclean/calc/source.py
+++ b/src/autoclean/calc/source.py
@@ -29,7 +29,6 @@ from tqdm import tqdm
 # Optional imports with availability flags
 try:
     import networkx as nx
-    from networkx.algorithms.community import louvain_communities, modularity
 
     NETWORK_ANALYSIS_AVAILABLE = True
 except ImportError:

--- a/src/autoclean/functions/preprocessing/__init__.py
+++ b/src/autoclean/functions/preprocessing/__init__.py
@@ -20,6 +20,7 @@ from .basic_ops import assign_channel_types, crop_data, drop_channels, trim_edge
 from .filtering import filter_data
 from .referencing import rereference_data
 from .resampling import resample_data
+from .wavelet_thresholding import wavelet_threshold
 
 __all__ = [
     "filter_data",
@@ -29,4 +30,5 @@ __all__ = [
     "crop_data",
     "trim_edges",
     "assign_channel_types",
+    "wavelet_threshold",
 ]

--- a/src/autoclean/functions/preprocessing/wavelet_thresholding.py
+++ b/src/autoclean/functions/preprocessing/wavelet_thresholding.py
@@ -1,0 +1,84 @@
+"""Wavelet thresholding for EEG data.
+
+This module implements wavelet-based denoising identical in spirit to the
+HAPPE MATLAB pipeline. It performs a discrete wavelet transform on each channel
+and applies universal soft-thresholding to attenuate high-amplitude
+transients.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import mne
+import numpy as np
+import pywt
+
+
+def _denoise_signal(
+    signal: np.ndarray,
+    wavelet: str,
+    level: int,
+) -> np.ndarray:
+    """Denoise a 1D signal using wavelet thresholding.
+
+    Parameters
+    ----------
+    signal : ndarray
+        The time series to denoise.
+    wavelet : str
+        Wavelet name.
+    level : int
+        Decomposition level.
+
+    Returns
+    -------
+    ndarray
+        Denoised signal.
+    """
+    coeffs = pywt.wavedec(signal, wavelet, level=level)
+    # Estimate noise sigma using median absolute deviation of detail coeffs at level 1
+    sigma = np.median(np.abs(coeffs[-1])) / 0.6745
+    uthresh = sigma * np.sqrt(2 * np.log(signal.size))
+    coeffs_thresh = [coeffs[0]]
+    for c in coeffs[1:]:
+        coeffs_thresh.append(pywt.threshold(c, uthresh, mode="soft"))
+    return pywt.waverec(coeffs_thresh, wavelet)
+
+
+def wavelet_threshold(
+    data: Union[mne.io.BaseRaw, mne.Epochs],
+    wavelet: str = "sym4",
+    level: int = 5,
+) -> Union[mne.io.BaseRaw, mne.Epochs]:
+    """Apply wavelet thresholding to EEG data.
+
+    Parameters
+    ----------
+    data : Raw or Epochs
+        MNE object containing EEG data. The data is copied before processing.
+    wavelet : str, default 'sym4'
+        Mother wavelet used for the discrete wavelet transform.
+    level : int, default 5
+        Decomposition level.
+
+    Returns
+    -------
+    Raw or Epochs
+        A copy of the input with wavelet thresholding applied channel-wise.
+    """
+    cleaned = data.copy()
+    if isinstance(cleaned, mne.io.BaseRaw):
+        arr = cleaned.get_data()
+        for idx in range(arr.shape[0]):
+            arr[idx] = _denoise_signal(arr[idx], wavelet, level)
+        cleaned._data = arr
+    elif isinstance(cleaned, mne.Epochs):
+        arr = cleaned.get_data()
+        for ep in range(arr.shape[0]):
+            for ch in range(arr.shape[1]):
+                arr[ep, ch] = _denoise_signal(arr[ep, ch], wavelet, level)
+        cleaned._data = arr
+    else:
+        raise TypeError("data must be mne.io.BaseRaw or mne.Epochs")
+    return cleaned

--- a/tests/functions/test_preprocessing.py
+++ b/tests/functions/test_preprocessing.py
@@ -96,3 +96,19 @@ class TestBasicOperations:
         """Placeholder test - will be implemented with basic ops functions."""
         # This will be replaced with actual tests when basic ops are implemented
         assert True
+
+
+class TestWaveletThreshold:
+    """Test wavelet thresholding function."""
+
+    def test_wavelet_threshold_basic(self):
+        """Wavelet thresholding should reduce artifact amplitude."""
+        from autoclean import wavelet_threshold
+
+        raw = create_synthetic_raw(n_channels=1, sfreq=250, duration=1)
+        raw_artifact = raw.copy()
+        raw_artifact._data[0, 100] += 1.0  # inject transient artifact
+
+        cleaned = wavelet_threshold(raw_artifact)
+
+        assert abs(cleaned.get_data()[0, 100]) < abs(raw_artifact.get_data()[0, 100])


### PR DESCRIPTION
## Summary
- implement wavelet-based denoising function and expose it in public API
- document wavelet thresholding and add dependency on PyWavelets
- provide basic unit test and update build dependencies

## Testing
- `pre-commit run --files pyproject.toml src/autoclean/__init__.py src/autoclean/calc/source.py src/autoclean/functions/preprocessing/__init__.py src/autoclean/functions/preprocessing/wavelet_thresholding.py tests/functions/test_preprocessing.py docs/mdx/wavelet-thresholding.mdx` *(fails: Remove unused import: `autoclean.utils.logging.message`)*
- `ruff check src/autoclean/functions/preprocessing/wavelet_thresholding.py src/autoclean/functions/preprocessing/__init__.py src/autoclean/__init__.py src/autoclean/calc/source.py tests/functions/test_preprocessing.py pyproject.toml` *(pass)*
- `black --check src/autoclean/functions/preprocessing/wavelet_thresholding.py src/autoclean/functions/preprocessing/__init__.py src/autoclean/__init__.py src/autoclean/calc/source.py tests/functions/test_preprocessing.py` *(pass)*
- `pytest tests/functions/test_preprocessing.py::TestWaveletThreshold::test_wavelet_threshold_basic` *(fails: Required test coverage of 15% not reached. Total coverage: 3.41%)*
- `pytest` *(fails: 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c12a9339008322aa4ceb70d28122da