### PR TITLE
feat(erp): add pre-epoched ERP task

### DIFF
--- a/src/autoclean/plugins/eeg_plugins/eeglab_gsn124_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_gsn124_plugin.py
@@ -46,12 +46,16 @@ class EEGLABSetGSN124Plugin(BaseEEGPlugin):
                 raw = mne.io.read_raw_eeglab(
                     input_fname=file_path, preload=preload, verbose=True
                 )
-            except ValueError as e:
+            except Exception as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
                     raise e
             message("success", "Successfully loaded .set file")
+
+            if isinstance(raw, mne.BaseEpochs):
+                message("info", "Epochs file detected - preserving imported epochs")
+                return raw
 
             # Step 1.5: Check for reference channel and rename if necessary
             ref_channel_names = ["VREF", "REF", "E129"]
@@ -73,26 +77,22 @@ class EEGLABSetGSN124Plugin(BaseEEGPlugin):
                     break
 
             # Step 2: Configure the GSN-HydroCel-124 montage
-            # Skip channel configuration for epochs - they already have proper setup
-            if isinstance(raw, mne.Epochs):
-                message("info", "Epochs file detected - skipping channel configuration")
-            else:
-                message("info", "Configuring GSN-HydroCel-124 channels")
+            message("info", "Configuring GSN-HydroCel-124 channels")
 
-                # Handle ECG channels (125-128)
-                ecg_channels = ["E125", "E126", "E127", "E128"]
+            # Handle ECG channels (125-128)
+            ecg_channels = ["E125", "E126", "E127", "E128"]
 
-                # Set channel types for ECG channels
-                ecg_mapping = {ch: "ecg" for ch in ecg_channels if ch in raw.ch_names}
-                if ecg_mapping:
-                    raw.set_channel_types(ecg_mapping)
-                    # Drop ECG channels
-                    raw.drop_channels(list(ecg_mapping.keys()))
+            # Set channel types for ECG channels
+            ecg_mapping = {ch: "ecg" for ch in ecg_channels if ch in raw.ch_names}
+            if ecg_mapping:
+                raw.set_channel_types(ecg_mapping)
+                # Drop ECG channels
+                raw.drop_channels(list(ecg_mapping.keys()))
 
-                # Pick only EEG channels
-                raw.pick("eeg")
+            # Pick only EEG channels
+            raw.pick("eeg")
 
-                message("success", "Successfully configured GSN-HydroCel-124 channels")
+            message("success", "Successfully configured GSN-HydroCel-124 channels")
             # Step 3: Extract and process events
             events_df = self._get_matlab_annotations_table(file_path)
 

--- a/src/autoclean/plugins/eeg_plugins/eeglab_gsn124_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_gsn124_plugin.py
@@ -46,7 +46,7 @@ class EEGLABSetGSN124Plugin(BaseEEGPlugin):
                 raw = mne.io.read_raw_eeglab(
                     input_fname=file_path, preload=preload, verbose=True
                 )
-            except Exception as e:
+            except (TypeError, ValueError) as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
@@ -54,6 +54,7 @@ class EEGLABSetGSN124Plugin(BaseEEGPlugin):
             message("success", "Successfully loaded .set file")
 
             if isinstance(raw, mne.BaseEpochs):
+                # Epochs already carry events/event_id; raw annotation extraction is skipped intentionally.
                 message("info", "Epochs file detected - preserving imported epochs")
                 return raw
 

--- a/src/autoclean/plugins/eeg_plugins/eeglab_gsn124_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_gsn124_plugin.py
@@ -50,7 +50,7 @@ class EEGLABSetGSN124Plugin(BaseEEGPlugin):
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
-                    raise e
+                    raise
             message("success", "Successfully loaded .set file")
 
             if isinstance(raw, mne.BaseEpochs):

--- a/src/autoclean/plugins/eeg_plugins/eeglab_gsn129_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_gsn129_plugin.py
@@ -50,7 +50,7 @@ class EEGLABSetGSN129Plugin(BaseEEGPlugin):
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
-                    raise e
+                    raise
             message("success", "Successfully loaded .set file")
 
             if isinstance(raw, mne.BaseEpochs):

--- a/src/autoclean/plugins/eeg_plugins/eeglab_gsn129_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_gsn129_plugin.py
@@ -46,7 +46,7 @@ class EEGLABSetGSN129Plugin(BaseEEGPlugin):
                 raw = mne.io.read_raw_eeglab(
                     input_fname=file_path, preload=preload, verbose=True
                 )
