### PR TITLE
Extract ICA plot layout into sandbox helper

### DIFF
--- a/docs/mdx/sandbox-ica-layout.mdx
+++ b/docs/mdx/sandbox-ica-layout.mdx
@@ -1,0 +1,54 @@
+---
+title: ICA Layout Sandbox Extraction
+description: Walkthrough of the sandbox helper that isolates the ICA component layout for future tuning.
+---
+
+# ICA Layout Sandbox Extraction
+
+This run peels the layout scaffolding out of the production plotting helper and drops it into a sandbox module. The goal is to
+give performance work a dedicated playground without forcing every experiment through the busy visualization package.
+
+<Diagram name="Layout responsibilities split">
+Existing plot helper ➜ Sandbox layout factory ➜ Plotting logic ➜ Reporting + batch jobs
+</Diagram>
+
+<Steps>
+<Step title="Objectives">
+1. Add a dedicated sandbox module that produces the Matplotlib layout for ICA components.
+2. Refactor the main `plot_component_for_classification` helper to consume the sandbox layout specification.
+3. Provide targeted unit tests and rerun the visualization suite so newcomers can validate the change locally.
+</Step>
+
+<Step title="Implementation"> 
+1. Created `src/autoclean/sandbox/ica_layout.py` with `build_ic_classification_layout`, which returns an `ICALayoutSpec` dataclass holding the figure, axes, and metadata needed by callers.
+2. Updated `icvision_layouts.py` to swap the inline GridSpec code for a call into the sandbox helper, keeping the rendering behaviour identical while decoupling the layout decisions.
+3. Added `tests/sandbox/test_ica_layout.py` to assert the sandbox helper generates consistent spacing in both in-memory and file-saving modes.
+</Step>
+
+<Step title="Verification">
+<Note>Run commands from the project root (`/workspace/autocleaneeg_pipeline`).</Note>
+1. Ensure development extras are available: `pip install -e .[dev]`
+2. Execute the new sandbox tests alongside the existing visualization coverage:
+   ```bash
+   pytest tests/sandbox/test_ica_layout.py tests/functions/test_visualization.py -k "plot_ica_components or test_build_layout"
+   ```
+3. Optional: open a REPL and call `build_ic_classification_layout(0, return_fig_object=True)` to inspect the returned figure and axes for hands-on experimentation.
+</Step>
+
+<Accordion title="Why the sandbox?">
+Carving out the layout logic lets us iterate on GridSpec tweaks (spacing, DPI, colorbars) without repeatedly touching the
+production plotting function—a hotspot shared by API users, PDF exports, and CLI tools. The sandbox helper can evolve quickly,
+and once a new layout proves itself we can promote it back into the main module.
+</Accordion>
+
+<Checklist>
+<li>Sandbox module returns a reusable layout specification.</li>
+<li>Visualization helper delegates layout creation to the sandbox.</li>
+<li>Unit tests cover both expanded and compact layout modes.</li>
+<li>Reproduction steps documented for fresh contributors.</li>
+</Checklist>
+
+<Callout type="warning" title="Future considerations">
+Profiling the sandbox helper against the production path will require representative ICA data. Capture timing metrics once the
+layout experiments begin so we can quantify improvements before merging them upstream.
+</Callout>

--- a/src/autoclean/functions/visualization/icvision_layouts.py
+++ b/src/autoclean/functions/visualization/icvision_layouts.py
@@ -20,10 +20,11 @@ import matplotlib
 import matplotlib.pyplot as plt
 import mne
 import numpy as np
-from matplotlib.gridspec import GridSpec
 from mne.preprocessing import ICA
 from mne.time_frequency import psd_array_welch
 from scipy.ndimage import uniform_filter1d
+
+from ...sandbox import build_ic_classification_layout
 
 # Force non-interactive backend for batch environments
 matplotlib.use("Agg", force=True)
