### PR TITLE
fix(config): improve task validation messages

### DIFF
--- a/docs/command_reference.rst
+++ b/docs/command_reference.rst
@@ -396,6 +396,7 @@ Task Commands
 
 ``autocleaneeg-pipeline task schema export --output task-schema.json``
    Export the task schema used for validation and generation tools.
+   Set ``AUTOCLEAN_CONFIG_DEBUG=1`` to include raw schema errors when debugging task validation failures.
 
    Example:
 

--- a/src/autoclean/configkit/__init__.py
+++ b/src/autoclean/configkit/__init__.py
@@ -8,6 +8,7 @@ from .schema import (
     IC_FLAGS,
     ICA_METHODS,
     THRESHOLD_MODES,
+    format_task_config_error,
     validate_task_module_config,
 )
 
@@ -16,5 +17,6 @@ __all__ = [
     "COMP_REJ_METHODS",
     "ICA_METHODS",
     "IC_FLAGS",
+    "format_task_config_error",
     "validate_task_module_config",
 ]

--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -766,10 +766,10 @@ def _format_received(value: object) -> str:
 
 def _suggest_fix(path: list[str], raw_message: str) -> str:
     dotted = ".".join(path)
-    if path and path[0] == "montage":
-        return "Use a supported montage name, `auto`, or None when montage should be inferred."
     if path and path[-1] == "enabled":
         return "Set `enabled` to true or false."
+    if path and path[0] == "montage":
+        return "Use a supported montage name, `auto`, or None when montage should be inferred."
     if "value" in path and "enabled" in raw_message:
         return "Use the standard step shape: {'enabled': bool, 'value': ...}."
     if dotted.startswith("filtering.value"):

--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -9,7 +9,7 @@ import os
 import re
 from reprlib import repr as short_repr
 
-from schema import And, Optional, Or, Schema
+from schema import And, Optional, Or, Schema, SchemaError
 
 from autoclean.utils.montage import VALID_MONTAGES
 