-            except Exception as e:
+            except (TypeError, ValueError) as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
@@ -54,6 +54,7 @@ class EEGLABSetGSN129Plugin(BaseEEGPlugin):
             message("success", "Successfully loaded .set file")
 
             if isinstance(raw, mne.BaseEpochs):
+                # Epochs already carry events/event_id; raw annotation extraction is skipped intentionally.
                 message("info", "Epochs file detected - preserving imported epochs")
                 return raw
 

--- a/src/autoclean/plugins/eeg_plugins/eeglab_gsn129_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_gsn129_plugin.py
@@ -46,12 +46,16 @@ class EEGLABSetGSN129Plugin(BaseEEGPlugin):
                 raw = mne.io.read_raw_eeglab(
                     input_fname=file_path, preload=preload, verbose=True
                 )
-            except TypeError as e:
+            except Exception as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
                     raise e
             message("success", "Successfully loaded .set file")
+
+            if isinstance(raw, mne.BaseEpochs):
+                message("info", "Epochs file detected - preserving imported epochs")
+                return raw
 
             # Step 1.5: Check for reference channel and rename if necessary
             ref_channel_names = ["VREF", "REF", "E129"]
@@ -73,22 +77,18 @@ class EEGLABSetGSN129Plugin(BaseEEGPlugin):
                     break
 
             # Step 2: Configure the GSN-HydroCel-129 montage
-            # Skip montage configuration for epochs - they already have channel positions
-            if isinstance(raw, mne.Epochs):
-                message("info", "Epochs file detected - skipping montage configuration")
-            else:
-                message("info", "Configuring GSN-HydroCel-129 montage")
+            message("info", "Configuring GSN-HydroCel-129 montage")
 
-                # Create montage and set the special 129th electrode name
-                montage = mne.channels.make_standard_montage("GSN-HydroCel-129")
+            # Create montage and set the special 129th electrode name
+            montage = mne.channels.make_standard_montage("GSN-HydroCel-129")
 
-                # Apply the montage
-                raw.set_montage(montage, match_case=False)
+            # Apply the montage
+            raw.set_montage(montage, match_case=False)
 
-                # Pick only EEG channels
-                raw.pick("eeg")
+            # Pick only EEG channels
+            raw.pick("eeg")
 
-                message("success", "Successfully configured GSN-HydroCel-129 montage")
+            message("success", "Successfully configured GSN-HydroCel-129 montage")
             # Step 3: Extract and process events
             events_df = self._get_matlab_annotations_table(file_path)
 

--- a/src/autoclean/plugins/eeg_plugins/eeglab_mea30_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_mea30_plugin.py
@@ -43,7 +43,7 @@ class EEGLABSetMEA30Plugin(BaseEEGPlugin):
                 raw = mne.io.read_raw_eeglab(
                     input_fname=file_path, preload=preload, verbose=True
                 )
-            except ValueError as e:
+            except Exception as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
@@ -52,8 +52,9 @@ class EEGLABSetMEA30Plugin(BaseEEGPlugin):
 
             # Step 2: Configure the MEA30 montage
             # Skip channel configuration for epochs - they already have proper setup
-            if isinstance(raw, mne.Epochs):
+            if isinstance(raw, mne.BaseEpochs):
                 message("info", "Epochs file detected - skipping channel configuration")
+                return raw
             else:
                 message("info", "Configuring MEA30 channels")
 

--- a/src/autoclean/plugins/eeg_plugins/eeglab_mea30_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_mea30_plugin.py
@@ -43,7 +43,7 @@ class EEGLABSetMEA30Plugin(BaseEEGPlugin):
                 raw = mne.io.read_raw_eeglab(
                     input_fname=file_path, preload=preload, verbose=True
                 )
-            except Exception as e:
+            except (TypeError, ValueError) as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
@@ -53,6 +53,7 @@ class EEGLABSetMEA30Plugin(BaseEEGPlugin):
             # Step 2: Configure the MEA30 montage
             # Skip channel configuration for epochs - they already have proper setup
             if isinstance(raw, mne.BaseEpochs):
+                # Epochs already carry events/event_id; raw annotation extraction is skipped intentionally.
                 message("info", "Epochs file detected - skipping channel configuration")
                 return raw
             else:

--- a/src/autoclean/plugins/eeg_plugins/eeglab_mea30_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_mea30_plugin.py
@@ -47,7 +47,7 @@ class EEGLABSetMEA30Plugin(BaseEEGPlugin):
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
-                    raise e
+                    raise
             message("success", "Successfully loaded .set file")
 
             # Step 2: Configure the MEA30 montage

