### PR TITLE
Add ERP-aware wavelet thresholding options

### DIFF
--- a/docs/mdx/run-wavelet-erp-upgrade.mdx
+++ b/docs/mdx/run-wavelet-erp-upgrade.mdx
@@ -1,0 +1,44 @@
+---
+title: Wavelet Threshold ERP Upgrade Run
+description: Summary of the hard-threshold and ERP-preserving enhancements.
+---
+
+# Wavelet Threshold ERP Upgrade
+
+<Diagram name="Processing flow">
+raw data -> optional ERP band-pass -> wavelet denoise -> artifact estimate -> subtract from original -> final ERP band-pass
+</Diagram>
+
+<Steps>
+<Step title="What changed">
+1. Added `threshold_mode` so you can switch between the classic soft shrinkage and a MATLAB-style hard threshold.
+2. Introduced `is_erp` and `bandpass` controls that mirror HAPPE2's filter → denoise → subtract → refilter loop.
+3. Expanded the PDF report helper so it tracks the threshold mode and whether ERP logic was enabled.
+</Step>
+<Step title="How we implemented it">
+1. Normalised the threshold mode and forwarded it into `pywt.threshold` for every detail coefficient.
+2. Wrapped the ERP branch in a recursive call: filter a copy, denoise the filtered data, compute artifacts as the difference, subtract from the unfiltered copy, then run a single final filter pass.
+3. Reused the same hooks in `generate_wavelet_report`, ensuring the summary now records the mode (`soft` or `hard`) and ERP flag.
+</Step>
+<Step title="How to verify it yourself">
+<Note>
+All commands run from the project root.
+</Note>
+```bash
+pytest tests/functions/test_preprocessing.py::TestWaveletThreshold::test_wavelet_threshold_supports_hard_mode
+pytest tests/functions/test_preprocessing.py::TestWaveletThreshold::test_wavelet_threshold_erp_mode_matches_single_filter_when_clean
+```
+</Step>
+<Step title="What to watch for next">
+<Note>
+If you pass a malformed band-pass tuple while `is_erp=True`, the function raises `ValueError`. This mirrors HAPPE2's expectations and prevents silent misconfigurations.
+</Note>
+</Step>
+</Steps>
+
+<Checklist>
+<li>Soft vs hard modes validated through unit tests.</li>
+<li>ERP mode gracefully handles clean data by collapsing to a single filter pass.</li>
+<li>Documentation updated with new usage patterns.</li>
+</Checklist>
+

--- a/docs/mdx/wavelet-thresholding.mdx
+++ b/docs/mdx/wavelet-thresholding.mdx
@@ -11,16 +11,31 @@ Wavelet thresholding attenuates short, high-amplitude artifacts by decomposing e
 <Step title="Run the function">
 ```python
 from autoclean import wavelet_threshold
-cleaned = wavelet_threshold(raw)
+cleaned = wavelet_threshold(raw, threshold_mode="soft")
+```
+</Step>
+<Step title="Switch to hard mode">
+<Note>
+`threshold_mode="hard"` mirrors the high-artifact option in HAPPE2. Coefficients above the universal threshold are left untouched so more ERP amplitude is preserved.
+</Note>
+</Step>
+<Step title="Enable ERP-preserving logic">
+```python
+erp_cleaned = wavelet_threshold(
+    raw,
+    is_erp=True,
+    bandpass=(1.0, 30.0),
+)
 ```
 </Step>
 <Step title="Verify the effect">
 1. Plot a channel before and after to see artifact reduction.
 2. Inspect summary statistics like peak-to-peak amplitude.
+3. Compare the ERP waveform amplitude to ensure it has not been double-filtered.
 </Step>
 <Step title="Concern: Over-smoothing">
 <Note>
-Excessive thresholding can remove neural signal. Adjust the `level` or `wavelet` if you notice over-smoothing.
+Excessive thresholding can remove neural signal. Adjust the `level`, `wavelet`, or switch between `soft`/`hard` to balance denoising versus signal preservation.
 </Note>
 </Step>
 </Steps>
@@ -30,10 +45,11 @@ Excessive thresholding can remove neural signal. Adjust the `level` or `wavelet`
 To test the implementation yourself:
 
 ```bash
-pytest tests/functions/test_preprocessing.py::TestWaveletThreshold::test_wavelet_threshold_basic
+pytest tests/functions/test_preprocessing.py::TestWaveletThreshold::test_wavelet_threshold_supports_hard_mode
+pytest tests/functions/test_preprocessing.py::TestWaveletThreshold::test_wavelet_threshold_erp_mode_matches_single_filter_when_clean
 ```
 
-This unit test injects a large transient into synthetic data and confirms the function reduces its amplitude.
+These unit tests exercise the new hard-thresholding branch and the ERP-aware filtering/subtraction workflow.
 
 ## PDF Reporting
 


### PR DESCRIPTION
## Summary
- add optional threshold_mode and ERP-preserving band-pass workflow to `wavelet_threshold`
- forward the new options into `generate_wavelet_report` and record them in the PDF summary
- document the new usage patterns and capture the run details in Mintify-flavored MDX docs
- expand the unit tests to cover hard mode selection, ERP flow validation, and error handling

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/functions/test_preprocessing.py::TestWaveletThreshold -q


------
https://chatgpt.com/codex/tasks/task_e_68cab508315883229712dbed1520c838