### PR TITLE
fix: prevent pending_approval tasks from overwriting approved tasks in registry

### DIFF
--- a/src/autoclean/tasks/__init__.py
+++ b/src/autoclean/tasks/__init__.py
@@ -12,27 +12,28 @@ from autoclean.core.task import Task
 # Get the current directory
 _current_dir = Path(__file__).parent
 
-# Collect all python files in the tasks directory
-_task_modules = {
+# Collect all approved python files in the tasks directory (non-pending)
+_approved_modules = {
     name: importlib.import_module(f"{__package__}.{name}")
     for finder, name, ispkg in pkgutil.iter_modules([str(_current_dir)])
     if not name.startswith("_")  # Skip private modules
 }
 
 _pending_dir = _current_dir / "pending_approval"
+_pending_modules = {}
 if _pending_dir.exists():
     for finder, name, ispkg in pkgutil.iter_modules([str(_pending_dir)]):
         if name.startswith("_"):
             continue
         module = importlib.import_module(f"{__package__}.pending_approval.{name}")
-        _task_modules[f"pending_approval.{name}"] = module
+        _pending_modules[f"pending_approval.{name}"] = module
 
 # Initialize collections
 __all__: List[str] = []
 task_registry: Dict[str, Type[Task]] = {}
 
-# Dynamically import all Task classes from each module
-for module_name, module in _task_modules.items():
+# Load approved tasks first
+for module_name, module in _approved_modules.items():
     # Get all classes that inherit from Task
     task_classes = {
         name.lower(): obj  # Convert to lowercase for consistent lookup
@@ -48,3 +49,19 @@ for module_name, module in _task_modules.items():
 
     # Add classes to the current namespace
     globals().update(task_classes)
+
+# Load pending_approval tasks — do NOT overwrite already-registered approved tasks
+for module_name, module in _pending_modules.items():
+    # Get all classes that inherit from Task
+    task_classes = {
+        name.lower(): obj  # Convert to lowercase for consistent lookup
+        for name, obj in inspect.getmembers(module, inspect.isclass)
+        if issubclass(obj, Task) and obj != Task  # Exclude the base Task class
+    }
+
+    for task_name, task_class in task_classes.items():
+        if task_name not in task_registry:
+            # Only register pending tasks that don't conflict with approved tasks
+            __all__.append(task_name)
+            task_registry[task_name] = task_class
+            globals()[task_name] = task_class

--- a/tests/unit/test_tasks_registry.py
+++ b/tests/unit/test_tasks_registry.py
@@ -1,0 +1,53 @@
+"""Tests for the tasks registry to ensure approved tasks are not overwritten by pending_approval tasks."""
+
+import pytest
+
+
+def test_approved_task_takes_precedence_over_pending():
+    """Approved tasks must not be overwritten by pending_approval tasks with the same name.
+
+    Regression test for: https://github.com/cincibrainlab/autocleaneeg_pipeline/issues/138
+    When a task exists in both src/autoclean/tasks/ (approved) and
+    src/autoclean/tasks/pending_approval/ (not yet approved), the approved
+    version must win. Otherwise the pending version's config (which may differ)
+    silently replaces the approved one.
+    """
+    from autoclean.tasks import task_registry
+
+    # RestingState_Basic exists in both approved and pending_approval directories.
+    # The approved version has crop_step disabled; the pending_approval version has it enabled.
+    task_name = "restingstate_basic"
+    assert task_name in task_registry, f"Task '{task_name}' not found in registry"
+
+    task_class = task_registry[task_name]
+
+    # The approved task's module is autoclean.tasks.RestingState_Basic (not pending_approval)
+    assert "pending_approval" not in task_class.__module__, (
+        f"Task '{task_name}' was loaded from pending_approval instead of the approved tasks directory. "
+        f"Module: {task_class.__module__}. "
+        "This means pending_approval tasks are overwriting approved tasks in the registry."
+    )
+
+
+def test_pending_only_task_is_registered():
+    """Tasks that exist only in pending_approval (with no approved counterpart) should be accessible."""
+    from autoclean.tasks import task_registry
+
+    # Check that pending_approval-only tasks are still registered
+    # (they don't conflict with any approved task)
+    # This ensures we haven't broken the ability to use pending tasks that are truly new.
+    # We verify by checking that the registry itself is non-empty and includes approved tasks.
+    assert len(task_registry) > 0, "Task registry should not be empty"
+
+
+def test_registry_does_not_contain_duplicate_approved_tasks():
+    """The registry should not contain duplicate entries for the same task name."""
+    from autoclean.tasks import task_registry, __all__
+
+    # Each task name should appear at most once in __all__ from approved tasks
+    # (pending_approval tasks that don't conflict are also fine, but duplicates are not)
+    registry_keys = list(task_registry.keys())
+    assert len(registry_keys) == len(set(registry_keys)), (
+        "Task registry contains duplicate keys: "
+        f"{[k for k in registry_keys if registry_keys.count(k) > 1]}"
+    )


### PR DESCRIPTION
Fixes #138

The task registry in `src/autoclean/tasks/__init__.py` was loading both approved tasks and `pending_approval` tasks, and when two tasks share the same class name, the pending_approval version was silently overwriting the approved version.

This caused `RestingState_Basic` to run with `crop_step: {enabled: True}` (from pending_approval) instead of `crop_step: {enabled: False}` (from the approved task), resulting in data being unexpectedly cropped to 60 seconds.

## Changes
- `src/autoclean/tasks/__init__.py`: Load approved tasks first, then only add pending_approval tasks that don't conflict with an approved task
- `tests/unit/test_tasks_registry.py`: Regression test verifying approved tasks take precedence

Generated with [Claude Code](https://claude.ai/code)