--- a/src/autoclean/plugins/eeg_plugins/eeglab_standard1020_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_standard1020_plugin.py
@@ -51,12 +51,12 @@ class EEGLABSetStandard1020Plugin(BaseEEGPlugin):
                 ) and "must be 1 for raw files" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
-                    raise e
+                    raise
             except Exception as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
-                    raise e
+                    raise
             message("success", "Successfully loaded .set file")
             # Step 2: Configure the standard 10-20 montage
             # Skip montage configuration for epochs - they already have channel positions

--- a/src/autoclean/plugins/eeg_plugins/eeglab_standard1020_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_standard1020_plugin.py
@@ -52,7 +52,7 @@ class EEGLABSetStandard1020Plugin(BaseEEGPlugin):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
                     raise e
-            except ValueError as e:
+            except Exception as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
@@ -60,8 +60,9 @@ class EEGLABSetStandard1020Plugin(BaseEEGPlugin):
             message("success", "Successfully loaded .set file")
             # Step 2: Configure the standard 10-20 montage
             # Skip montage configuration for epochs - they already have channel positions
-            if isinstance(raw, mne.Epochs):
+            if isinstance(raw, mne.BaseEpochs):
                 message("info", "Epochs file detected - skipping montage configuration")
+                return raw
             else:
                 message("info", "Setting up standard 10-20 montage")
                 # Apply the standard 10-20 montage

--- a/src/autoclean/plugins/eeg_plugins/eeglab_standard1020_plugin.py
+++ b/src/autoclean/plugins/eeg_plugins/eeglab_standard1020_plugin.py
@@ -52,7 +52,7 @@ class EEGLABSetStandard1020Plugin(BaseEEGPlugin):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
                     raise
-            except Exception as e:
+            except ValueError as e:
                 if "trials" in str(e) and "read_epochs_eeglab" in str(e):
                     raw = mne.io.read_epochs_eeglab(input_fname=file_path, verbose=True)
                 else:
@@ -61,6 +61,7 @@ class EEGLABSetStandard1020Plugin(BaseEEGPlugin):
             # Step 2: Configure the standard 10-20 montage
             # Skip montage configuration for epochs - they already have channel positions
             if isinstance(raw, mne.BaseEpochs):
+                # Epochs already carry events/event_id; raw annotation extraction is skipped intentionally.
                 message("info", "Epochs file detected - skipping montage configuration")
                 return raw
             else:

