### PR TITLE
Fix auto clean review export file format

### DIFF
--- a/src/autoclean/tools/autoclean_exclude.py
+++ b/src/autoclean/tools/autoclean_exclude.py
@@ -6531,9 +6531,9 @@ class ExclusionFileSelector(ReviewBase):
                     if bad_selection_indices:
                         epochs.drop(bad_selection_indices, reason="USER", verbose=False)
 
-                # Save to qa/ with same filename using MNE's native save
+                # Save to qa/ with same filename in EEGLAB format
                 dest_file = qa_dir / source_file.name
-                epochs.save(str(dest_file), overwrite=True, verbose=False)
+                epochs.export(str(dest_file), fmt="eeglab", overwrite=True)
 
                 # Update CSV record with export metadata
                 record["qa_export_hash"] = current_hash


### PR DESCRIPTION
The _batch_export_to_qa() function was using epochs.save() which saves in MNE FIF format by default, regardless of file extension. This meant users clicking "Export to QA" were getting FIF data written to files with .set extensions.

Changed to epochs.export(fmt="eeglab") to properly save in EEGLAB .set format as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches QA batch export to use `epochs.export(fmt="eeglab")`, producing proper EEGLAB `.set` files instead of MNE FIF.
> 
> - **QA Export**:
>   - Change `src/autoclean/tools/autoclean_exclude.py` `_batch_export_to_qa()` to save cleaned epochs using `epochs.export(fmt="eeglab")` to `qa/<filename>.set`.
>   - Update inline comment to reflect EEGLAB `.set` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e50d6ec51ef2278197370e3d377a28b5e9cc9eb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->