### PR TITLE
Fix reprocess override error when task has no docstring

### DIFF
--- a/src/autoclean/tools/autoclean_exclude.py
+++ b/src/autoclean/tools/autoclean_exclude.py
@@ -387,7 +387,21 @@ def _generate_reprocess_task_from_original(
     - Manual bad channel list: {bad_channels}
     - Manual ICA component rejection: {rejected_ica}
     """
-            node.body[0] = ast.Expr(value=ast.Constant(value=docstring.strip()))
+            new_docstring = ast.Expr(value=ast.Constant(value=docstring.strip()))
+
+            # Check if the first element is already a docstring (Expr with string Constant)
+            # If so, replace it; otherwise insert the docstring at the beginning
+            if (
+                node.body
+                and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Constant)
+                and isinstance(node.body[0].value.value, str)
+            ):
+                # Replace existing docstring
+                node.body[0] = new_docstring
+            else:
+                # No docstring exists - insert at beginning (don't replace methods!)
+                node.body.insert(0, new_docstring)
 
             return node
 


### PR DESCRIPTION
The ClassRenamer in _generate_reprocess_task_from_original was unconditionally replacing node.body[0] with a docstring. If the original task class didn't have a docstring as its first element (e.g., if the run method came first), this would replace the run method with a docstring, effectively removing it.

This caused "Can't instantiate abstract class ... with abstract method run" errors when reprocessing with overrides.

The fix checks if body[0] is already a docstring before replacing, otherwise it inserts the docstring at the beginning to preserve existing methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevent overwriting the first class member (e.g., run method) by inserting a docstring only when absent, otherwise replacing the existing one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4359428083b72b97bf6bbb4cb355820f4235f6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->