@@ -652,7 +652,11 @@ def validate_task_module_config(task_config: dict) -> dict:
     """
     migrated = migrate_legacy_task_config(dict(task_config))
     schema = _build_task_settings_schema()
-    return schema.validate(migrated)
+    try:
+        return schema.validate(migrated)
+    except SchemaError as exc:
+        exc.task_config = migrated
+        raise
 
 
 def format_task_config_error(
@@ -770,8 +774,7 @@ def _suggest_fix(path: list[str], raw_message: str) -> str:
         return "Set `enabled` to true or false."
     if path and path[0] == "montage":
         return "Use a supported montage name, `auto`, or None when montage should be inferred."
-    if "value" in path and "enabled" in raw_message:
-        return "Use the standard step shape: {'enabled': bool, 'value': ...}."
+
     if dotted.startswith("filtering.value"):
         return "Use numeric filter frequencies or None; use lists/numbers for notch settings."
     if dotted.startswith("epoch_settings"):

--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -5,6 +5,10 @@ Exports enums and a validator for Python task module `config` dicts.
 
 from __future__ import annotations
 
+import os
+import re
+from reprlib import repr as short_repr
+
 from schema import And, Optional, Or, Schema
 
 from autoclean.utils.montage import VALID_MONTAGES
@@ -649,3 +653,127 @@ def validate_task_module_config(task_config: dict) -> dict:
     migrated = migrate_legacy_task_config(dict(task_config))
     schema = _build_task_settings_schema()
     return schema.validate(migrated)
+
+
+def format_task_config_error(
+    exc: Exception,
+    task_config: dict,
+    *,
+    task_name: str | None = None,
+    task_file: str | None = None,
+    debug: bool | None = None,
+) -> str:
+    """Render a schema validation exception as an actionable task error."""
+
+    raw_message = str(exc)
+    path = _schema_error_path(exc)
+    received = _lookup_path(task_config, path)
+    expected = _expected_for_path(path)
+    suggestion = _suggest_fix(path, raw_message)
+
+    lines = ["Task config validation failed"]
+    if task_name:
+        lines[0] += f" for {task_name}"
+    if task_file:
+        lines.append(f"Task file: {task_file}")
+    lines.extend(
+        [
+            f"Config path: {_format_config_path(path)}",
+            f"Received: {_format_received(received)}",
+            f"Expected: {expected}",
+            f"Suggested fix: {suggestion}",
+            "Template reference: run `autocleaneeg-pipeline task schema` "
+            "or compare against a built-in task in `src/autoclean/tasks/`.",
+        ]
+    )
+
+    show_debug = (
+        bool(debug)
+        if debug is not None
+        else os.getenv("AUTOCLEAN_CONFIG_DEBUG", "").lower()
+        in {"1", "true", "yes", "on"}
+    )
+    if show_debug:
+        lines.extend(["", "Raw schema error:", raw_message])
+
+    return "\n".join(lines)
+
+
+def _schema_error_path(exc: Exception) -> list[str]:
+    autos = [item for item in getattr(exc, "autos", []) or [] if item]
+    path: list[str] = []
+    for line in autos:
+        match = re.match(r"Key '([^']+)' error:", line)
+        if match:
+            path.append(match.group(1))
+            continue
+        match = re.match(r"Missing key: '([^']+)'", line)
+        if match:
+            path.append(match.group(1))
+            continue
+        match = re.match(r"Wrong key '([^']+)'", line)
+        if match:
+            path.append(match.group(1))
+            continue
+    return path
+
+
+def _lookup_path(config: dict, path: list[str]) -> object:
+    current: object = config
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return "<missing>"
+        current = current[key]
+    return current
+
+
+def _expected_for_path(path: list[str]) -> str:
+    node: object = export_task_schema_layout()["tasks"]
+    for index, key in enumerate(path):
+        if index == 0 and key == "schema_version":
+            return SCHEMA_VERSION
+        if isinstance(node, dict) and key in node:
+            node = node[key]
+        else:
+            return "see task schema"
+    if isinstance(node, dict):
+        return _summarize_shape(node)
+    return str(node)
+
+
+def _summarize_shape(node: dict) -> str:
+    keys = ", ".join(str(key) for key in node.keys())
+    return f"mapping with keys: {keys}"
+
+
+def _format_config_path(path: list[str]) -> str:
+    if not path:
+        return "config"
+    return "config" + "".join(f"[{key!r}]" for key in path)
+
+
+def _format_received(value: object) -> str:
+    if value == "<missing>":
+        return "<missing>"
+    return f"{short_repr(value)} ({type(value).__name__})"
+
+
+def _suggest_fix(path: list[str], raw_message: str) -> str:
+    dotted = ".".join(path)
+    if path and path[0] == "montage":
+        return "Use a supported montage name, `auto`, or None when montage should be inferred."
+    if path and path[-1] == "enabled":
+        return "Set `enabled` to true or false."
+    if "value" in path and "enabled" in raw_message:
+        return "Use the standard step shape: {'enabled': bool, 'value': ...}."
+    if dotted.startswith("filtering.value"):
+        return "Use numeric filter frequencies or None; use lists/numbers for notch settings."
+    if dotted.startswith("epoch_settings"):
+        return "Use numeric tmin/tmax, a dict or None for event_id, and valid baseline/rejection settings."
+    if dotted.startswith("apply_source_localization"):
+        return "Use source-localization fields such as method, lambda2, pick_ori, n_jobs, and convert_to_eeg."
+    if "Missing key" in raw_message:
+        return "Add the missing required key, or copy the section from a built-in task template."
+    if "Wrong key" in raw_message:
+        return "Remove the extra key or rename it to one of the supported task schema keys."
+    return "Compare this section with a built-in task template and use the expected shape above."

--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -663,7 +663,10 @@ def format_task_config_error(
     task_file: str | None = None,
     debug: bool | None = None,
 ) -> str:
-    """Render a schema validation exception as an actionable task error."""
+    """Render a schema validation exception as an actionable task error.
+
+    Set AUTOCLEAN_CONFIG_DEBUG=1 to include the raw schema exception text.
+    """
 
     raw_message = str(exc)
     path = _schema_error_path(exc)
@@ -718,11 +721,14 @@ def _schema_error_path(exc: Exception) -> list[str]:
     return path
 
 
+_MISSING = object()
+
+
 def _lookup_path(config: dict, path: list[str]) -> object:
     current: object = config
     for key in path:
         if not isinstance(current, dict) or key not in current:
-            return "<missing>"
+            return _MISSING
         current = current[key]
     return current
 
@@ -753,7 +759,7 @@ def _format_config_path(path: list[str]) -> str:
 
 
 def _format_received(value: object) -> str:
-    if value == "<missing>":
+    if value is _MISSING:
         return "<missing>"
     return f"{short_repr(value)} ({type(value).__name__})"
 

--- a/src/autoclean/core/task.py
+++ b/src/autoclean/core/task.py
@@ -45,7 +45,6 @@ except ImportError as e:
 
 from autoclean.configkit.schema import (
     format_task_config_error,
-    migrate_legacy_task_config,
     validate_task_module_config,
 )
 from autoclean.utils.auth import require_authentication
@@ -102,15 +101,14 @@ class Task(ABC, *DISCOVERED_MIXINS):
             module = inspect.getmodule(self.__class__)
             if module and hasattr(module, "config"):
                 self.settings = module.config
-                migrated_settings = migrate_legacy_task_config(dict(self.settings))
                 # Validate python task module config (raises on mismatch)
                 try:
-                    self.settings = validate_task_module_config(migrated_settings)
+                    self.settings = validate_task_module_config(self.settings)
                 except Exception as exc:
                     task_file = getattr(module, "__file__", None)
                     message_text = format_task_config_error(
                         exc,
-                        migrated_settings,
+                        getattr(exc, "task_config", self.settings),
                         task_name=self.__class__.__name__,
                         task_file=task_file,
                     )

--- a/src/autoclean/core/task.py
+++ b/src/autoclean/core/task.py
@@ -45,6 +45,7 @@ except ImportError as e:
 
 from autoclean.configkit.schema import (
     format_task_config_error,
+    migrate_legacy_task_config,
     validate_task_module_config,
 )
 from autoclean.utils.auth import require_authentication
@@ -101,6 +102,7 @@ class Task(ABC, *DISCOVERED_MIXINS):
             module = inspect.getmodule(self.__class__)
             if module and hasattr(module, "config"):
                 self.settings = module.config
+                migrated_settings = migrate_legacy_task_config(dict(self.settings))
                 # Validate python task module config (raises on mismatch)
                 try:
                     self.settings = validate_task_module_config(self.settings)
@@ -108,7 +110,7 @@ class Task(ABC, *DISCOVERED_MIXINS):
                     task_file = getattr(module, "__file__", None)
                     message_text = format_task_config_error(
                         exc,
-                        self.settings,
+                        migrated_settings,
                         task_name=self.__class__.__name__,
                         task_file=task_file,
                     )

--- a/src/autoclean/core/task.py
+++ b/src/autoclean/core/task.py
@@ -105,7 +105,7 @@ class Task(ABC, *DISCOVERED_MIXINS):
                 migrated_settings = migrate_legacy_task_config(dict(self.settings))
                 # Validate python task module config (raises on mismatch)
                 try:
-                    self.settings = validate_task_module_config(self.settings)
+                    self.settings = validate_task_module_config(migrated_settings)
                 except Exception as exc:
                     task_file = getattr(module, "__file__", None)
                     message_text = format_task_config_error(

--- a/src/autoclean/core/task.py
+++ b/src/autoclean/core/task.py
@@ -43,7 +43,10 @@ except ImportError as e:
 
     DISCOVERED_MIXINS = (_ImportErrorMixinFallback,)
 
-from autoclean.configkit.schema import validate_task_module_config
+from autoclean.configkit.schema import (
+    format_task_config_error,
+    validate_task_module_config,
+)
 from autoclean.utils.auth import require_authentication
 
 
@@ -102,7 +105,14 @@ class Task(ABC, *DISCOVERED_MIXINS):
                 try:
                     self.settings = validate_task_module_config(self.settings)
                 except Exception as exc:
-                    raise ValueError(f"Task config validation failed: {exc}") from exc
+                    task_file = getattr(module, "__file__", None)
+                    message_text = format_task_config_error(
+                        exc,
+                        self.settings,
+                        task_name=self.__class__.__name__,
+                        task_file=task_file,
+                    )
+                    raise ValueError(message_text) from exc
             else:
                 self.settings = None
 

--- a/tests/config/test_config_validation_messages.py
+++ b/tests/config/test_config_validation_messages.py
@@ -4,9 +4,11 @@ import sys
 import types
 
 import pytest
+from schema import SchemaError
 
 from autoclean.configkit.schema import (
     SCHEMA_VERSION,
+    _schema_error_path,
     format_task_config_error,
     validate_task_module_config,
 )
@@ -76,6 +78,19 @@ def test_format_task_config_error_shows_bad_montage_path_received_and_fix() -> N
     assert "Expected: string (valid montage) | 'auto' | None" in message
     assert "Use a supported montage name" in message
     assert "Raw schema error" not in message
+
+
+def test_format_task_config_error_prioritizes_enabled_suggestion_for_montage_enabled() -> (
+    None
+):
+    config = _minimal_config()
+    config["montage"]["enabled"] = "yes"
+
+    message = _formatted_error(config)
+
+    assert "Config path: config['montage']['enabled']" in message
+    assert "Set `enabled` to true or false." in message
+    assert "Use a supported montage name" not in message
 
 
 def test_format_task_config_error_shows_nested_filter_value() -> None:
@@ -160,6 +175,15 @@ def test_format_task_config_error_handles_non_schema_exception() -> None:
     assert "Raw schema error" not in message
 
 
+def test_schema_error_path_parses_nested_autos() -> None:
+    error = SchemaError(
+        ["Key 'montage' error:", "Key 'enabled' error:"],
+        None,
+    )
+
+    assert _schema_error_path(error) == ["montage", "enabled"]
+
+
 def test_task_init_formats_legacy_iclabel_errors_against_migrated_config() -> None:
     module = types.ModuleType("autoclean_test_legacy_bad_task_module")
     module.__file__ = "legacy_bad_task_file.py"
@@ -170,26 +194,29 @@ def test_task_init_formats_legacy_iclabel_errors_against_migrated_config() -> No
         "value": {"ic_flags_to_reject": "brain"},
     }
     sys.modules[module.__name__] = module
+    try:
 
-    class LegacyBadTask(Task):
-        __module__ = module.__name__
+        class LegacyBadTask(Task):
+            __module__ = module.__name__
 
-        def run(self) -> None:
-            return None
+            def run(self) -> None:
+                return None
 
-    setattr(module, "LegacyBadTask", LegacyBadTask)
+        setattr(module, "LegacyBadTask", LegacyBadTask)
 
-    with pytest.raises(ValueError) as exc_info:
-        LegacyBadTask({})
+        with pytest.raises(ValueError) as exc_info:
+            LegacyBadTask({})
 
-    message = str(exc_info.value)
-    assert "Task config validation failed for LegacyBadTask" in message
-    assert (
-        "Config path: config['component_rejection']['value']['ic_flags_to_reject']"
-        in message
-    )
-    assert "Received: 'brain' (str)" in message
-    assert "Received: <missing>" not in message
+        message = str(exc_info.value)
+        assert "Task config validation failed for LegacyBadTask" in message
+        assert (
+            "Config path: config['component_rejection']['value']['ic_flags_to_reject']"
+            in message
+        )
+        assert "Received: 'brain' (str)" in message
+        assert "Received: <missing>" not in message
+    finally:
+        sys.modules.pop(module.__name__, None)
 
 
 def test_task_init_wraps_config_errors_with_actionable_message() -> None:
@@ -198,20 +225,23 @@ def test_task_init_wraps_config_errors_with_actionable_message() -> None:
     module.config = _minimal_config()
     module.config["montage"] = {"enabled": True, "value": "invalid"}
     sys.modules[module.__name__] = module
+    try:
 
-    class BadTask(Task):
-        __module__ = module.__name__
+        class BadTask(Task):
+            __module__ = module.__name__
 
-        def run(self) -> None:
-            return None
+            def run(self) -> None:
+                return None
 
-    setattr(module, "BadTask", BadTask)
+        setattr(module, "BadTask", BadTask)
 
-    with pytest.raises(ValueError) as exc_info:
-        BadTask({})
+        with pytest.raises(ValueError) as exc_info:
+            BadTask({})
 
-    message = str(exc_info.value)
-    assert "Task config validation failed for BadTask" in message
-    assert "Task file: bad_task_file.py" in message
-    assert "Config path: config['montage']['value']" in message
-    assert "Raw schema error" not in message
+        message = str(exc_info.value)
+        assert "Task config validation failed for BadTask" in message
+        assert "Task file: bad_task_file.py" in message
+        assert "Config path: config['montage']['value']" in message
+        assert "Raw schema error" not in message
+    finally:
+        sys.modules.pop(module.__name__, None)

--- a/tests/config/test_config_validation_messages.py
+++ b/tests/config/test_config_validation_messages.py
@@ -194,6 +194,16 @@ def test_format_task_config_error_extracts_path_from_real_schema_error() -> None
     assert "Received: 'beginning' (str)" in message
 
 
+def test_schema_error_path_extracts_path_from_real_schema_error() -> None:
+    config = _minimal_config()
+    config["crop_step"]["value"]["start"] = "beginning"
+
+    with pytest.raises(SchemaError) as exc_info:
+        validate_task_module_config(config)
+
+    assert _schema_error_path(exc_info.value) == ["crop_step", "value", "start"]
+
+
 def test_task_init_formats_legacy_iclabel_errors_against_migrated_config() -> None:
     module = types.ModuleType("autoclean_test_legacy_bad_task_module")
     module.__file__ = "legacy_bad_task_file.py"

--- a/tests/config/test_config_validation_messages.py
+++ b/tests/config/test_config_validation_messages.py
@@ -51,7 +51,7 @@ def _minimal_config() -> dict:
     }
 
 
-def _formatted_error(config: dict, *, debug: bool = False) -> str:
+def _formatted_error(config: dict, *, debug: bool | None = None) -> str:
     with pytest.raises(Exception) as exc_info:
         validate_task_module_config(config)
     return format_task_config_error(
@@ -113,6 +113,16 @@ def test_format_task_config_error_shows_wrong_key_without_dumping_config() -> No
     assert "'schema_version':" not in message
 
 
+def test_format_task_config_error_distinguishes_literal_missing_string() -> None:
+    config = _minimal_config()
+    config["extra_key"] = "<missing>"
+
+    message = _formatted_error(config)
+
+    assert "Config path: config['extra_key']" in message
+    assert "Received: '<missing>' (str)" in message
+
+
 def test_format_task_config_error_includes_raw_error_when_debug_enabled() -> None:
     config = _minimal_config()
     config["epoch_settings"]["value"]["tmin"] = "early"
@@ -122,6 +132,64 @@ def test_format_task_config_error_includes_raw_error_when_debug_enabled() -> Non
     assert "Config path: config['epoch_settings']['value']['tmin']" in message
     assert "Raw schema error:" in message
     assert "'early' should be instance" in message
+
+
+def test_format_task_config_error_includes_raw_error_when_env_debug_enabled(
+    monkeypatch,
+) -> None:
+    config = _minimal_config()
+    config["epoch_settings"]["value"]["tmin"] = "early"
+    monkeypatch.setenv("AUTOCLEAN_CONFIG_DEBUG", "1")
+
+    message = _formatted_error(config)
+
+    assert "Raw schema error:" in message
+    assert "'early' should be instance" in message
+
+
+def test_format_task_config_error_handles_non_schema_exception() -> None:
+    message = format_task_config_error(
+        RuntimeError("plain failure"),
+        {"schema_version": SCHEMA_VERSION},
+        task_name="PlainTask",
+    )
+
+    assert "Task config validation failed for PlainTask" in message
+    assert "Config path: config" in message
+    assert "Received: {'schema_version':" in message
+    assert "Raw schema error" not in message
+
+
+def test_task_init_formats_legacy_iclabel_errors_against_migrated_config() -> None:
+    module = types.ModuleType("autoclean_test_legacy_bad_task_module")
+    module.__file__ = "legacy_bad_task_file.py"
+    module.config = _minimal_config()
+    del module.config["component_rejection"]
+    module.config["ICLabel"] = {
+        "enabled": True,
+        "value": {"ic_flags_to_reject": "brain"},
+    }
+    sys.modules[module.__name__] = module
+
+    class LegacyBadTask(Task):
+        __module__ = module.__name__
+
+        def run(self) -> None:
+            return None
+
+    setattr(module, "LegacyBadTask", LegacyBadTask)
+
+    with pytest.raises(ValueError) as exc_info:
+        LegacyBadTask({})
+
+    message = str(exc_info.value)
+    assert "Task config validation failed for LegacyBadTask" in message
+    assert (
+        "Config path: config['component_rejection']['value']['ic_flags_to_reject']"
+        in message
+    )
+    assert "Received: 'brain' (str)" in message
+    assert "Received: <missing>" not in message
 
 
 def test_task_init_wraps_config_errors_with_actionable_message() -> None:

--- a/tests/config/test_config_validation_messages.py
+++ b/tests/config/test_config_validation_messages.py
@@ -184,6 +184,16 @@ def test_schema_error_path_parses_nested_autos() -> None:
     assert _schema_error_path(error) == ["montage", "enabled"]
 
 
+def test_format_task_config_error_extracts_path_from_real_schema_error() -> None:
+    config = _minimal_config()
+    config["crop_step"]["value"]["start"] = "beginning"
+
+    message = _formatted_error(config)
+
+    assert "Config path: config['crop_step']['value']['start']" in message
+    assert "Received: 'beginning' (str)" in message
+
+
 def test_task_init_formats_legacy_iclabel_errors_against_migrated_config() -> None:
     module = types.ModuleType("autoclean_test_legacy_bad_task_module")
     module.__file__ = "legacy_bad_task_file.py"

--- a/tests/config/test_config_validation_messages.py
+++ b/tests/config/test_config_validation_messages.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from autoclean.configkit.schema import (
+    SCHEMA_VERSION,
+    format_task_config_error,
+    validate_task_module_config,
+)
+from autoclean.core.task import Task
+
+
+def _minimal_config() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "montage": {"enabled": True, "value": None},
+        "resample_step": {"enabled": False, "value": None},
+        "filtering": {
+            "enabled": False,
+            "value": {
+                "l_freq": None,
+                "h_freq": None,
+                "notch_freqs": None,
+                "notch_widths": None,
+            },
+        },
+        "drop_outerlayer": {"enabled": False, "value": None},
+        "eog_step": {"enabled": False, "value": None},
+        "trim_step": {"enabled": False, "value": 0},
+        "crop_step": {"enabled": False, "value": {"start": 0, "end": None}},
+        "reference_step": {"enabled": False, "value": None},
+        "ICA": {"enabled": False, "value": {"method": "fastica"}},
+        "component_rejection": {
+            "enabled": False,
+            "method": "iclabel",
+            "value": {
+                "ic_flags_to_reject": [],
+                "ic_rejection_threshold": 0,
+            },
+        },
+        "epoch_settings": {
+            "enabled": False,
+            "value": {"tmin": None, "tmax": None},
+            "event_id": None,
+            "remove_baseline": {"enabled": False, "window": None},
+            "threshold_rejection": {"enabled": False, "volt_threshold": {}},
+        },
+    }
+
+
+def _formatted_error(config: dict, *, debug: bool = False) -> str:
+    with pytest.raises(Exception) as exc_info:
+        validate_task_module_config(config)
+    return format_task_config_error(
+        exc_info.value,
+        config,
+        task_name="BadTask",
+        task_file="bad_task.py",
+        debug=debug,
+    )
+
+
+def test_format_task_config_error_shows_bad_montage_path_received_and_fix() -> None:
+    config = _minimal_config()
+    config["montage"] = {"enabled": True, "value": "not_a_montage"}
+
+    message = _formatted_error(config)
+
+    assert "Task config validation failed for BadTask" in message
+    assert "Task file: bad_task.py" in message
+    assert "Config path: config['montage']['value']" in message
+    assert "Received: 'not_a_montage' (str)" in message
+    assert "Expected: string (valid montage) | 'auto' | None" in message
+    assert "Use a supported montage name" in message
+    assert "Raw schema error" not in message
+
+
+def test_format_task_config_error_shows_nested_filter_value() -> None:
+    config = _minimal_config()
+    config["filtering"]["value"]["l_freq"] = "abc"
+
+    message = _formatted_error(config)
+
+    assert "Config path: config['filtering']['value']['l_freq']" in message
+    assert "Received: 'abc' (str)" in message
+    assert "Expected: number|null" in message
+    assert "Use numeric filter frequencies" in message
+
+
+def test_format_task_config_error_shows_missing_key() -> None:
+    config = _minimal_config()
+    del config["ICA"]
+
+    message = _formatted_error(config)
+
+    assert "Config path: config['ICA']" in message
+    assert "Received: <missing>" in message
+    assert "Add the missing required key" in message
+
+
+def test_format_task_config_error_shows_wrong_key_without_dumping_config() -> None:
+    config = _minimal_config()
+    config["extra_key"] = 1
+
+    message = _formatted_error(config)
+
+    assert "Config path: config['extra_key']" in message
+    assert "Received: 1 (int)" in message
+    assert "Remove the extra key" in message
+    assert "'schema_version':" not in message
+
+
+def test_format_task_config_error_includes_raw_error_when_debug_enabled() -> None:
+    config = _minimal_config()
+    config["epoch_settings"]["value"]["tmin"] = "early"
+
+    message = _formatted_error(config, debug=True)
+
+    assert "Config path: config['epoch_settings']['value']['tmin']" in message
+    assert "Raw schema error:" in message
+    assert "'early' should be instance" in message
+
+
+def test_task_init_wraps_config_errors_with_actionable_message() -> None:
+    module = types.ModuleType("autoclean_test_bad_task_module")
+    module.__file__ = "bad_task_file.py"
+    module.config = _minimal_config()
+    module.config["montage"] = {"enabled": True, "value": "invalid"}
+    sys.modules[module.__name__] = module
+
+    class BadTask(Task):
+        __module__ = module.__name__
+
+        def run(self) -> None:
+            return None
+
+    setattr(module, "BadTask", BadTask)
+
+    with pytest.raises(ValueError) as exc_info:
+        BadTask({})
+
+    message = str(exc_info.value)
+    assert "Task config validation failed for BadTask" in message
+    assert "Task file: bad_task_file.py" in message
+    assert "Config path: config['montage']['value']" in message
+    assert "Raw schema error" not in message


### PR DESCRIPTION
## Summary
- improves task config validation errors with clearer expected/received/schema context
- exposes configkit validation helpers for task validation
- adds focused regression coverage for the improved config validation messages

## Verification
- `uv run --extra dev pytest tests\config\test_config_validation_messages.py -q --no-cov`
- `uv run ruff check src\autoclean\configkit\__init__.py src\autoclean\configkit\schema.py src\autoclean\core\task.py tests\config\test_config_validation_messages.py`
- `git diff --check origin/main..HEAD`

Closes #197