### PR TITLE
test(export): cover PR0 fallback paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install black==25.9.0 isort==6.0.1 mypy==1.18.2 ruff==0.15.20
 
+      # TODO: restore whole-repo formatting/linting once the existing baseline is clean.
       - name: Run formatting checks on changed Python files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -59,6 +60,7 @@ jobs:
           fi
           ruff check $files
 
+      # TODO: make mypy blocking after a typed baseline or per-module allowlist exists.
       - name: Run type checks (advisory baseline)
         run: |
           mypy src/autoclean || echo "mypy baseline is currently advisory; changed-file lint remains blocking."

--- a/src/autoclean/io/export.py
+++ b/src/autoclean/io/export.py
@@ -262,6 +262,9 @@ def save_raw_to_set(
                     saved_paths.append(path)
                 except Exception as set_err:
                     err_str = str(set_err)
+                    # eeglabio/MNE surface MATLAB v5 .set size failures as
+                    # message text rather than a stable exception type. Keep
+                    # this fallback paired with tests so string drift is caught.
                     if "Matlab 5" in err_str or "Matrix too large" in err_str:
                         fif_path = path.with_suffix(".fif")
                         message(
@@ -625,6 +628,9 @@ def save_epochs_to_set(
                 saved_paths.append(path)
             except Exception as set_err:
                 err_str = str(set_err)
+                # eeglabio/MNE surface MATLAB v5 .set size failures as message
+                # text rather than a stable exception type. Keep this fallback
+                # paired with tests so string drift is caught.
                 if "Matlab 5" in err_str or "Matrix too large" in err_str:
                     message(
                         "warning",

--- a/src/autoclean/plugins/eeg_plugins/xdat_h32_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/xdat_h32_plugin.py
@@ -169,6 +169,9 @@ class XDATMouseH32Plugin(BaseEEGPlugin):
         # Create MNE Raw object
         info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types_list)
         raw = mne.io.RawArray(data, info)
+        # MNE has no public setter for RawArray source filenames. Downstream
+        # export/provenance code reads this private attribute, so keep this
+        # assignment narrow and revisit it if MNE changes Raw._filenames.
         raw._filenames = [file_path]
 
         return raw

--- a/tests/unit/io/test_export_fallbacks.py
+++ b/tests/unit/io/test_export_fallbacks.py
@@ -3,6 +3,9 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pytest
+
 from autoclean.io.export import save_epochs_to_set, save_raw_to_set
 
 
@@ -15,9 +18,16 @@ def _autoclean_dict(tmp_path: Path) -> dict:
     }
 
 
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Matlab 5 file format cannot store matrix",
+        "Matrix too large for Matlab 5",
+    ],
+)
 @patch("autoclean.io.export.manage_database_conditionally")
 def test_save_raw_to_set_falls_back_to_fif_for_eeglab_size_error(
-    mock_manage_database, tmp_path: Path
+    mock_manage_database, tmp_path: Path, error_message: str
 ) -> None:
     """Raw export should save FIF when EEGLAB rejects MATLAB v5 matrix size."""
     raw = MagicMock()
