### PR TITLE
ci: upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary
Clean replacement for Dependabot PR #132.

## Changes
- update `actions/checkout` from `v4` to `v6` in the two active Claude workflows
- avoid the line-ending and file-mode churn from the Dependabot branch

## Validation
- verified the semantic diff is only two workflow line changes
- no YAML parsing/test suite run