--- a/src/autoclean/tasks/PreEpochedERP.py
+++ b/src/autoclean/tasks/PreEpochedERP.py
@@ -1,0 +1,119 @@
+"""Pre-epoched ERP built-in task.
+
+Use this task when the input file already contains epochs, event IDs, and labels
+from a completed ERP paradigm such as P300, MMN, or ASSR. The task intentionally
+does not run raw-data preprocessing steps by default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autoclean.core.task import Task
+from autoclean.utils.erp import generate_erp_outputs, validate_erp_input
+
+config = {
+    "schema_version": "2025.09",
+    "montage": {"enabled": True, "value": "auto"},
+    "move_flagged_files": False,
+    "resample_step": {"enabled": False, "value": None},
+    "filtering": {
+        "enabled": False,
+        "value": {
+            "l_freq": None,
+            "h_freq": None,
+            "notch_freqs": None,
+            "notch_widths": None,
+        },
+    },
+    "drop_outerlayer": {"enabled": False, "value": []},
+    "eog_step": {"enabled": False, "value": None},
+    "trim_step": {"enabled": False, "value": 0},
+    "crop_step": {"enabled": False, "value": {"start": 0, "end": None}},
+    "reference_step": {"enabled": False, "value": None},
+    "ICA": {
+        "enabled": False,
+        "value": {
+            "method": "fastica",
+            "n_components": None,
+            "fit_params": None,
+            "temp_highpass_for_ica": None,
+        },
+    },
+    "component_rejection": {
+        "enabled": False,
+        "method": "iclabel",
+        "value": {
+            "ic_flags_to_reject": ["muscle", "heart", "eog", "ch_noise", "line_noise"],
+            "ic_rejection_threshold": 0.3,
+        },
+    },
+    "epoch_settings": {
+        "enabled": False,
+        "value": {"tmin": None, "tmax": None},
+        "event_id": None,
+        "remove_baseline": {"enabled": False, "window": [None, 0]},
+        "threshold_rejection": {"enabled": False, "volt_threshold": {"eeg": 0.000125}},
+    },
+    "apply_erp_outputs": {
+        "enabled": True,
+        "value": {
+            "required_conditions": [],
+            "conditions": [],
+            "analysis_window": [-0.2, 0.8],
+            "difference_waves": [],
+            "save_evokeds": True,
+            "save_amplitudes": True,
+            "examples": {
+                "P300": {"conditions": ["target", "standard"]},
+                "MMN": {"conditions": ["deviant", "standard"]},
+                "ASSR": {"conditions": ["stimulus"]},
+            },
+        },
+    },
+    "ai_reporting": False,
+}
+
+
+class PreEpochedERP(Task):
+    """Task template for already-epoched ERP datasets."""
+
+    def run(self) -> None:
+        self.import_epochs()
+
+        erp_enabled, erp_settings = self._check_step_enabled("apply_erp_outputs")
+        erp_config = (erp_settings or {}).get("value", {})
+
+        validation = validate_erp_input(
+            self.epochs,
+            required_conditions=erp_config.get("required_conditions"),
+            analysis_window=erp_config.get("analysis_window"),
+        )
+        self._update_metadata("step_validate_pre_epoched_erp", validation)
+
+        if not erp_enabled:
+            return
+
+        output_dir = self._erp_output_dir()
+        conditions = erp_config.get("conditions") or None
+        outputs = generate_erp_outputs(
+            self.epochs,
+            output_dir,
+            conditions=conditions,
+            difference_waves=erp_config.get("difference_waves"),
+            analysis_window=erp_config.get("analysis_window"),
+            save_evokeds=erp_config.get("save_evokeds", True),
+            save_amplitudes=erp_config.get("save_amplitudes", True),
+        )
+        self._update_metadata("step_generate_erp_outputs", outputs)
+
+    def _erp_output_dir(self) -> Path:
+        reports_dir = self.config.get("reports_dir")
+        if reports_dir:
+            return Path(reports_dir) / "erp"
+
+        metadata_dir = self.config.get("metadata_dir")
+        if metadata_dir:
+            return Path(metadata_dir) / "erp"
+
+        return Path(self.config["stage_dir"]) / "erp"

--- a/src/autoclean/utils/erp.py
+++ b/src/autoclean/utils/erp.py
@@ -1,0 +1,205 @@
+"""Helpers for pre-epoched ERP task templates."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import mne
+
+from autoclean.utils.logging import message
+
+
+def validate_erp_input(
+    epochs: mne.BaseEpochs,
+    *,
+    required_conditions: list[str] | None = None,
+    analysis_window: tuple[float, float] | list[float] | None = None,
+) -> dict[str, Any]:
+    """Validate condition labels and analysis-window coverage for ERP epochs."""
+
+    event_id = dict(getattr(epochs, "event_id", {}) or {})
+    required_conditions = list(required_conditions or [])
+    missing = [name for name in required_conditions if name not in event_id]
+    if missing:
+        available = ", ".join(sorted(event_id)) or "none"
+        raise ValueError(
+            "Pre-epoched ERP input is missing required condition(s): "
+            f"{', '.join(missing)}. Available conditions: {available}"
+        )
+
+    warnings: list[str] = []
+    if analysis_window is not None:
+        start, end = float(analysis_window[0]), float(analysis_window[1])
+        if start < float(epochs.tmin) or end > float(epochs.tmax):
+            warning = (
+                "ERP analysis window "
+                f"[{start:g}, {end:g}]s is outside epoch coverage "
+                f"[{float(epochs.tmin):g}, {float(epochs.tmax):g}]s."
+            )
+            warnings.append(warning)
+            message("warning", warning)
+
+    counts = _condition_counts(epochs)
+    return {
+        "n_epochs": int(len(epochs)),
+        "event_id": event_id,
+        "condition_counts": counts,
+        "analysis_window": (
+            list(analysis_window) if analysis_window is not None else None
+        ),
+        "warnings": warnings,
+    }
+
+
+def generate_erp_outputs(
+    epochs: mne.BaseEpochs,
+    output_dir: str | Path,
+    *,
+    conditions: list[str] | None = None,
+    difference_waves: list[dict[str, str]] | None = None,
+    analysis_window: tuple[float, float] | list[float] | None = None,
+    save_evokeds: bool = True,
+    save_amplitudes: bool = True,
+) -> dict[str, Any]:
+    """Write compact ERP summaries for pre-epoched data."""
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    event_id = dict(getattr(epochs, "event_id", {}) or {})
+    selected_conditions = list(conditions or sorted(event_id))
+    missing = [
+        condition for condition in selected_conditions if condition not in event_id
+    ]
+    if missing:
+        available = ", ".join(sorted(event_id)) or "none"
+        raise ValueError(
+            f"Cannot generate ERP outputs for missing condition(s): {', '.join(missing)}. "
+            f"Available conditions: {available}"
+        )
+
+    counts = _condition_counts(epochs)
+    counts_path = output_path / "erp_condition_counts.csv"
+    with counts_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle, fieldnames=["condition", "event_code", "n_epochs"]
+        )
+        writer.writeheader()
+        for condition in selected_conditions:
+            writer.writerow(
+                {
+                    "condition": condition,
+                    "event_code": event_id[condition],
+                    "n_epochs": counts.get(condition, 0),
+                }
+            )
+
+    evoked_paths: dict[str, str] = {}
+    evokeds: dict[str, mne.Evoked] = {}
+    for condition in selected_conditions:
+        evoked = epochs[condition].average()
+        evokeds[condition] = evoked
+        if save_evokeds:
+            evoked_path = output_path / f"erp_average_{_safe_name(condition)}-ave.fif"
+            mne.write_evokeds(evoked_path, evoked, overwrite=True, verbose=False)
+            evoked_paths[condition] = str(evoked_path)
+
+    difference_paths: dict[str, str] = {}
+    for spec in difference_waves or []:
+        name = (
+            spec.get("name")
+            or f"{spec.get('positive', '')}_minus_{spec.get('negative', '')}"
+        )
+        positive = spec.get("positive")
+        negative = spec.get("negative")
+        if positive not in evokeds or negative not in evokeds:
+            raise ValueError(
+                "Difference wave requires generated conditions "
+                f"positive={positive!r}, negative={negative!r}"
+            )
+        diff = mne.combine_evoked([evokeds[positive], evokeds[negative]], [1, -1])
+        diff.comment = name
+        diff_path = output_path / f"erp_difference_{_safe_name(name)}-ave.fif"
+        mne.write_evokeds(diff_path, diff, overwrite=True, verbose=False)
+        difference_paths[name] = str(diff_path)
+
+    amplitude_path = None
+    if save_amplitudes:
+        amplitude_path = output_path / "erp_amplitude_summary.csv"
+        _write_amplitude_summary(
+            amplitude_path,
+            {**evokeds, **_load_difference_evokeds(difference_paths)},
+            analysis_window=analysis_window,
+        )
+
+    return {
+        "counts_file": str(counts_path),
+        "evoked_files": evoked_paths,
+        "difference_files": difference_paths,
+        "amplitude_summary_file": str(amplitude_path) if amplitude_path else None,
+    }
+
+
+def _condition_counts(epochs: mne.BaseEpochs) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for condition in sorted((getattr(epochs, "event_id", {}) or {}).keys()):
+        try:
+            counts[condition] = int(len(epochs[condition]))
+        except Exception:
+            counts[condition] = 0
+    return counts
+
+
+def _safe_name(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in value)
+    return safe.strip("_") or "condition"
+
+
+def _load_difference_evokeds(paths: dict[str, str]) -> dict[str, mne.Evoked]:
+    evokeds: dict[str, mne.Evoked] = {}
+    for name, path in paths.items():
+        evokeds[name] = mne.read_evokeds(path, condition=0, verbose=False)
+    return evokeds
+
+
+def _write_amplitude_summary(
+    path: Path,
+    evokeds: dict[str, mne.Evoked],
+    *,
+    analysis_window: tuple[float, float] | list[float] | None,
+) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "condition",
+                "window_start",
+                "window_end",
+                "mean_amplitude",
+                "peak_amplitude",
+                "peak_latency",
+            ],
+        )
+        writer.writeheader()
+        for condition, evoked in evokeds.items():
+            cropped = evoked.copy()
+            if analysis_window is not None:
+                start = max(float(analysis_window[0]), float(cropped.times[0]))
+                end = min(float(analysis_window[1]), float(cropped.times[-1]))
+                if start <= end:
+                    cropped.crop(start, end)
+            data = cropped.data
+            channel_mean = data.mean(axis=0)
+            peak_idx = int(abs(channel_mean).argmax())
+            writer.writerow(
+                {
+                    "condition": condition,
+                    "window_start": float(cropped.times[0]),
+                    "window_end": float(cropped.times[-1]),
+                    "mean_amplitude": float(data.mean()),
+                    "peak_amplitude": float(channel_mean[peak_idx]),
+                    "peak_latency": float(cropped.times[peak_idx]),
+                }
+            )

