### PR TITLE
fix: show outer layer channels in Bad Channels report section

### DIFF
--- a/src/autoclean/step_functions/reports.py
+++ b/src/autoclean/step_functions/reports.py
@@ -1439,6 +1439,17 @@ def create_json_summary(run_id: str, flagged_reasons: list[str] = []) -> dict:
                 f"Skipping flagged-channels file with invalid encoding: {flagged_chs_path.name}",
             )
 
+    # Add outer layer dropped channels as a named category in channel_dict
+    if "step_drop_outerlayer" in metadata:
+        try:
+            outer_channels = metadata["step_drop_outerlayer"].get(
+                "dropped_outer_layer_channels", []
+            )
+            if outer_channels:
+                channel_dict["outer_layer"] = outer_channels
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     # Get all removed channels from unified metadata (preferred) or legacy sources
     if "channel_removals" in metadata:
         # Use unified channel removals for accurate tracking


### PR DESCRIPTION
## Summary
This ports the outer-layer bad-channel reporting fix onto current `main`.

## Changes
- add dropped outer-layer channels to the bad-channel summary dictionary
- surface them as a named category in the report instead of only reflecting them in totals or processing details

## Impact
This does not change EEG cleaning or which channels are dropped.
It only makes the generated report reflect outer-layer removals more clearly.

## Validation
- cherry-picked cleanly onto current `main`
- touched file compiles cleanly
