### PR TITLE
deps: bump pandas to 2.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     # Core scientific computing
     "numpy==2.3.3",
     "scipy==1.16.2",
-    "pandas==2.3.2",
+    "pandas==2.3.3",
     "matplotlib==3.10.6",
     "seaborn==0.13.2",
     "PyWavelets==1.9.0",


### PR DESCRIPTION
## Summary
Clean replacement for Dependabot PR #125.

## Changes
- bump `pandas` from `2.3.2` to `2.3.3`
- avoid the line-ending and file-mode churn from the Dependabot branch

## Validation
- verified the semantic diff is a single version-line change in `pyproject.toml`
- no test suite run