--- a/src/autoclean/utils/erp.py
+++ b/src/autoclean/utils/erp.py
@@ -30,8 +30,9 @@ def validate_erp_input(
         )
 
     warnings: list[str] = []
-    if analysis_window is not None:
-        start, end = float(analysis_window[0]), float(analysis_window[1])
+    analysis_bounds = _analysis_window_bounds(analysis_window)
+    if analysis_bounds is not None:
+        start, end = analysis_bounds
         if start < float(epochs.tmin) or end > float(epochs.tmax):
             warning = (
                 "ERP analysis window "
@@ -47,7 +48,7 @@ def validate_erp_input(
         "event_id": event_id,
         "condition_counts": counts,
         "analysis_window": (
-            list(analysis_window) if analysis_window is not None else None
+            list(analysis_bounds) if analysis_bounds is not None else None
         ),
         "warnings": warnings,
     }
@@ -80,6 +81,7 @@ def generate_erp_outputs(
             f"Available conditions: {available}"
         )
 
+    analysis_bounds = _analysis_window_bounds(analysis_window)
     counts = _condition_counts(epochs)
     counts_path = output_path / "erp_condition_counts.csv"
     with counts_path.open("w", newline="", encoding="utf-8") as handle:
@@ -107,6 +109,7 @@ def generate_erp_outputs(
             evoked_paths[condition] = str(evoked_path)
 
     difference_paths: dict[str, str] = {}
+    difference_evokeds: dict[str, mne.Evoked] = {}
     for spec in difference_waves or []:
         name = (
             spec.get("name")
@@ -124,14 +127,15 @@ def generate_erp_outputs(
         diff_path = output_path / f"erp_difference_{_safe_name(name)}-ave.fif"
         mne.write_evokeds(diff_path, diff, overwrite=True, verbose=False)
         difference_paths[name] = str(diff_path)
+        difference_evokeds[name] = diff
 
     amplitude_path = None
     if save_amplitudes:
         amplitude_path = output_path / "erp_amplitude_summary.csv"
         _write_amplitude_summary(
             amplitude_path,
-            {**evokeds, **_load_difference_evokeds(difference_paths)},
-            analysis_window=analysis_window,
+            {**evokeds, **difference_evokeds},
+            analysis_window=analysis_bounds,
         )
 
     return {
@@ -147,7 +151,10 @@ def _condition_counts(epochs: mne.BaseEpochs) -> dict[str, int]:
     for condition in sorted((getattr(epochs, "event_id", {}) or {}).keys()):
         try:
             counts[condition] = int(len(epochs[condition]))
-        except Exception:
+        except Exception as exc:
+            message(
+                "warning", f"Could not count epochs for condition {condition!r}: {exc}"
+            )
             counts[condition] = 0
     return counts
 
@@ -157,11 +164,14 @@ def _safe_name(value: str) -> str:
     return safe.strip("_") or "condition"
 
 
-def _load_difference_evokeds(paths: dict[str, str]) -> dict[str, mne.Evoked]:
-    evokeds: dict[str, mne.Evoked] = {}
-    for name, path in paths.items():
-        evokeds[name] = mne.read_evokeds(path, condition=0, verbose=False)
-    return evokeds
+def _analysis_window_bounds(
+    analysis_window: tuple[float, float] | list[float] | None,
+) -> tuple[float, float] | None:
+    if analysis_window is None:
+        return None
+    if len(analysis_window) < 2:
+        raise ValueError("ERP analysis_window must contain start and end times.")
+    return float(analysis_window[0]), float(analysis_window[1])
 
 
 def _write_amplitude_summary(

--- a/tests/unit/plugins/test_eeg_plugins.py
+++ b/tests/unit/plugins/test_eeg_plugins.py
@@ -457,7 +457,7 @@ def test_eeglab_plugins_fallback_to_epochs_reader_for_epoched_set(
         patch("mne.io.read_raw_eeglab") as read_raw,
         patch("mne.io.read_epochs_eeglab", return_value=epochs) as read_epochs,
     ):
-        read_raw.side_effect = RuntimeError(
+        read_raw.side_effect = ValueError(
             "The number of trials is 2. It must be 1 for raw files. "
             "Please use `mne.io.read_epochs_eeglab` if the .set file contains epochs."
         )

--- a/tests/unit/plugins/test_eeg_plugins.py
+++ b/tests/unit/plugins/test_eeg_plugins.py
@@ -1,7 +1,7 @@
 """Unit tests for EEG plugins."""
 
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import mne
 import pytest

--- a/tests/unit/plugins/test_eeg_plugins.py
+++ b/tests/unit/plugins/test_eeg_plugins.py
@@ -417,3 +417,52 @@ class TestPluginIntegration:
         EEGAssertions.assert_raw_properties(result)
 
 
+@pytest.mark.skipif(not PLUGIN_BASE_AVAILABLE, reason="Plugin base not available")
+@pytest.mark.parametrize(
+    "plugin_path,class_name",
+    [
+        (
+            "autoclean.plugins.eeg_plugins.eeglab_gsn124_plugin",
+            "EEGLABSetGSN124Plugin",
+        ),
+        (
+            "autoclean.plugins.eeg_plugins.eeglab_gsn129_plugin",
+            "EEGLABSetGSN129Plugin",
+        ),
+        (
+            "autoclean.plugins.eeg_plugins.eeglab_standard1020_plugin",
+            "EEGLABSetStandard1020Plugin",
+        ),
+        (
+            "autoclean.plugins.eeg_plugins.eeglab_mea30_plugin",
+            "EEGLABSetMEA30Plugin",
+        ),
+    ],
+)
+def test_eeglab_plugins_fallback_to_epochs_reader_for_epoched_set(
+    plugin_path, class_name
+):
+    module = __import__(plugin_path, fromlist=[class_name])
+    plugin_class = getattr(module, class_name)
+    epochs = mne.EpochsArray(
+        data=[[[0.0, 0.0]], [[1.0, 1.0]]],
+        info=mne.create_info(["Fz"], sfreq=100, ch_types="eeg"),
+        events=[[0, 0, 1], [100, 0, 2]],
+        event_id={"standard": 1, "target": 2},
+        tmin=0,
+        verbose=False,
+    )
+
+    with (
+        patch("mne.io.read_raw_eeglab") as read_raw,
+        patch("mne.io.read_epochs_eeglab", return_value=epochs) as read_epochs,
+    ):
+        read_raw.side_effect = RuntimeError(
+            "The number of trials is 2. It must be 1 for raw files. "
+            "Please use `mne.io.read_epochs_eeglab` if the .set file contains epochs."
+        )
+
+        result = plugin_class().import_and_configure(Path("sample.set"), {})
+
+    assert result is epochs
+    read_epochs.assert_called_once_with(input_fname=Path("sample.set"), verbose=True)

--- a/tests/unit/tasks/test_pre_epoched_erp.py
+++ b/tests/unit/tasks/test_pre_epoched_erp.py
@@ -7,7 +7,11 @@ import numpy as np
 import pytest
 
 from autoclean.configkit.schema import validate_task_module_config
-from autoclean.utils.erp import generate_erp_outputs, validate_erp_input
+from autoclean.utils.erp import (
+    _condition_counts,
+    generate_erp_outputs,
+    validate_erp_input,
+)
 
 
 def _epochs() -> mne.EpochsArray:
@@ -69,7 +73,38 @@ def test_validate_erp_input_warns_when_window_exceeds_epochs() -> None:
     assert "outside epoch coverage" in result["warnings"][0]
 
 
+def test_validate_erp_input_rejects_short_analysis_window() -> None:
+    with pytest.raises(ValueError, match="analysis_window must contain start and end"):
+        validate_erp_input(_epochs(), analysis_window=[0.1])
+
+
+def test_generate_erp_outputs_rejects_short_analysis_window(tmp_path) -> None:
+    with pytest.raises(ValueError, match="analysis_window must contain start and end"):
+        generate_erp_outputs(_epochs(), tmp_path, analysis_window=[0.1])
+
+
+def test_condition_counts_warns_when_condition_slice_fails(monkeypatch) -> None:
+    messages = []
+
+    class BrokenEpochs:
+        event_id = {"bad": 1}
+
+        def __getitem__(self, condition):
+            raise RuntimeError(f"cannot slice {condition}")
+
+    monkeypatch.setattr(
+        "autoclean.utils.erp.message",
+        lambda level, text: messages.append((level, text)),
+    )
+
+    assert _condition_counts(BrokenEpochs()) == {"bad": 0}
+    assert messages == [
+        ("warning", "Could not count epochs for condition 'bad': cannot slice bad")
+    ]
+
+
 def test_generate_erp_outputs_clamps_out_of_range_amplitude_window(tmp_path) -> None:
+
     result = generate_erp_outputs(
         _epochs(),
         tmp_path,
@@ -83,7 +118,13 @@ def test_generate_erp_outputs_clamps_out_of_range_amplitude_window(tmp_path) -> 
 
 def test_generate_erp_outputs_writes_counts_evokeds_difference_and_amplitudes(
     tmp_path,
+    monkeypatch,
 ) -> None:
+    def fail_if_difference_evokeds_are_reloaded(*args, **kwargs):
+        raise AssertionError("difference evokeds should stay in memory")
+
+    monkeypatch.setattr(mne, "read_evokeds", fail_if_difference_evokeds_are_reloaded)
+
     result = generate_erp_outputs(
         _epochs(),
         tmp_path,

--- a/tests/unit/tasks/test_pre_epoched_erp.py
+++ b/tests/unit/tasks/test_pre_epoched_erp.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import csv
+
+import mne
+import numpy as np
+import pytest
+
+from autoclean.configkit.schema import validate_task_module_config
+from autoclean.utils.erp import generate_erp_outputs, validate_erp_input
+
+
+def _epochs() -> mne.EpochsArray:
+    info = mne.create_info(["Fz", "Cz"], sfreq=100, ch_types="eeg")
+    data = np.zeros((4, 2, 101))
+    data[2:] = 1e-6
+    events = np.array(
+        [
+            [0, 0, 1],
+            [150, 0, 1],
+            [300, 0, 2],
+            [450, 0, 2],
+        ]
+    )
+    return mne.EpochsArray(
+        data,
+        info,
+        events=events,
+        event_id={"standard": 1, "target": 2},
+        tmin=-0.2,
+        verbose=False,
+    )
+
+
+def test_pre_epoched_erp_task_config_validates() -> None:
+    from autoclean import Pipeline
+
+    assert Pipeline.__name__ == "Pipeline"
+    from autoclean.tasks.PreEpochedERP import config
+
+    validated = validate_task_module_config(config)
+
+    assert validated["epoch_settings"]["enabled"] is False
+    assert validated["filtering"]["enabled"] is False
+    assert validated["ICA"]["enabled"] is False
+    assert validated["reference_step"]["enabled"] is False
+
+
+def test_validate_erp_input_preserves_event_labels_and_counts() -> None:
+    result = validate_erp_input(
+        _epochs(),
+        required_conditions=["standard", "target"],
+        analysis_window=[-0.1, 0.5],
+    )
+
+    assert result["event_id"] == {"standard": 1, "target": 2}
+    assert result["condition_counts"] == {"standard": 2, "target": 2}
+    assert result["warnings"] == []
+
+
+def test_validate_erp_input_rejects_missing_condition() -> None:
+    with pytest.raises(ValueError, match="missing required condition"):
+        validate_erp_input(_epochs(), required_conditions=["deviant"])
+
+
+def test_validate_erp_input_warns_when_window_exceeds_epochs() -> None:
+    result = validate_erp_input(_epochs(), analysis_window=[-0.3, 0.9])
+
+    assert "outside epoch coverage" in result["warnings"][0]
+
+
+def test_generate_erp_outputs_clamps_out_of_range_amplitude_window(tmp_path) -> None:
+    result = generate_erp_outputs(
+        _epochs(),
+        tmp_path,
+        conditions=["standard"],
+        analysis_window=[-0.5, 1.2],
+    )
+
+    assert result["amplitude_summary_file"] is not None
+    assert (tmp_path / "erp_amplitude_summary.csv").exists()
+
+
+def test_generate_erp_outputs_writes_counts_evokeds_difference_and_amplitudes(
+    tmp_path,
+) -> None:
+    result = generate_erp_outputs(
+        _epochs(),
+        tmp_path,
+        conditions=["standard", "target"],
+        difference_waves=[
+            {
+                "name": "target_minus_standard",
+                "positive": "target",
+                "negative": "standard",
+            }
+        ],
+        analysis_window=[-0.1, 0.5],
+    )
+
+    counts_file = tmp_path / "erp_condition_counts.csv"
+    with counts_file.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows == [
+        {"condition": "standard", "event_code": "1", "n_epochs": "2"},
+        {"condition": "target", "event_code": "2", "n_epochs": "2"},
+    ]
+    assert set(result["evoked_files"]) == {"standard", "target"}
+    assert "target_minus_standard" in result["difference_files"]
+    assert (tmp_path / "erp_amplitude_summary.csv").exists()


### PR DESCRIPTION
## Summary
- Adds the pre-epoched ERP task/template and ERP output helpers.
- Extends EEGLAB plugin imports for pre-epoched ERP compatibility.
- Adds focused unit coverage for ERP output generation and related plugin behavior.

## Verification
- `uv run --extra dev pytest tests\unit\tasks\test_pre_epoched_erp.py tests\unit\plugins\test_eeg_plugins.py -q --no-cov` -> 26 passed
- `git diff --check origin/main..HEAD` -> clean

Closes #196