### PR TITLE
deps: bump schema to 0.7.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "python-dotenv==1.1.1",
     "defusedxml==0.7.1",
     "pyyaml==6.0.2",
-    "schema==0.7.7",
+    "schema==0.7.8",
     "watchfiles>=0.24.0",
 
     "Jinja2==3.1.6",


### PR DESCRIPTION
## Summary
Clean replacement for Dependabot PR #124.

## Changes
- bump `schema` from `0.7.7` to `0.7.8`
- avoid the line-ending and file-mode churn from the Dependabot branch

## Validation
- verified the semantic diff is a single version-line change in `pyproject.toml`
- no test suite run
