### PR TITLE
fix(biosemi): support BDF layouts and status events

### DIFF
--- a/src/autoclean/io/import_.py
+++ b/src/autoclean/io/import_.py
@@ -211,12 +211,14 @@ def register_plugin(plugin_class: Type[BaseEEGPlugin]) -> None:
             "GSN-HydroCel-129",
             "GSN-HydroCel-124",
             "standard_1020",
+            "biosemi32",
             "biosemi64",
+            "biosemi128",
+            "biosemi256",
             "MEA30",
             "MEA30_EDF",
             "MouseEEGv2_H32",
             "MEA30_MNI",
-            "BioSemi-256",
             "CustomCap-64",
         ]
 
@@ -323,6 +325,17 @@ def get_plugin_for_combination(format_id: str, montage_name: str) -> BaseEEGPlug
         for key, plugin_class in _PLUGIN_REGISTRY.items()
         if key[0] == format_id
     ]
+
+    if format_plugins and format_id == "BIOSEMI_BDF":
+        supported_montages = sorted(
+            montage
+            for plugin_format, montage in _PLUGIN_REGISTRY
+            if plugin_format == format_id
+        )
+        raise ValueError(
+            f"No plugin found for format '{format_id}' and montage '{montage_name}'. "
+            f"Supported montages for {format_id}: {', '.join(supported_montages)}"
+        )
 
     if format_plugins:
         message(

--- a/src/autoclean/io/import_.py
+++ b/src/autoclean/io/import_.py
@@ -39,6 +39,7 @@ __all__ = [
     "BaseEventProcessor",
     "register_event_processor",
     "get_event_processor_for_task",
+    "normalize_montage_name",
 ]
 
 # Registry to store format mappings and plugins
@@ -57,6 +58,23 @@ _CORE_FORMATS = {
     "bdf": "BIOSEMI_BDF",
     "cnt": "NEUROSCAN_CNT",
 }
+
+_BIOSEMI_MONTAGE_ALIASES = {
+    "biosemi-32": "biosemi32",
+    "biosemi32": "biosemi32",
+    "biosemi-64": "biosemi64",
+    "biosemi64": "biosemi64",
+    "biosemi-128": "biosemi128",
+    "biosemi128": "biosemi128",
+    "biosemi-256": "biosemi256",
+    "biosemi256": "biosemi256",
+}
+
+
+def normalize_montage_name(montage_name: str) -> str:
+    """Normalize supported montage aliases while preserving unknown names."""
+    normalized_key = str(montage_name).strip().lower()
+    return _BIOSEMI_MONTAGE_ALIASES.get(normalized_key, montage_name)
 
 
 def register_format(extension: str, format_id: str) -> None:
@@ -211,6 +229,10 @@ def register_plugin(plugin_class: Type[BaseEEGPlugin]) -> None:
             "GSN-HydroCel-129",
             "GSN-HydroCel-124",
             "standard_1020",
+            "BioSemi-32",
+            "BioSemi-64",
+            "BioSemi-128",
+            "BioSemi-256",
             "biosemi32",
             "biosemi64",
             "biosemi128",
@@ -307,16 +329,17 @@ def get_plugin_for_combination(format_id: str, montage_name: str) -> BaseEEGPlug
     """
     # Ensure plugins are discovered (will only run once)
     discover_plugins()
+    normalized_montage_name = normalize_montage_name(montage_name)
 
     # Try to get an exact match
-    key = (format_id, montage_name)
+    key = (format_id, normalized_montage_name)
     if key in _PLUGIN_REGISTRY:
         plugin_class = _PLUGIN_REGISTRY[key]
         return plugin_class()
 
     # If no exact match, look for plugins that claim they can handle this combination
     for plugin_class in set(_PLUGIN_REGISTRY.values()):
-        if plugin_class.supports_format_montage(format_id, montage_name):
+        if plugin_class.supports_format_montage(format_id, normalized_montage_name):
             return plugin_class()
 
     # If still no match, try to find a plugin that supports this format with any montage
@@ -333,7 +356,8 @@ def get_plugin_for_combination(format_id: str, montage_name: str) -> BaseEEGPlug
             if plugin_format == format_id
         )
         raise ValueError(
-            f"No plugin found for format '{format_id}' and montage '{montage_name}'. "
+            f"No plugin found for format '{format_id}' and montage '{montage_name}' "
+            f"(normalized to '{normalized_montage_name}'). "
             f"Supported montages for {format_id}: {', '.join(supported_montages)}"
         )
 
@@ -404,9 +428,10 @@ def import_eeg(
 
         # Get montage name from configuration
         montage_name = autoclean_dict["eeg_system"]
+        normalized_montage_name = normalize_montage_name(montage_name)
 
         # Get appropriate plugin
-        plugin = get_plugin_for_combination(format_id, montage_name)
+        plugin = get_plugin_for_combination(format_id, normalized_montage_name)
         message("header", f"Using plugin: {plugin.__class__.__name__}")
 
         # Import and configure the data
@@ -439,7 +464,7 @@ def import_eeg(
                 "import_function": "import_eeg",
                 "plugin_used": plugin.__class__.__name__,
                 "file_format": format_id,
-                "montage_name": montage_name,
+                "montage_name": normalized_montage_name,
                 "creationDateTime": datetime.now().isoformat(),
                 "unprocessedFile": str(unprocessed_file.name),
                 "eegSystem": autoclean_dict["eeg_system"],

--- a/src/autoclean/plugins/eeg_plugins/_biosemi_bdf_common.py
+++ b/src/autoclean/plugins/eeg_plugins/_biosemi_bdf_common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import mne
+import pandas as pd
 
 from autoclean.utils.logging import message
 
@@ -41,7 +42,9 @@ def import_biosemi_bdf(
         _biosemi_import_options(autoclean_dict)
     )
 
-    message("info", f"Loading BioSemi BDF file with {montage_name} montage: {file_path}")
+    message(
+        "info", f"Loading BioSemi BDF file with {montage_name} montage: {file_path}"
+    )
     message(
         "info",
         "BioSemi BDF import immediately re-references EEG to LM/RM mastoids when both channels are available.",
@@ -136,3 +139,65 @@ def import_biosemi_bdf(
 
     message("info", f"Selected {len(raw.ch_names)} channels after configuration")
     return raw
+
+
+def _events_dataframe(events, event_id: dict[str, int], sfreq: float) -> pd.DataFrame:
+    """Create the BioSemi event metadata table used by BDF plugins."""
+    reverse_event_id = {value: key for key, value in event_id.items()}
+    return pd.DataFrame(
+        {
+            "time": events[:, 0] / sfreq,
+            "sample": events[:, 0],
+            "id": events[:, 2],
+            "type": [
+                reverse_event_id.get(event, f"Status-{event}") for event in events[:, 2]
+            ],
+        }
+    )
+
+
+def process_biosemi_bdf_events(raw: mne.io.Raw) -> tuple:
+    """Extract BioSemi events from annotations, then fall back to Status/stim data."""
+    message("info", "Processing events from BDF status channel")
+    try:
+        events, event_id = mne.events_from_annotations(raw, verbose=False)
+        if events is None or len(events) == 0:
+            stim_channels = [
+                name
+                for name, kind in zip(raw.ch_names, raw.get_channel_types())
+                if name == "Status" or kind == "stim"
+            ]
+            if not stim_channels:
+                message(
+                    "warning", "No Status or stim channel found in BioSemi BDF data"
+                )
+                return None, None, None
+
+            status_channel = "Status" if "Status" in stim_channels else stim_channels[0]
+            events = mne.find_events(
+                raw,
+                stim_channel=status_channel,
+                shortest_event=1,
+                verbose=False,
+            )
+            event_id = {
+                f"Status-{event_code}": int(event_code)
+                for event_code in sorted(set(events[:, 2]))
+            }
+
+        if events is None or len(events) == 0:
+            message("warning", "No events found in the BDF status channel")
+            return None, None, None
+
+        events_df = _events_dataframe(events, event_id, raw.info["sfreq"])
+        unique_event_types = events_df["type"].unique()
+        message(
+            "info",
+            f"Found {len(events)} events of {len(unique_event_types)} unique types: {unique_event_types}",
+        )
+        message("info", f"Event counts: {events_df['type'].value_counts().to_dict()}")
+        return events, event_id, events_df
+
+    except Exception as e:  # pylint: disable=broad-except
+        message("warning", f"Failed to process events: {str(e)}")
+        return None, None, None

--- a/src/autoclean/plugins/eeg_plugins/bdf_biosemi128_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/bdf_biosemi128_plugin.py
@@ -8,10 +8,12 @@ for BioSemi BDF files with the 128-channel BioSemi electrode system.
 from pathlib import Path
 
 import mne
-import pandas as pd
 
 from autoclean.io.import_ import BaseEEGPlugin
-from autoclean.plugins.eeg_plugins._biosemi_bdf_common import import_biosemi_bdf
+from autoclean.plugins.eeg_plugins._biosemi_bdf_common import (
+    import_biosemi_bdf,
+    process_biosemi_bdf_events,
+)
 from autoclean.utils.logging import message
 
 
@@ -48,53 +50,8 @@ class BDFBiosemi128Plugin(BaseEEGPlugin):
             ) from e
 
     def process_events(self, raw: mne.io.Raw) -> tuple:
-        """Process events and annotations from BDF status channel.
-
-        BioSemi BDF files encode triggers in a 16-bit status channel,
-        with system status information in the upper bits.
-        """
-        message("info", "Processing events from BDF status channel")
-        try:
-            # Get events from annotations (MNE auto-extracts from status channel)
-            events, event_id = mne.events_from_annotations(raw)
-
-            # Create a detailed events DataFrame
-            if events is not None and len(events) > 0:
-                events_df = pd.DataFrame(
-                    {
-                        "time": events[:, 0] / raw.info["sfreq"],
-                        "sample": events[:, 0],
-                        "id": events[:, 2],
-                        "type": [
-                            (
-                                list(event_id.keys())[list(event_id.values()).index(id)]
-                                if id in event_id.values()
-                                else f"Unknown-{id}"
-                            )
-                            for id in events[:, 2]
-                        ],
-                    }
-                )
-
-                # Log event information
-                unique_event_types = events_df["type"].unique()
-                message(
-                    "info",
-                    f"Found {len(events)} events of {len(unique_event_types)} unique types: {unique_event_types}",
-                )
-
-                # Count events by type
-                event_counts = events_df["type"].value_counts().to_dict()
-                message("info", f"Event counts: {event_counts}")
-
-                return events, event_id, events_df
-            else:
-                message("warning", "No events found in the BDF status channel")
-                return None, None, None
-
-        except Exception as e:  # pylint: disable=broad-except
-            message("warning", f"Failed to process events: {str(e)}")
-            return None, None, None
+        """Process events and annotations from BDF status channel."""
+        return process_biosemi_bdf_events(raw)
 
     def get_metadata(self) -> dict:
         """Get additional metadata about this plugin."""

--- a/src/autoclean/plugins/eeg_plugins/bdf_biosemi256_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/bdf_biosemi256_plugin.py
@@ -8,10 +8,12 @@ for BioSemi BDF files with the 256-channel BioSemi electrode system.
 from pathlib import Path
 
 import mne
-import pandas as pd
 
 from autoclean.io.import_ import BaseEEGPlugin
-from autoclean.plugins.eeg_plugins._biosemi_bdf_common import import_biosemi_bdf
+from autoclean.plugins.eeg_plugins._biosemi_bdf_common import (
+    import_biosemi_bdf,
+    process_biosemi_bdf_events,
+)
 from autoclean.utils.logging import message
 
 
@@ -48,53 +50,8 @@ class BDFBiosemi256Plugin(BaseEEGPlugin):
             ) from e
 
     def process_events(self, raw: mne.io.Raw) -> tuple:
-        """Process events and annotations from BDF status channel.
-
-        BioSemi BDF files encode triggers in a 16-bit status channel,
-        with system status information in the upper bits.
-        """
-        message("info", "Processing events from BDF status channel")
-        try:
-            # Get events from annotations (MNE auto-extracts from status channel)
-            events, event_id = mne.events_from_annotations(raw)
-
-            # Create a detailed events DataFrame
-            if events is not None and len(events) > 0:
-                events_df = pd.DataFrame(
-                    {
-                        "time": events[:, 0] / raw.info["sfreq"],
-                        "sample": events[:, 0],
-                        "id": events[:, 2],
-                        "type": [
-                            (
-                                list(event_id.keys())[list(event_id.values()).index(id)]
-                                if id in event_id.values()
-                                else f"Unknown-{id}"
-                            )
-                            for id in events[:, 2]
-                        ],
-                    }
-                )
-
-                # Log event information
-                unique_event_types = events_df["type"].unique()
-                message(
-                    "info",
-                    f"Found {len(events)} events of {len(unique_event_types)} unique types: {unique_event_types}",
-                )
-
-                # Count events by type
-                event_counts = events_df["type"].value_counts().to_dict()
-                message("info", f"Event counts: {event_counts}")
-
-                return events, event_id, events_df
-            else:
-                message("warning", "No events found in the BDF status channel")
-                return None, None, None
-
-        except Exception as e:  # pylint: disable=broad-except
-            message("warning", f"Failed to process events: {str(e)}")
-            return None, None, None
+        """Process events and annotations from BDF status channel."""
+        return process_biosemi_bdf_events(raw)
 
     def get_metadata(self) -> dict:
         """Get additional metadata about this plugin."""

--- a/src/autoclean/plugins/eeg_plugins/bdf_biosemi32_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/bdf_biosemi32_plugin.py
@@ -8,10 +8,12 @@ for BioSemi BDF files with the 32-channel BioSemi electrode system.
 from pathlib import Path
 
 import mne
-import pandas as pd
 
 from autoclean.io.import_ import BaseEEGPlugin
-from autoclean.plugins.eeg_plugins._biosemi_bdf_common import import_biosemi_bdf
+from autoclean.plugins.eeg_plugins._biosemi_bdf_common import (
+    import_biosemi_bdf,
+    process_biosemi_bdf_events,
+)
 from autoclean.utils.logging import message
 
 
@@ -48,53 +50,8 @@ class BDFBiosemi32Plugin(BaseEEGPlugin):
             ) from e
 
     def process_events(self, raw: mne.io.Raw) -> tuple:
-        """Process events and annotations from BDF status channel.
-
-        BioSemi BDF files encode triggers in a 16-bit status channel,
-        with system status information in the upper bits.
-        """
-        message("info", "Processing events from BDF status channel")
-        try:
-            # Get events from annotations (MNE auto-extracts from status channel)
-            events, event_id = mne.events_from_annotations(raw)
-
-            # Create a detailed events DataFrame
-            if events is not None and len(events) > 0:
-                events_df = pd.DataFrame(
-                    {
-                        "time": events[:, 0] / raw.info["sfreq"],
-                        "sample": events[:, 0],
-                        "id": events[:, 2],
-                        "type": [
-                            (
-                                list(event_id.keys())[list(event_id.values()).index(id)]
-                                if id in event_id.values()
-                                else f"Unknown-{id}"
-                            )
-                            for id in events[:, 2]
-                        ],
-                    }
-                )
-
-                # Log event information
-                unique_event_types = events_df["type"].unique()
-                message(
-                    "info",
-                    f"Found {len(events)} events of {len(unique_event_types)} unique types: {unique_event_types}",
-                )
-
-                # Count events by type
-                event_counts = events_df["type"].value_counts().to_dict()
-                message("info", f"Event counts: {event_counts}")
-
-                return events, event_id, events_df
-            else:
-                message("warning", "No events found in the BDF status channel")
-                return None, None, None
-
-        except Exception as e:  # pylint: disable=broad-except
-            message("warning", f"Failed to process events: {str(e)}")
-            return None, None, None
+        """Process events and annotations from BDF status channel."""
+        return process_biosemi_bdf_events(raw)
 
     def get_metadata(self) -> dict:
         """Get additional metadata about this plugin."""

--- a/src/autoclean/plugins/eeg_plugins/bdf_biosemi64_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/bdf_biosemi64_plugin.py
@@ -8,10 +8,12 @@ for BioSemi BDF files with the 64-channel BioSemi electrode system.
 from pathlib import Path
 
 import mne
-import pandas as pd
 
 from autoclean.io.import_ import BaseEEGPlugin
-from autoclean.plugins.eeg_plugins._biosemi_bdf_common import import_biosemi_bdf
+from autoclean.plugins.eeg_plugins._biosemi_bdf_common import (
+    import_biosemi_bdf,
+    process_biosemi_bdf_events,
+)
 from autoclean.utils.logging import message
 
 
@@ -48,53 +50,8 @@ class BDFBiosemi64Plugin(BaseEEGPlugin):
             ) from e
 
     def process_events(self, raw: mne.io.Raw) -> tuple:
-        """Process events and annotations from BDF status channel.
-
-        BioSemi BDF files encode triggers in a 16-bit status channel,
-        with system status information in the upper bits.
-        """
-        message("info", "Processing events from BDF status channel")
-        try:
-            # Get events from annotations (MNE auto-extracts from status channel)
-            events, event_id = mne.events_from_annotations(raw)
-
-            # Create a detailed events DataFrame
-            if events is not None and len(events) > 0:
-                events_df = pd.DataFrame(
-                    {
-                        "time": events[:, 0] / raw.info["sfreq"],
-                        "sample": events[:, 0],
-                        "id": events[:, 2],
-                        "type": [
-                            (
-                                list(event_id.keys())[list(event_id.values()).index(id)]
-                                if id in event_id.values()
-                                else f"Unknown-{id}"
-                            )
-                            for id in events[:, 2]
-                        ],
-                    }
-                )
-
-                # Log event information
-                unique_event_types = events_df["type"].unique()
-                message(
-                    "info",
-                    f"Found {len(events)} events of {len(unique_event_types)} unique types: {unique_event_types}",
-                )
-
-                # Count events by type
-                event_counts = events_df["type"].value_counts().to_dict()
-                message("info", f"Event counts: {event_counts}")
-
-                return events, event_id, events_df
-            else:
-                message("warning", "No events found in the BDF status channel")
-                return None, None, None
-
-        except Exception as e:  # pylint: disable=broad-except
-            message("warning", f"Failed to process events: {str(e)}")
-            return None, None, None
+        """Process events and annotations from BDF status channel."""
+        return process_biosemi_bdf_events(raw)
 
     def get_metadata(self) -> dict:
         """Get additional metadata about this plugin."""

--- a/tests/unit/plugins/test_bdf_plugins.py
+++ b/tests/unit/plugins/test_bdf_plugins.py
@@ -11,6 +11,7 @@ from autoclean.io.import_ import (
     _PLUGIN_REGISTRY,
     find_plugin_for_combination,
     get_format_from_extension,
+    normalize_montage_name,
     register_plugin,
 )
 from autoclean.plugins.eeg_plugins.bdf_biosemi32_plugin import BDFBiosemi32Plugin
@@ -631,10 +632,24 @@ def test_biosemi_bdf_format_and_plugin_registry_routes_all_supported_montages():
         assert _PLUGIN_REGISTRY[("BIOSEMI_BDF", "biosemi64")] is BDFBiosemi64Plugin
         assert _PLUGIN_REGISTRY[("BIOSEMI_BDF", "biosemi128")] is BDFBiosemi128Plugin
         assert _PLUGIN_REGISTRY[("BIOSEMI_BDF", "biosemi256")] is BDFBiosemi256Plugin
+        assert (
+            find_plugin_for_combination("BIOSEMI_BDF", "BioSemi-256").__class__
+            is BDFBiosemi256Plugin
+        )
     finally:
         _PLUGIN_REGISTRY.clear()
         _PLUGIN_REGISTRY.update(original_registry)
         import_module._PLUGINS_DISCOVERED = original_discovered
+
+
+def test_biosemi_montage_aliases_accept_user_facing_names():
+    """User-facing BioSemi-32/64/128/256 names should map to plugin keys."""
+    assert normalize_montage_name("BioSemi-32") == "biosemi32"
+    assert normalize_montage_name("BioSemi-64") == "biosemi64"
+    assert normalize_montage_name("BioSemi-128") == "biosemi128"
+    assert normalize_montage_name("BioSemi-256") == "biosemi256"
+    assert normalize_montage_name("biosemi256") == "biosemi256"
+    assert normalize_montage_name("GSN-HydroCel-129") == "GSN-HydroCel-129"
 
 
 def test_biosemi_bdf_registry_rejects_unsupported_montage():

--- a/tests/unit/plugins/test_bdf_plugins.py
+++ b/tests/unit/plugins/test_bdf_plugins.py
@@ -11,6 +11,12 @@ from autoclean.plugins.eeg_plugins.bdf_biosemi32_plugin import BDFBiosemi32Plugi
 from autoclean.plugins.eeg_plugins.bdf_biosemi64_plugin import BDFBiosemi64Plugin
 from autoclean.plugins.eeg_plugins.bdf_biosemi128_plugin import BDFBiosemi128Plugin
 from autoclean.plugins.eeg_plugins.bdf_biosemi256_plugin import BDFBiosemi256Plugin
+from autoclean.io.import_ import (
+    _PLUGIN_REGISTRY,
+    find_plugin_for_combination,
+    get_format_from_extension,
+    register_plugin,
+)
 from tests.fixtures.synthetic_data import create_synthetic_raw
 from tests.fixtures.test_utils import EEGAssertions
 
@@ -87,20 +93,12 @@ class TestBDFBiosemi32Plugin:
         plugin_class = MockBDFBiosemi32Plugin
 
         # Should support correct combination
-        assert (
-            plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi32") is True
-        )
+        assert plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi32") is True
 
         # Should not support incorrect combinations
-        assert (
-            plugin_class.supports_format_montage("EGI_RAW", "biosemi32") is False
-        )
-        assert (
-            plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi64") is False
-        )
-        assert (
-            plugin_class.supports_format_montage("EEGLAB_SET", "biosemi32") is False
-        )
+        assert plugin_class.supports_format_montage("EGI_RAW", "biosemi32") is False
+        assert plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi64") is False
+        assert plugin_class.supports_format_montage("EEGLAB_SET", "biosemi32") is False
 
     @patch("mne.io.read_raw_bdf")
     def test_bdf_biosemi32_import_functionality(self, mock_read_bdf):
@@ -180,14 +178,10 @@ class TestBDFBiosemi64Plugin:
         plugin_class = MockBDFBiosemi64Plugin
 
         # Should support correct combination
-        assert (
-            plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi64") is True
-        )
+        assert plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi64") is True
 
         # Should not support incorrect combinations
-        assert (
-            plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi32") is False
-        )
+        assert plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi32") is False
         assert (
             plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi128") is False
         )
@@ -267,14 +261,10 @@ class TestBDFBiosemi128Plugin:
         plugin_class = MockBDFBiosemi128Plugin
 
         # Should support correct combination
-        assert (
-            plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi128") is True
-        )
+        assert plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi128") is True
 
         # Should not support incorrect combinations
-        assert (
-            plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi64") is False
-        )
+        assert plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi64") is False
         assert (
             plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi256") is False
         )
@@ -353,9 +343,7 @@ class TestBDFBiosemi256Plugin:
         plugin_class = MockBDFBiosemi256Plugin
 
         # Should support correct combination
-        assert (
-            plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi256") is True
-        )
+        assert plugin_class.supports_format_montage("BIOSEMI_BDF", "biosemi256") is True
 
         # Should not support incorrect combinations
         assert (
@@ -618,6 +606,78 @@ class TestBDFPluginMocked:
                 break
 
         assert selected_plugin == plugin_128
+
+
+def test_biosemi_bdf_format_and_plugin_registry_routes_all_supported_montages():
+    """BioSemi BDF should route explicitly to each supported montage plugin."""
+    original_registry = _PLUGIN_REGISTRY.copy()
+    original_discovered = __import__(
+        "autoclean.io.import_", fromlist=["_PLUGINS_DISCOVERED"]
+    )._PLUGINS_DISCOVERED
+    import_module = __import__("autoclean.io.import_", fromlist=["_PLUGINS_DISCOVERED"])
+    import_module._PLUGINS_DISCOVERED = True
+    _PLUGIN_REGISTRY.clear()
+    try:
+        for plugin_class in (
+            BDFBiosemi32Plugin,
+            BDFBiosemi64Plugin,
+            BDFBiosemi128Plugin,
+            BDFBiosemi256Plugin,
+        ):
+            register_plugin(plugin_class)
+
+        assert get_format_from_extension(".bdf") == "BIOSEMI_BDF"
+        assert _PLUGIN_REGISTRY[("BIOSEMI_BDF", "biosemi32")] is BDFBiosemi32Plugin
+        assert _PLUGIN_REGISTRY[("BIOSEMI_BDF", "biosemi64")] is BDFBiosemi64Plugin
+        assert _PLUGIN_REGISTRY[("BIOSEMI_BDF", "biosemi128")] is BDFBiosemi128Plugin
+        assert _PLUGIN_REGISTRY[("BIOSEMI_BDF", "biosemi256")] is BDFBiosemi256Plugin
+    finally:
+        _PLUGIN_REGISTRY.clear()
+        _PLUGIN_REGISTRY.update(original_registry)
+        import_module._PLUGINS_DISCOVERED = original_discovered
+
+
+def test_biosemi_bdf_registry_rejects_unsupported_montage():
+    """Unsupported BioSemi BDF montages should fail instead of using a wrong plugin."""
+    original_registry = _PLUGIN_REGISTRY.copy()
+    import_module = __import__("autoclean.io.import_", fromlist=["_PLUGINS_DISCOVERED"])
+    original_discovered = import_module._PLUGINS_DISCOVERED
+    import_module._PLUGINS_DISCOVERED = True
+    _PLUGIN_REGISTRY.clear()
+    try:
+        for plugin_class in (
+            BDFBiosemi32Plugin,
+            BDFBiosemi64Plugin,
+            BDFBiosemi128Plugin,
+            BDFBiosemi256Plugin,
+        ):
+            register_plugin(plugin_class)
+
+        assert find_plugin_for_combination("BIOSEMI_BDF", "biosemi16") is None
+    finally:
+        _PLUGIN_REGISTRY.clear()
+        _PLUGIN_REGISTRY.update(original_registry)
+        import_module._PLUGINS_DISCOVERED = original_discovered
+
+
+def test_biosemi_process_events_falls_back_to_status_channel():
+    """BioSemi plugins should read triggers from the Status stim channel."""
+    info = mne.create_info(
+        ch_names=["Fp1", "Fp2", "Status"],
+        sfreq=100.0,
+        ch_types=["eeg", "eeg", "stim"],
+    )
+    data = np.zeros((3, 40))
+    data[2, 10:12] = 7
+    data[2, 25:27] = 9
+    raw = mne.io.RawArray(data, info, verbose=False)
+
+    events, event_id, events_df = BDFBiosemi64Plugin().process_events(raw)
+
+    assert events[:, 0].tolist() == [10, 25]
+    assert events[:, 2].tolist() == [7, 9]
+    assert event_id == {"Status-7": 7, "Status-9": 9}
+    assert events_df["type"].tolist() == ["Status-7", "Status-9"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/plugins/test_bdf_plugins.py
+++ b/tests/unit/plugins/test_bdf_plugins.py
@@ -7,16 +7,16 @@ import mne
 import numpy as np
 import pytest
 
-from autoclean.plugins.eeg_plugins.bdf_biosemi32_plugin import BDFBiosemi32Plugin
-from autoclean.plugins.eeg_plugins.bdf_biosemi64_plugin import BDFBiosemi64Plugin
-from autoclean.plugins.eeg_plugins.bdf_biosemi128_plugin import BDFBiosemi128Plugin
-from autoclean.plugins.eeg_plugins.bdf_biosemi256_plugin import BDFBiosemi256Plugin
 from autoclean.io.import_ import (
     _PLUGIN_REGISTRY,
     find_plugin_for_combination,
     get_format_from_extension,
     register_plugin,
 )
+from autoclean.plugins.eeg_plugins.bdf_biosemi32_plugin import BDFBiosemi32Plugin
+from autoclean.plugins.eeg_plugins.bdf_biosemi64_plugin import BDFBiosemi64Plugin
+from autoclean.plugins.eeg_plugins.bdf_biosemi128_plugin import BDFBiosemi128Plugin
+from autoclean.plugins.eeg_plugins.bdf_biosemi256_plugin import BDFBiosemi256Plugin
 from tests.fixtures.synthetic_data import create_synthetic_raw
 from tests.fixtures.test_utils import EEGAssertions
 


### PR DESCRIPTION
## Summary
- Adds explicit BioSemi BDF import support for BioSemi 32/64/128/256 layouts.
- Routes `.bdf` files through the BioSemi plugin family using file format plus montage.
- Adds Status/stim-channel event extraction fallback so BDF event data is not missed when annotations are absent.
- Updates BioSemi plugin tests for layout routing, montage behavior, and Status channel handling.

## Verification
- `uv run --extra dev pytest tests\unit\plugins\test_bdf_plugins.py -q --no-cov` -> 28 passed
- Prior human Serve smoke test routed synthetic BioSemi32 BDF through the route/import path; later failure was expected from too-short synthetic resting data, not BDF import routing.

Closes #198