@@ -124,49 +125,23 @@ def plot_component_for_classification(
     # Always start from a clean canvas to keep batch jobs deterministic
     plt.close("all")
 
-    fig_height = 9.5
-    gridspec_bottom = 0.05
-
-    if return_fig_object and classification_reason:
-        fig_height = 11
-        gridspec_bottom = 0.18
-
-    fig = plt.figure(figsize=(12, fig_height), dpi=120)
-    method_display = None
-    if classification_method:
-        method_key = classification_method.lower()
-        method_display = {
-            "iclabel": "ICLabel",
-            "icvision": "ICVision",
-            "hybrid": "Hybrid",
-        }.get(method_key, classification_method)
-    method_suffix = f" [{method_display}]" if method_display else ""
-    main_title = f"ICA Component IC{component_idx} Analysis{method_suffix}"
-    gridspec_top = 0.95
-    suptitle_y_pos = 0.98
-
-    if return_fig_object and classification_label is not None:
-        gridspec_top = 0.90
-        suptitle_y_pos = 0.96
-
-    gs = GridSpec(
-        3,
-        2,
-        figure=fig,
-        height_ratios=[0.915, 0.572, 2.213],
-        width_ratios=[0.9, 1.0],
-        hspace=0.7,
-        wspace=0.35,
-        left=0.05,
-        right=0.95,
-        top=gridspec_top,
-        bottom=gridspec_bottom,
+    layout = build_ic_classification_layout(
+        component_idx,
+        classification_label=classification_label,
+        classification_reason=classification_reason,
+        classification_method=classification_method,
+        return_fig_object=return_fig_object,
     )
 
-    ax_topo = fig.add_subplot(gs[0:2, 0])
-    ax_cont_data = fig.add_subplot(gs[2, 0])
-    ax_ts_scroll = fig.add_subplot(gs[0, 1])
-    ax_psd = fig.add_subplot(gs[2, 1])
+    fig = layout.fig
+    ax_topo = layout.ax_topo
+    ax_cont_data = layout.ax_cont_data
+    ax_ts_scroll = layout.ax_ts_scroll
+    ax_psd = layout.ax_psd
+    method_display = layout.method_display
+    main_title = layout.main_title
+    gridspec_bottom = layout.gridspec_bottom
+    suptitle_y_pos = layout.suptitle_y_pos
 
     try:
         sources = ica_obj.get_sources(raw_obj)

--- a/src/autoclean/sandbox/__init__.py
+++ b/src/autoclean/sandbox/__init__.py
@@ -1,0 +1,8 @@
+"""Sandbox utilities for experimental refactors and optimizations."""
+
+from .ica_layout import ICALayoutSpec, build_ic_classification_layout
+
+__all__ = [
+    "ICALayoutSpec",
+    "build_ic_classification_layout",
+]

--- a/src/autoclean/sandbox/ica_layout.py
+++ b/src/autoclean/sandbox/ica_layout.py
@@ -1,0 +1,131 @@
+"""Isolated helpers for experimenting with ICA component layout tweaks.
+
+The production plotting helper ``plot_component_for_classification`` inside
+``src/autoclean/functions/visualization/icvision_layouts.py`` still performs
+all of the data munging and rendering.  The layout (figure size, GridSpec
+configuration, and axis creation) is now delegated to the sandbox function
+defined here so that we can iterate on spacing experiments without touching
+the high-traffic visualization module.  The sandbox location keeps the helper
+out of the public API while we benchmark alternative arrangements.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
+
+
+@dataclass
+class ICALayoutSpec:
+    """Container describing the figure and axes produced by the layout helper."""
+
+    fig: plt.Figure
+    ax_topo: plt.Axes
+    ax_cont_data: plt.Axes
+    ax_ts_scroll: plt.Axes
+    ax_psd: plt.Axes
+    main_title: str
+    method_display: Optional[str]
+    gridspec_bottom: float
+    suptitle_y_pos: float
+
+
+def _resolve_method_display(classification_method: Optional[str]) -> Optional[str]:
+    """Normalize the classifier name for consistent labelling."""
+
+    if not classification_method:
+        return None
+
+    method_key = classification_method.lower()
+    return {
+        "iclabel": "ICLabel",
+        "icvision": "ICVision",
+        "hybrid": "Hybrid",
+    }.get(method_key, classification_method)
+
+
+def build_ic_classification_layout(
+    component_idx: int,
+    *,
+    classification_label: Optional[str] = None,
+    classification_reason: Optional[str] = None,
+    classification_method: Optional[str] = None,
+    return_fig_object: bool = False,
+) -> ICALayoutSpec:
+    """Create the Matplotlib layout used by the ICA classification plots.
+
+    Parameters
+    ----------
+    component_idx:
+        Zero-based ICA component index for title construction.
+    classification_label:
+        Optional label shown in figure headers when rendering to a Figure.
+    classification_reason:
+        Optional rationale string.  When supplied alongside ``return_fig_object``
+        a taller canvas is requested to make room for the footer textbox.
+    classification_method:
+        Name of the classifier (``"iclabel"``, ``"icvision"``, etc.).  The value
+        is prettified for display in the figure title.
+    return_fig_object:
+        Whether the caller intends to keep the Figure in-memory.  This affects
+        the subplot spacing so that headers and reasoning text fit comfortably.
+
+    Returns
+    -------
+    ICALayoutSpec
+        Dataclass containing the figure, axes, and metadata used by the caller
+        to complete the rendering pipeline.
+    """
+
+    fig_height = 9.5
+    gridspec_bottom = 0.05
+
+    if return_fig_object and classification_reason:
+        fig_height = 11
+        gridspec_bottom = 0.18
+
+    fig = plt.figure(figsize=(12, fig_height), dpi=120)
+    method_display = _resolve_method_display(classification_method)
+    method_suffix = f" [{method_display}]" if method_display else ""
+    main_title = f"ICA Component IC{component_idx} Analysis{method_suffix}"
+
+    gridspec_top = 0.95
+    suptitle_y_pos = 0.98
+
+    if return_fig_object and classification_label is not None:
+        gridspec_top = 0.90
+        suptitle_y_pos = 0.96
+
+    gs = GridSpec(
+        3,
+        2,
+        figure=fig,
+        height_ratios=[0.915, 0.572, 2.213],
+        width_ratios=[0.9, 1.0],
+        hspace=0.7,
+        wspace=0.35,
+        left=0.05,
+        right=0.95,
+        top=gridspec_top,
+        bottom=gridspec_bottom,
+    )
+
+    ax_topo = fig.add_subplot(gs[0:2, 0])
+    ax_cont_data = fig.add_subplot(gs[2, 0])
+    ax_ts_scroll = fig.add_subplot(gs[0, 1])
+    ax_psd = fig.add_subplot(gs[2, 1])
+
+    return ICALayoutSpec(
+        fig=fig,
+        ax_topo=ax_topo,
+        ax_cont_data=ax_cont_data,
+        ax_ts_scroll=ax_ts_scroll,
+        ax_psd=ax_psd,
+        main_title=main_title,
+        method_display=method_display,
+        gridspec_bottom=gridspec_bottom,
+        suptitle_y_pos=suptitle_y_pos,
+    )

--- a/tests/sandbox/test_ica_layout.py
+++ b/tests/sandbox/test_ica_layout.py
@@ -1,0 +1,44 @@
+"""Tests for the sandbox ICA layout helper."""
+
+import matplotlib.pyplot as plt
+
+from autoclean.sandbox import build_ic_classification_layout
+
+
+def test_build_layout_returns_expected_spec():
+    layout = build_ic_classification_layout(
+        2,
+        classification_label="brain",
+        classification_reason="Example rationale",
+        classification_method="iclabel",
+        return_fig_object=True,
+    )
+
+    assert layout.fig is not None
+    assert layout.ax_topo.get_figure() is layout.fig
+    assert layout.ax_cont_data.get_figure() is layout.fig
+    assert layout.ax_ts_scroll.get_figure() is layout.fig
+    assert layout.ax_psd.get_figure() is layout.fig
+    assert "IC2" in layout.main_title
+    assert layout.method_display == "ICLabel"
+    assert layout.gridspec_bottom > 0.1  # taller canvas for the rationale box
+    assert layout.suptitle_y_pos == 0.96
+
+    plt.close(layout.fig)
+
+
+def test_build_layout_saving_mode_stays_compact():
+    layout = build_ic_classification_layout(
+        5,
+        classification_label=None,
+        classification_reason="ignored unless returning fig",
+        classification_method="Hybrid",
+        return_fig_object=False,
+    )
+
+    assert layout.gridspec_bottom == 0.05
+    assert layout.suptitle_y_pos == 0.98
+    assert layout.method_display == "Hybrid"
+    assert layout.main_title.endswith("[Hybrid]")
+
+    plt.close(layout.fig)


### PR DESCRIPTION
## Summary
- add a sandbox module that returns an `ICALayoutSpec` for ICA component figures
- refactor `plot_component_for_classification` to reuse the sandbox layout factory
- document the sandbox extraction run and add unit tests around the helper

## Testing
- `pytest tests/sandbox/test_ica_layout.py tests/functions/test_visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd36992e648322837e5e0aaf43925e