### PR TITLE
fix: include .bdf in default file discovery glob pattern

### DIFF
--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -1115,8 +1115,8 @@ For detailed help on any command: autocleaneeg-pipeline <command> --help
     process_parser.add_argument(
         "--format",
         type=str,
-        default="*.{raw,set}",
-        help="File format glob pattern for directory processing (default: *.{raw,set}). Examples: '*.raw', '*.edf', '*.set'. Note: '.raw' will be auto-corrected to '*.raw'",
+        default="*.{raw,set,bdf}",
+        help="File format glob pattern for directory processing (default: *.{raw,set,bdf}). Examples: '*.raw', '*.edf', '*.set', '*.bdf'. Note: '.raw' will be auto-corrected to '*.raw'",
     )
     process_parser.add_argument(
         "--recursive",
@@ -2613,7 +2613,7 @@ def _show_process_guard(args) -> bool:
                 console.print("   Type: [accent]Directory[/accent]")
 
                 # Count files based on format pattern
-                format_pattern = getattr(args, "format", "*.{raw,set}")
+                format_pattern = getattr(args, "format", "*.{raw,set,bdf}")
                 try:
 
                     def _expand_brace_glob(pat: str) -> list[str]:
@@ -2767,7 +2767,7 @@ def validate_args(args) -> bool:
                 )
                 tbl.add_row(
                     "--format",
-                    "Glob pattern (default: *.{raw,set}; '*.raw', '*.edf', ...)",
+                    "Glob pattern (default: *.{raw,set,bdf}; '*.raw', '*.edf', '*.bdf', ...)",
                 )
                 tbl.add_row("--recursive", "Search subdirectories for matching files")
                 tbl.add_row("-p N", "Process N files in parallel (default 3, max 8)")
@@ -2864,7 +2864,7 @@ def validate_args(args) -> bool:
                         )
                         tbl.add_row(
                             "--format",
-                            "Glob pattern (default: *.{raw,set}; '*.raw', '*.edf', ...)",
+                            "Glob pattern (default: *.{raw,set,bdf}; '*.raw', '*.edf', '*.bdf', ...)",
                         )
                         tbl.add_row(
                             "--recursive", "Search subdirectories for matching files"

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -119,7 +119,7 @@ matplotlib.use("Agg")
 
 
 def _expand_brace_glob(pattern: str) -> list[str]:
-    """Expand simple brace globs like '*.{raw,set}' into ['*.raw', '*.set'].
+    """Expand simple brace globs like '*.{raw,set,bdf}' into ['*.raw', '*.set', '*.bdf'].
 
     This supports a single pair of braces with comma-separated options.
     If no braces are present, returns the pattern as a single-item list.
@@ -942,7 +942,7 @@ class Pipeline:
         self,
         directory: Optional[str | Path] = None,
         task: str = "",
-        pattern: str = "*.{raw,set}",
+        pattern: str = "*.{raw,set,bdf}",
         recursive: bool = False,
     ) -> None:
         """Processes all files matching a pattern within a directory sequentially.
@@ -955,7 +955,7 @@ class Pipeline:
         task : str
             The name of the task to perform (e.g., 'RestingEyesOpen').
         pattern : str, optional
-            Glob pattern to match files within the directory, default is `*.{raw,set}`.
+            Glob pattern to match files within the directory, default is `*.{raw,set,bdf}`.
         recursive : bool, optional
             If True, searches subdirectories recursively, by default False.
 
@@ -974,11 +974,11 @@ class Pipeline:
         >>> pipeline.process_directory(
         ...     directory='data/rest_state/',
         ...     task='rest_eyesopen',
-        ...     pattern='*.{raw,set}',
+        ...     pattern='*.{raw,set,bdf}',
         ...     recursive=True
         ... )
         >>> # Or use input_path from task config
-        >>> pipeline.process_directory(task='rest_eyesopen', pattern='*.{raw,set}')
+        >>> pipeline.process_directory(task='rest_eyesopen', pattern='*.{raw,set,bdf}')
         """
         # Use input_path from task config if directory not provided
         if directory is None:
@@ -1018,7 +1018,7 @@ class Pipeline:
             f"All files in directory ({len(all_files)}): {[f.name for f in all_files if f.is_file()]}",
         )
 
-        # Support brace expansion patterns like '*.{raw,set}'
+        # Support brace expansion patterns like '*.{raw,set,bdf}'
         files: list[Path] = []
         seen: set[Path] = set()
         for pat in _expand_brace_glob(search_pattern):
@@ -1076,7 +1076,7 @@ class Pipeline:
         self,
         directory_path: Optional[str | Path] = None,
         task: str = "",
-        pattern: str = "*.{raw,set}",
+        pattern: str = "*.{raw,set,bdf}",
         sub_directories: bool = False,
         max_concurrent: int = 3,
     ) -> None:
@@ -1090,7 +1090,7 @@ class Pipeline:
         task : str
             The name of the task to perform (e.g., 'RestingEyesOpen').
         pattern : str, optional
-            Glob pattern to match files within the directory, default is `*.{raw,set}`.
+            Glob pattern to match files within the directory, default is `*.{raw,set,bdf}`.
         sub_directories : bool, optional
             If True, searches subdirectories recursively, by default False.
         max_concurrent : int, optional
@@ -1145,7 +1145,7 @@ class Pipeline:
             f"All files in directory ({len(all_files)}): {[f.name for f in all_files if f.is_file()]}",
         )
 
-        # Support brace expansion patterns like '*.{raw,set}'
+        # Support brace expansion patterns like '*.{raw,set,bdf}'
         files: list[Path] = []
         seen: set[Path] = set()
         for pat in _expand_brace_glob(search_pattern):


### PR DESCRIPTION
## Summary
- The default format pattern for directory processing was `*.{raw,set}`, which excluded BDF files from discovery even though BDF plugins and format registration were fully implemented
- Updated all occurrences to `*.{raw,set,bdf}` across `cli.py` (4 locations) and `pipeline.py` (8 locations)
- BDF plugins, MNE integration (`read_raw_bdf`), and `_CORE_FORMATS` registry were already correct — only file discovery was broken

## Test plan
- [ ] Run `autocleaneeg-pipeline process --dir <dir_with_bdf_files>` and verify `.bdf` files are discovered
- [ ] Verify `--format '*.bdf'` still works as explicit override
- [ ] Confirm `.raw` and `.set` files continue to be discovered by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to default file discovery patterns and help text; low risk aside from potentially processing additional `.bdf` files by default in directory runs.
> 
> **Overview**
> Updates default directory-processing glob patterns from `*.{raw,set}` to `*.{raw,set,bdf}` across the CLI and `Pipeline.process_directory`/`process_directory_async`, so `.bdf` files are discovered without requiring an explicit `--format` override.
> 
> Also refreshes related help text and brace-glob documentation strings to reflect the new default pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58ccc885bb78ac1aac65388a277af7f26a7d9f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->