### PR TITLE
deps: bump mne-icalabel to 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "PyWavelets==1.9.0",
     # EEG processing core
     "mne==1.10.1",
-    "mne-icalabel==0.8.0",
+    "mne-icalabel==0.8.1",
     "mne-bids==0.17.0",
     "autoreject==0.4.3",
     "pyprep==0.5.0",


### PR DESCRIPTION
## Summary
Clean replacement for Dependabot PR #122.

## Changes
- bump `mne-icalabel` from `0.8.0` to `0.8.1`
- avoid the line-ending and file-mode churn from the Dependabot branch

## Validation
- verified the semantic diff is a single version-line change in `pyproject.toml`
- no test suite run
