### PR TITLE
deps: bump mne to 1.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "seaborn==0.13.2",
     "PyWavelets==1.9.0",
     # EEG processing core
-    "mne==1.10.1",
+    "mne==1.10.2",
     "mne-icalabel==0.8.1",
     "mne-bids==0.17.0",
     "autoreject==0.4.3",


### PR DESCRIPTION
## Summary
Clean replacement for Dependabot PR #130.

## Changes
- bump `mne` from `1.10.1` to `1.10.2`
- avoid the line-ending and file-mode churn from the Dependabot branch

## Validation
- verified the semantic diff is a single version-line change in `pyproject.toml`
- no test suite run
