### PR TITLE
Ensure CLI reports failure when errors logged

### DIFF
--- a/docs/mdx/run-processing-status-failure-handling.mdx
+++ b/docs/mdx/run-processing-status-failure-handling.mdx
@@ -1,0 +1,63 @@
+---
+title: Processing Status Failure Handling Run Log
+description: Tracking error-level logs so the CLI surfaces a failure summary whenever any task raises an error.
+---
+
+# Processing Status Failure Handling Run Log
+
+This run teaches the CLI how to sense when anything went wrong so it never signs off with a success banner after errors were raised.
+
+<Steps>
+  <Step title="What triggered the run?">
+    A real-world pipeline run logged multiple `ERROR` entries (missing JSON summary, task parameter failure, downstream crash), yet the session still ended with <code>Processing completed successfully!</code>. The CLI never asked the logger whether errors occurred.
+  </Step>
+  <Step title="How did we fix it?">
+    <ul>
+      <li>Introduced a shared logging state using a thread-safe <code>Event</code> that flips on the first error-level message.</li>
+      <li>Registered a dedicated Loguru sink so even modules that call <code>logger.error</code> directly still trigger the failure flag.</li>
+      <li>Updated the CLI <code>process</code> command to check the flag before printing the final summary, returning a non-zero exit code when errors were seen.</li>
+    </ul>
+  </Step>
+  <Step title="What should a reviewer look at?">
+    <ol>
+      <li><code>src/autoclean/utils/logging.py</code> now exposes <code>has_logged_errors()</code> and automatically resets the flag every time <code>configure_logger()</code> runs.</li>
+      <li><code>src/autoclean/cli.py</code> emits <em>Processing failed with errors. See log for details.</em> whenever any error was logged.</li>
+      <li><code>src/autoclean/utils/__init__.py</code> re-exports the helper so other modules can consume it.</li>
+    </ol>
+  </Step>
+</Steps>
+
+## Flow at a Glance
+
+<Diagram name="How the CLI now decides between success and failure">
+Pipeline/Tasks -> log via message() or logger.error() -> Loguru sinks -> _error_event.set()
+CLI process command -> has_logged_errors()?
+  Yes -> print failure summary + exit 1
+  No  -> print success summary + exit 0
+</Diagram>
+
+## Hands-On Verification
+
+<Tip>
+Run these commands from the repository root; they validate the new behavior end-to-end.
+</Tip>
+
+<Steps>
+  <Step title="Unit confidence">
+    Execute <code>pytest tests/unit/core/test_pipeline.py</code> to make sure the pipeline bootstrap still wires the logger correctly.
+  </Step>
+  <Step title="Manual sanity check">
+    Trigger a dry failure by running <code>autocleaneeg-pipeline process --task bad_task</code> against a test file and confirm the CLI ends with <code>Processing failed with errors. See log for details.</code> and a non-zero exit code.
+  </Step>
+  <Step title="Success scenario">
+    Run the CLI on a known-good dataset; the summary should stay as <code>Processing completed successfully!</code> because no errors were logged.
+  </Step>
+</Steps>
+
+## Concerns & Safeguards
+
+<Note>
+The error flag is global to the Python process. <strong>Always</strong> call <code>configure_logger()</code> (which the pipeline does automatically) before starting a new run so the flag resets. The helper is thread-safe, so concurrent async workers cannot clobber each other's status.
+</Note>
+
+By following this playbook a novice contributor can replicate the run, understand the reasoning, and verify both failure and success paths.

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -35,7 +35,7 @@ from autoclean.utils.config import (
 )
 from autoclean.utils.console import get_console
 from autoclean.utils.database import DB_PATH
-from autoclean.utils.logging import message
+from autoclean.utils.logging import has_logged_errors, message
 from autoclean.utils.task_discovery import (
     extract_config_from_task,
     get_task_by_name,
@@ -1782,6 +1782,10 @@ def cmd_process(args) -> int:
                     pattern=args.format,
                     recursive=args.recursive,
                 )
+        if has_logged_errors():
+            message("info", "Processing failed with errors. See log for details.")
+            return 1
+
         message("info", "Processing completed successfully!")
         return 0
 

--- a/src/autoclean/utils/__init__.py
+++ b/src/autoclean/utils/__init__.py
@@ -9,7 +9,7 @@ from .bids import (
 from .config import load_config, validate_eeg_system
 from .database import get_run_record, manage_database
 from .file_system import step_prepare_directories
-from .logging import configure_logger, message
+from .logging import configure_logger, has_logged_errors, message
 from .montage import VALID_MONTAGES
 
 __all__ = [
@@ -24,5 +24,6 @@ __all__ = [
     "step_prepare_directories",
     "message",
     "configure_logger",
+    "has_logged_errors",
     "VALID_MONTAGES",
 ]

--- a/src/autoclean/utils/logging.py
+++ b/src/autoclean/utils/logging.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 from enum import Enum
 from pathlib import Path
+from threading import Event
 from typing import Optional, Union
 
 from loguru import logger
@@ -16,6 +17,32 @@ from autoclean.utils.user_config import UserConfigManager
 
 # Remove default handler
 logger.remove()
+
+
+# ---------------------------------------------------------------------------
+# Logging state management
+# ---------------------------------------------------------------------------
+
+_error_event = Event()
+
+
+def _track_error_records(message) -> None:
+    """Loguru sink that marks the run as failed when errors are emitted."""
+
+    if message.record["level"].name in {LogLevel.ERROR.value, LogLevel.CRITICAL.value}:
+        _error_event.set()
+
+
+def has_logged_errors() -> bool:
+    """Return True if any error-level log entries have been emitted."""
+
+    return _error_event.is_set()
+
+
+def reset_log_state() -> None:
+    """Clear the tracked logging state for a fresh run."""
+
+    _error_event.clear()
 
 # Define custom levels with specific order
 # Standard levels are already defined:
@@ -176,6 +203,10 @@ def message(level: str, text: str, **kwargs) -> None:
     # Convert level to proper case
     level = level.upper()
 
+    # Track error level messages so the CLI can report accurate status
+    if level in {LogLevel.ERROR.value, LogLevel.CRITICAL.value}:
+        _error_event.set()
+
     # Handle expensive computations lazily
     if kwargs:
         logger.opt(lazy=True).log(level, text, **kwargs)
@@ -217,6 +248,17 @@ def configure_logger(
         Appropriate MNE verbosity level ('DEBUG', 'INFO', 'WARNING', 'ERROR', or 'CRITICAL')
     """
     logger.remove()
+
+    # Reset log state for each new configuration
+    reset_log_state()
+
+    # Monitor error records regardless of logging helper usage
+    logger.add(
+        _track_error_records,
+        level=LogLevel.ERROR.value,
+        backtrace=False,
+        diagnose=False,
+    )
 
     # Convert input to LogLevel using our new conversion method
     level = LogLevel.from_value(verbose)


### PR DESCRIPTION
## Summary
- track error-level log events via a shared logging state so the CLI can query run health
- update the `process` command to emit a failure summary and non-zero exit when errors occur
- document the run details and verification steps for novice contributors

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/unit/core/test_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68d064cbfcfc8322b97554c1463e0c9d