@@ -25,14 +35,14 @@ def test_save_raw_to_set_falls_back_to_fif_for_eeglab_size_error(
     raw.ch_names = ["Cz", "Pz"]
     raw.info = {"sfreq": 100.0}
     raw.times = [0.0, 0.99]
-    raw.export.side_effect = RuntimeError("Matlab 5 file format cannot store matrix")
+    raw.export.side_effect = RuntimeError(error_message)
 
     result = save_raw_to_set(raw, _autoclean_dict(tmp_path), stage="post_import")
 
     assert result.suffix == ".fif"
     raw.save.assert_called_once_with(result, overwrite=True, fmt="single")
     raw.export.assert_called_once()
-    assert mock_manage_database.call_count == 2
+    assert mock_manage_database.call_count == 2  # metadata + status updates
 
 
 @patch("autoclean.io.export.manage_database_conditionally")
@@ -56,7 +66,7 @@ def test_save_epochs_to_set_falls_back_to_chunked_for_eeglab_size_error(
     epochs.times = [0.0, 0.1, 0.2]
     epochs.info = {"sfreq": 100.0}
     epochs.metadata = None
-    epochs.events = []
+    epochs.events = np.array([[1, 0, 1], [5, 0, 2]], dtype=int)
     epochs.export.side_effect = RuntimeError("Matrix too large for Matlab 5")
 
     result = save_epochs_to_set(
@@ -67,4 +77,4 @@ def test_save_epochs_to_set_falls_back_to_chunked_for_eeglab_size_error(
     mock_chunked.assert_called_once()
     mock_loadmat.assert_called_once_with(chunk_path)
     mock_savemat.assert_called_once()
-    assert mock_manage_database.call_count == 2
+    assert mock_manage_database.call_count == 2  # metadata + status updates

--- a/tests/unit/io/test_export_fallbacks.py
+++ b/tests/unit/io/test_export_fallbacks.py
@@ -1,0 +1,70 @@
+"""Tests for export fallbacks used by large EEGLAB outputs."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from autoclean.io.export import save_epochs_to_set, save_raw_to_set
+
+
+def _autoclean_dict(tmp_path: Path) -> dict:
+    return {
+        "run_id": "run-001",
+        "unprocessed_file": str(tmp_path / "sample.set"),
+        "stage_dir": tmp_path / "stage",
+        "move_flagged_files": True,
+    }
+
+
+@patch("autoclean.io.export.manage_database_conditionally")
+def test_save_raw_to_set_falls_back_to_fif_for_eeglab_size_error(
+    mock_manage_database, tmp_path: Path
+) -> None:
+    """Raw export should save FIF when EEGLAB rejects MATLAB v5 matrix size."""
+    raw = MagicMock()
+    raw.n_times = 100
+    raw.ch_names = ["Cz", "Pz"]
+    raw.info = {"sfreq": 100.0}
+    raw.times = [0.0, 0.99]
+    raw.export.side_effect = RuntimeError("Matlab 5 file format cannot store matrix")
+
+    result = save_raw_to_set(raw, _autoclean_dict(tmp_path), stage="post_import")
+
+    assert result.suffix == ".fif"
+    raw.save.assert_called_once_with(result, overwrite=True, fmt="single")
+    raw.export.assert_called_once()
+    assert mock_manage_database.call_count == 2
+
+
+@patch("autoclean.io.export.manage_database_conditionally")
+@patch("autoclean.io.export.sio.savemat")
+@patch("autoclean.io.export.sio.loadmat", return_value={})
+@patch("autoclean.io.export.save_epochs_to_set_chunked")
+def test_save_epochs_to_set_falls_back_to_chunked_for_eeglab_size_error(
+    mock_chunked,
+    mock_loadmat,
+    mock_savemat,
+    mock_manage_database,
+    tmp_path: Path,
+) -> None:
+    """Epoch export should chunk when EEGLAB rejects MATLAB v5 matrix size."""
+    chunk_path = tmp_path / "stage" / "01_clean_epochs" / "sample_clean_epochs_epo.set"
+    mock_chunked.return_value = [chunk_path]
+
+    epochs = MagicMock()
+    epochs.__len__.return_value = 2
+    epochs.ch_names = ["Cz", "Pz"]
+    epochs.times = [0.0, 0.1, 0.2]
+    epochs.info = {"sfreq": 100.0}
+    epochs.metadata = None
+    epochs.events = []
+    epochs.export.side_effect = RuntimeError("Matrix too large for Matlab 5")
+
+    result = save_epochs_to_set(
+        epochs, _autoclean_dict(tmp_path), stage="post_clean_epochs"
+    )
+
+    assert result.suffix == ".set"
+    mock_chunked.assert_called_once()
+    mock_loadmat.assert_called_once_with(chunk_path)
+    mock_savemat.assert_called_once()
+    assert mock_manage_database.call_count == 2

--- a/tests/unit/utils/test_ingestion.py
+++ b/tests/unit/utils/test_ingestion.py
@@ -278,6 +278,45 @@ def test_parse_serve_config_defaults(tmp_path: Path) -> None:
     assert route.id == "Resting-standard_1020-v1"
 
 
+def test_parse_serve_config_route_can_disable_sentinel_requirement(
+    tmp_path: Path,
+) -> None:
+    runtime_dir = tmp_path / "runtimes" / "test"
+    runtime_dir.mkdir(parents=True)
+    automation_root = tmp_path / "automations"
+    automation_root.mkdir()
+    ingestion_root = tmp_path / "ingest"
+    ingestion_root.mkdir()
+    config_path = tmp_path / "serve-test.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "mode: test",
+                "runtime: runtimes/test",
+                "automation_mode: true",
+                "defaults:",
+                "  automation_root: automations",
+                "  workspace_name: taskfile-montage-version",
+                "  file_globs: ['*.set']",
+                "  sentinel_ext: .ready",
+                "automations:",
+                "  - taskfile: Resting",
+                "    montage: standard_1020",
+                "    sentinel_ext:",
+                "    ingestion_folders:",
+                "      - ingest",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_serve_config(config_path)
+    serve_config, warnings = parse_serve_config(config, tmp_path, strict=False)
+
+    assert not warnings
+    assert serve_config.routes[0].sentinel_ext is None
+
+
 def test_parse_serve_config_strict_requires_ingestion_folders_exist(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds debt notes for the temporary changed-file CI gates and advisory mypy baseline.
- Documents the private MNE `Raw._filenames` assignment used by the XDAT RawArray importer.
- Documents the EEGLAB/MATLAB v5 size-error string fallback and adds focused tests for raw FIF fallback and epoch chunked fallback.
- Restores explicit ingestion coverage for routes that intentionally disable sentinel-file readiness.

## Verification
- `uv run --extra dev black src\autoclean\io\export.py src\autoclean\plugins\eeg_plugins\xdat_h32_plugin.py tests\unit\io\test_export_fallbacks.py tests\unit\utils\test_ingestion.py`
- `uv run --extra dev isort src\autoclean\io\export.py src\autoclean\plugins\eeg_plugins\xdat_h32_plugin.py tests\unit\io\test_export_fallbacks.py tests\unit\utils\test_ingestion.py`
- `uv run --extra dev ruff check src\autoclean\io\export.py src\autoclean\plugins\eeg_plugins\xdat_h32_plugin.py tests\unit\io\test_export_fallbacks.py tests\unit\utils\test_ingestion.py`
- `uv run --extra dev pytest tests\unit\io\test_export_fallbacks.py tests\unit\utils\test_ingestion.py -q --no-cov` -> 39 passed

Follow-up to #205. Does not close an issue.