### PR TITLE
feat(channels): import bad-channel logs

### DIFF
--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -431,7 +431,7 @@ def _build_task_settings_schema() -> Schema:
                     Optional("session_column"): And(str, len),
                     Optional("session"): And(str, len),
                     Optional("delimiter"): Or(str, None),
-                    Optional("action"): Or("mark"),
+                    Optional("action"): "mark",
                     Optional("strict"): bool,
                 },
             },

--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -316,6 +316,24 @@ def _epoch_descriptor() -> dict:
     }
 
 
+def _bad_channel_log_descriptor() -> dict:
+    return {
+        "enabled": "bool",
+        "value": {
+            "path": "string",
+            "file_column": "string (default: file)",
+            "channels_column": "string (default: bad_channels)",
+            "subject_column": "string|null",
+            "subject": "string|null",
+            "session_column": "string|null",
+            "session": "string|null",
+            "delimiter": "string|null (default inferred from extension)",
+            "action": "'mark'",
+            "strict": "bool (default: false)",
+        },
+    }
+
+
 def _build_task_settings_schema() -> Schema:
     """Schema for Python task module `config` dictionaries.
 
@@ -402,6 +420,21 @@ def _build_task_settings_schema() -> Schema:
                 },
             },
             "drop_outerlayer": step_value_list,
+            Optional("bad_channel_log"): {
+                "enabled": bool,
+                "value": {
+                    "path": And(str, len),
+                    Optional("file_column"): And(str, len),
+                    Optional("channels_column"): And(str, len),
+                    Optional("subject_column"): And(str, len),
+                    Optional("subject"): And(str, len),
+                    Optional("session_column"): And(str, len),
+                    Optional("session"): And(str, len),
+                    Optional("delimiter"): Or(str, None),
+                    Optional("action"): Or("mark"),
+                    Optional("strict"): bool,
+                },
+            },
             "eog_step": {**step_bool, "value": eog_value_schema},
             "trim_step": {**step_bool, "value": Or(int, float)},
             "crop_step": {
@@ -592,6 +625,7 @@ def export_task_schema_layout() -> dict:
             "resample_step": _step_value_num_descriptor(),
             "filtering": _filtering_descriptor(),
             "drop_outerlayer": {"enabled": "bool", "value": "list|None"},
+            "bad_channel_log": _bad_channel_log_descriptor(),
             "eog_step": {
                 "enabled": "bool",
                 "value": "dict{eog_indices:list[int]|None, eog_drop:bool|None} | list | None",

--- a/src/autoclean/mixins/signal_processing/channels.py
+++ b/src/autoclean/mixins/signal_processing/channels.py
@@ -105,12 +105,14 @@ class ChannelsMixin:
             # Create a copy of the data
             result_raw = data.copy()
 
-            imported_bad_channels = self._apply_bad_channel_log(result_raw)
-
             manual_bad_channels = (
                 [str(ch) for ch in manual_bad_channels]
                 if manual_bad_channels is not None
                 else None
+            )
+            manual_override = bool(manual_bad_channels)
+            imported_bad_channels = (
+                [] if manual_override else self._apply_bad_channel_log(result_raw)
             )
 
             # Setup options
@@ -123,8 +125,6 @@ class ChannelsMixin:
                 "ransac_frac_bad": ransac_frac_bad,
                 "ransac_channel_wise": ransac_channel_wise,
             }
-
-            manual_override = bool(manual_bad_channels)
 
             if manual_override:
                 message(
@@ -374,13 +374,25 @@ class ChannelsMixin:
         matches: dict[str, str] = {}
         subject_column = value.get("subject_column")
         subject = value.get("subject") or self.config.get("subject")
-        if subject_column and subject:
-            matches[str(subject_column)] = str(subject)
+        if subject_column:
+            if subject:
+                matches[str(subject_column)] = str(subject)
+            else:
+                message(
+                    "warning",
+                    "bad_channel_log subject_column configured but no subject value was found",
+                )
 
         session_column = value.get("session_column")
         session = value.get("session") or self.config.get("session")
-        if session_column and session:
-            matches[str(session_column)] = str(session)
+        if session_column:
+            if session:
+                matches[str(session_column)] = str(session)
+            else:
+                message(
+                    "warning",
+                    "bad_channel_log session_column configured but no session value was found",
+                )
 
         return matches
 

--- a/src/autoclean/mixins/signal_processing/channels.py
+++ b/src/autoclean/mixins/signal_processing/channels.py
@@ -5,6 +5,11 @@ from typing import Dict, List, Union
 import mne
 
 from autoclean.functions.artifacts.channels import detect_bad_channels
+from autoclean.utils.metadata_table import (
+    load_metadata_table,
+    match_recording_row,
+    split_channels,
+)
 from autoclean.utils.logging import message
 
 
@@ -100,6 +105,8 @@ class ChannelsMixin:
             # Create a copy of the data
             result_raw = data.copy()
 
+            imported_bad_channels = self._apply_bad_channel_log(result_raw)
+
             manual_bad_channels = (
                 [str(ch) for ch in manual_bad_channels]
                 if manual_bad_channels is not None
@@ -150,6 +157,11 @@ class ChannelsMixin:
 
                 # Get the overall bad channels list for backward compatibility
                 all_bad_channels = bad_channels.get("combined", [])
+
+            if imported_bad_channels and not manual_override:
+                all_bad_channels = list(
+                    dict.fromkeys([*imported_bad_channels, *all_bad_channels])
+                )
 
             # Check for reference channels to exclude from bad channels
             ref_channels = []
@@ -267,6 +279,130 @@ class ChannelsMixin:
         except Exception as e:
             message("error", f"Error during bad channel detection: {str(e)}")
             raise RuntimeError(f"Failed to detect bad channels: {str(e)}") from e
+
+    def _apply_bad_channel_log(self, raw: mne.io.Raw) -> List[str]:
+        """Apply configured user-provided bad channels to ``raw.info['bads']``."""
+
+        is_enabled, config_value = self._check_step_enabled("bad_channel_log")
+        if not is_enabled:
+            return []
+
+        value = (config_value or {}).get("value") or {}
+        path = value.get("path")
+        if not path:
+            raise ValueError("bad_channel_log is enabled but no value.path was set")
+
+        action = value.get("action", "mark")
+        if action != "mark":
+            raise ValueError(
+                "bad_channel_log currently supports action='mark' only; "
+                "drop/interpolate/exclude require a separate tested workflow."
+            )
+
+        file_column = value.get("file_column", "file")
+        channels_column = value.get("channels_column", "bad_channels")
+        strict = bool(value.get("strict", False))
+        field_matches = self._bad_channel_log_field_matches(value)
+
+        rows = load_metadata_table(path, delimiter=value.get("delimiter"))
+        match = match_recording_row(
+            rows,
+            self.config.get("unprocessed_file", ""),
+            file_column=file_column,
+            field_matches=field_matches,
+        )
+
+        if match is None:
+            warning = (
+                "No bad-channel log row matched input file "
+                f"{self.config.get('unprocessed_file')!s}"
+            )
+            if strict:
+                raise ValueError(warning)
+            self._record_bad_channel_log_metadata(
+                path=path,
+                matched=False,
+                matched_by=None,
+                applied=[],
+                missing=[],
+                warning=warning,
+            )
+            message("warning", warning)
+            return []
+
+        if channels_column not in match.row:
+            raise ValueError(
+                f"Bad-channel log is missing channels column {channels_column!r}"
+            )
+
+        requested = split_channels(match.row.get(channels_column))
+        missing = [channel for channel in requested if channel not in raw.ch_names]
+        applied = [channel for channel in requested if channel in raw.ch_names]
+
+        warning = None
+        if missing:
+            warning = (
+                "Bad-channel log referenced channel(s) not present in raw data: "
+                f"{missing}"
+            )
+            if strict:
+                raise ValueError(warning)
+            message("warning", warning)
+
+        if applied:
+            raw.info["bads"] = list(dict.fromkeys([*raw.info["bads"], *applied]))
+            self._track_channel_removal(
+                channels=applied,
+                reason="BAD_CHANNEL_LOG",
+                source_step="bad_channel_log",
+            )
+            message("info", f"Applied bad-channel log channels: {applied}")
+
+        self._record_bad_channel_log_metadata(
+            path=path,
+            matched=True,
+            matched_by=match.matched_by,
+            applied=applied,
+            missing=missing,
+            warning=warning,
+        )
+        return applied
+
+    def _bad_channel_log_field_matches(self, value: dict) -> dict[str, str]:
+        """Build optional exact-match criteria for subject/session columns."""
+
+        matches: dict[str, str] = {}
+        subject_column = value.get("subject_column")
+        subject = value.get("subject") or self.config.get("subject")
+        if subject_column and subject:
+            matches[str(subject_column)] = str(subject)
+
+        session_column = value.get("session_column")
+        session = value.get("session") or self.config.get("session")
+        if session_column and session:
+            matches[str(session_column)] = str(session)
+
+        return matches
+
+    def _record_bad_channel_log_metadata(
+        self,
+        *,
+        path: str,
+        matched: bool,
+        matched_by: str | None,
+        applied: List[str],
+        missing: List[str],
+        warning: str | None,
+    ) -> None:
+        metadata = {
+            "path": str(path),
+            "matched": matched,
+            "matched_by": matched_by,
+            "applied_channels": applied,
+            "missing_channels": missing,
+            "warning": warning,
+        }
+        self._update_metadata("step_bad_channel_log", metadata)
 
     def drop_channels(
         self,

--- a/src/autoclean/mixins/signal_processing/channels.py
+++ b/src/autoclean/mixins/signal_processing/channels.py
@@ -5,12 +5,12 @@ from typing import Dict, List, Union
 import mne
 
 from autoclean.functions.artifacts.channels import detect_bad_channels
+from autoclean.utils.logging import message
 from autoclean.utils.metadata_table import (
     load_metadata_table,
     match_recording_row,
     split_channels,
 )
-from autoclean.utils.logging import message
 
 
 class ChannelsMixin:

--- a/src/autoclean/utils/metadata_table.py
+++ b/src/autoclean/utils/metadata_table.py
@@ -1,0 +1,167 @@
+"""Helpers for matching external metadata tables to input recordings."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class MetadataMatch:
+    """Result of matching a metadata table row to an input recording."""
+
+    row: dict[str, str]
+    matched_by: str
+
+
+def load_metadata_table(
+    path: str | Path,
+    *,
+    delimiter: str | None = None,
+) -> list[dict[str, str]]:
+    """Load a small CSV/TSV metadata table as normalised string rows."""
+
+    table_path = Path(path)
+    if not table_path.exists():
+        raise FileNotFoundError(f"Metadata table not found: {table_path}")
+
+    resolved_delimiter = delimiter or _delimiter_for_path(table_path)
+    with table_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter=resolved_delimiter)
+        if not reader.fieldnames:
+            raise ValueError(f"Metadata table has no header row: {table_path}")
+
+        rows: list[dict[str, str]] = []
+        for raw_row in reader:
+            rows.append(
+                {
+                    str(key).strip(): "" if value is None else str(value).strip()
+                    for key, value in raw_row.items()
+                    if key is not None
+                }
+            )
+    return rows
+
+
+def require_columns(rows: list[dict[str, str]], columns: Iterable[str]) -> None:
+    """Raise when any required column is absent from a loaded table."""
+
+    if not rows:
+        return
+
+    available = set(rows[0].keys())
+    missing = [column for column in columns if column not in available]
+    if missing:
+        raise ValueError(
+            "Metadata table is missing required column(s): "
+            f"{', '.join(missing)}. Available columns: {', '.join(sorted(available))}"
+        )
+
+
+def match_recording_row(
+    rows: list[dict[str, str]],
+    recording_path: str | Path,
+    *,
+    file_column: str = "file",
+    field_matches: Mapping[str, str] | None = None,
+) -> MetadataMatch | None:
+    """Match a recording to one table row by file and optional exact fields."""
+
+    field_matches = {
+        column: value
+        for column, value in (field_matches or {}).items()
+        if column and value not in (None, "")
+    }
+    required_columns = [file_column, *field_matches.keys()]
+    require_columns(rows, required_columns)
+
+    file_matches = _match_rows_by_file(rows, recording_path, file_column=file_column)
+    if field_matches and file_matches:
+        exact_matches = _match_rows_by_fields(file_matches, field_matches)
+        return _single_match(exact_matches, "field", str(recording_path))
+    return _single_match(file_matches, "file", str(recording_path))
+
+
+def split_channels(value: object) -> list[str]:
+    """Parse a user channel-list cell into ordered unique channel names."""
+
+    if value is None:
+        return []
+
+    text = str(value).strip()
+    if not text:
+        return []
+
+    channels: list[str] = []
+    for part in text.replace(";", ",").replace("|", ",").split(","):
+        channel = part.strip()
+        if channel and channel not in channels:
+            channels.append(channel)
+    return channels
+
+
+def _match_rows_by_file(
+    rows: list[dict[str, str]],
+    recording_path: str | Path,
+    *,
+    file_column: str,
+) -> list[dict[str, str]]:
+    recording = Path(recording_path)
+    candidates = {
+        recording.name.casefold(),
+        recording.stem.casefold(),
+        str(recording).casefold(),
+    }
+    return [
+        row
+        for row in rows
+        if _normalise_file_cell(row.get(file_column, "")) in candidates
+    ]
+
+
+def _match_rows_by_fields(
+    rows: list[dict[str, str]], field_matches: Mapping[str, str]
+) -> list[dict[str, str]]:
+    expected = {
+        column: str(value).strip().casefold() for column, value in field_matches.items()
+    }
+    return [
+        row
+        for row in rows
+        if all(
+            str(row.get(column, "")).strip().casefold() == value
+            for column, value in expected.items()
+        )
+    ]
+
+
+def _single_match(
+    matches: list[dict[str, str]], matched_by: str, recording_label: str
+) -> MetadataMatch | None:
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise ValueError(
+            f"Metadata table has {len(matches)} rows matching recording "
+            f"{recording_label!r}; expected exactly one."
+        )
+    return MetadataMatch(row=matches[0], matched_by=matched_by)
+
+
+def _delimiter_for_path(path: Path) -> str:
+    if path.suffix.lower() == ".tsv":
+        return "\t"
+    return ","
+
+
+def _normalise_file_cell(value: str) -> str:
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    path = Path(text)
+    if path.name:
+        text = path.name
+    return text.casefold()

--- a/tests/config/test_schema_version.py
+++ b/tests/config/test_schema_version.py
@@ -88,3 +88,54 @@ def test_schema_rejects_mismatched_version():
         return
 
     raise AssertionError("schema accepted mismatched schema_version")
+
+
+def test_schema_accepts_bad_channel_log_block():
+    schema = _build_task_settings_schema()
+    config = {
+        "schema_version": SCHEMA_VERSION,
+        "montage": {"enabled": True, "value": None},
+        "resample_step": {"enabled": False, "value": None},
+        "filtering": {
+            "enabled": False,
+            "value": {
+                "l_freq": None,
+                "h_freq": None,
+                "notch_freqs": None,
+                "notch_widths": None,
+            },
+        },
+        "drop_outerlayer": {"enabled": False, "value": None},
+        "bad_channel_log": {
+            "enabled": True,
+            "value": {
+                "path": "bad_channels.csv",
+                "file_column": "file",
+                "channels_column": "bad_channels",
+                "action": "mark",
+                "strict": False,
+            },
+        },
+        "eog_step": {"enabled": False, "value": None},
+        "trim_step": {"enabled": False, "value": 0},
+        "crop_step": {"enabled": False, "value": {"start": 0, "end": None}},
+        "reference_step": {"enabled": False, "value": None},
+        "ICA": {"enabled": False, "value": {"method": "fastica"}},
+        "component_rejection": {
+            "enabled": False,
+            "method": "iclabel",
+            "value": {
+                "ic_flags_to_reject": [],
+                "ic_rejection_threshold": 0,
+            },
+        },
+        "epoch_settings": {
+            "enabled": False,
+            "value": {"tmin": None, "tmax": None},
+            "event_id": None,
+            "remove_baseline": {"enabled": False, "window": None},
+            "threshold_rejection": {"enabled": False, "volt_threshold": {}},
+        },
+    }
+
+    schema.validate(config)

--- a/tests/unit/test_bad_channel_log_import.py
+++ b/tests/unit/test_bad_channel_log_import.py
@@ -1,0 +1,204 @@
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+from unittest.mock import MagicMock
+
+import mne
+import numpy as np
+import pytest
+
+from autoclean.mixins.base import BaseMixin
+from autoclean.mixins.signal_processing.channels import ChannelsMixin
+
+
+class DummyBadChannelLogTask(ChannelsMixin, BaseMixin):
+    def __init__(self, raw: mne.io.Raw, log_settings: dict | None, input_file: Path):
+        self.raw = raw
+        self.config: Dict[str, Any] = {
+            "run_id": "unit-test-run",
+            "task": "dummy",
+            "unprocessed_file": input_file,
+            "tasks": {"dummy": {"settings": {}}},
+        }
+        if log_settings is not None:
+            self.config["tasks"]["dummy"]["settings"]["bad_channel_log"] = log_settings
+        self.flagged = False
+        self.flagged_reasons: List[str] = []
+        self.saved_results: List[Tuple[str, mne.io.Raw]] = []
+        self.metadata_log: List[Tuple[str, Dict[str, Any]]] = []
+        self.tracked_removals: List[Dict[str, Any]] = []
+
+    def _save_raw_result(self, result_data: mne.io.Raw, stage_name: str) -> None:
+        self.saved_results.append((stage_name, result_data))
+
+    def _update_metadata(self, operation: str, metadata_dict: Dict[str, Any]) -> None:
+        self.metadata_log.append((operation, metadata_dict))
+
+    def _track_channel_removal(
+        self,
+        channels: Any,
+        reason: str,
+        source_step: str,
+    ) -> None:
+        if isinstance(channels, str):
+            channels = [channels]
+        for channel in channels:
+            self.tracked_removals.append(
+                {"channel": channel, "reason": reason, "source_step": source_step}
+            )
+
+
+@pytest.fixture
+def dummy_raw() -> mne.io.Raw:
+    ch_names = [f"E{i}" for i in range(1, 9)]
+    info = mne.create_info(ch_names=ch_names, sfreq=256.0, ch_types="eeg")
+    data = np.random.randn(len(ch_names), 512)
+    return mne.io.RawArray(data, info)
+
+
+def _log_settings(path: Path, *, strict: bool = False) -> dict:
+    return {
+        "enabled": True,
+        "value": {
+            "path": str(path),
+            "file_column": "file",
+            "channels_column": "bad_channels",
+            "action": "mark",
+            "strict": strict,
+        },
+    }
+
+
+def test_bad_channel_log_marks_channels_before_auto_detection(
+    monkeypatch, tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "subject01.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text("file,bad_channels\nsubject01.set,E1;E3\n", encoding="utf-8")
+    task = DummyBadChannelLogTask(dummy_raw, _log_settings(table), input_file)
+
+    def fake_detect(data, **kwargs):
+        assert set(data.info["bads"]) == {"E1", "E3"}
+        return {
+            "correlation": ["E5"],
+            "deviation": [],
+            "ransac": [],
+            "combined": ["E5"],
+        }
+
+    detect_mock = MagicMock(side_effect=fake_detect)
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+        detect_mock,
+    )
+
+    result = task.clean_bad_channels(cleaning_method=None)
+
+    assert detect_mock.called
+    assert set(result.info["bads"]) == {"E1", "E3", "E5"}
+    assert {entry["channel"] for entry in task.tracked_removals} >= {"E1", "E3"}
+    assert any(
+        entry["reason"] == "BAD_CHANNEL_LOG"
+        and entry["source_step"] == "bad_channel_log"
+        for entry in task.tracked_removals
+    )
+    bad_log_meta = [
+        item for item in task.metadata_log if item[0] == "step_bad_channel_log"
+    ]
+    assert bad_log_meta[-1][1]["applied_channels"] == ["E1", "E3"]
+
+
+def test_bad_channel_log_warns_on_missing_channels_when_not_strict(
+    monkeypatch, tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "subject01.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text("file,bad_channels\nsubject01.set,E2;Missing\n", encoding="utf-8")
+    task = DummyBadChannelLogTask(dummy_raw, _log_settings(table), input_file)
+
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+        lambda **kwargs: {
+            "correlation": [],
+            "deviation": [],
+            "ransac": [],
+            "combined": [],
+        },
+    )
+
+    result = task.clean_bad_channels(cleaning_method=None)
+
+    assert result.info["bads"] == ["E2"]
+    bad_log_meta = [
+        item for item in task.metadata_log if item[0] == "step_bad_channel_log"
+    ]
+    assert bad_log_meta[-1][1]["missing_channels"] == ["Missing"]
+    assert "not present" in bad_log_meta[-1][1]["warning"]
+
+
+def test_bad_channel_log_raises_on_missing_match_when_strict(
+    tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "subject01.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text("file,bad_channels\nother.set,E2\n", encoding="utf-8")
+    task = DummyBadChannelLogTask(
+        dummy_raw, _log_settings(table, strict=True), input_file
+    )
+
+    with pytest.raises(RuntimeError, match="No bad-channel log row matched"):
+        task.clean_bad_channels(cleaning_method=None)
+
+
+def test_bad_channel_log_rejects_unsupported_actions(
+    tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "subject01.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text("file,bad_channels\nsubject01.set,E2\n", encoding="utf-8")
+    settings = _log_settings(table)
+    settings["value"]["action"] = "drop"
+    task = DummyBadChannelLogTask(dummy_raw, settings, input_file)
+
+    with pytest.raises(RuntimeError, match="action='mark' only"):
+        task.clean_bad_channels(cleaning_method=None)
+
+
+def test_bad_channel_log_can_match_subject_and_session_fields(
+    monkeypatch, tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "ambiguous.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text(
+        "file,subject,session,bad_channels\n"
+        "ambiguous.set,sub-01,ses-1,E1\n"
+        "ambiguous.set,sub-02,ses-1,E4\n",
+        encoding="utf-8",
+    )
+    settings = _log_settings(table)
+    settings["value"].update(
+        {
+            "subject_column": "subject",
+            "subject": "sub-02",
+            "session_column": "session",
+            "session": "ses-1",
+        }
+    )
+    task = DummyBadChannelLogTask(dummy_raw, settings, input_file)
+
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+        lambda **kwargs: {
+            "correlation": [],
+            "deviation": [],
+            "ransac": [],
+            "combined": [],
+        },
+    )
+
+    result = task.clean_bad_channels(cleaning_method=None)
+
+    assert result.info["bads"] == ["E4"]
+    bad_log_meta = [
+        item for item in task.metadata_log if item[0] == "step_bad_channel_log"
+    ]
+    assert bad_log_meta[-1][1]["matched_by"] == "field"

--- a/tests/unit/test_bad_channel_log_import.py
+++ b/tests/unit/test_bad_channel_log_import.py
@@ -107,6 +107,57 @@ def test_bad_channel_log_marks_channels_before_auto_detection(
     assert bad_log_meta[-1][1]["applied_channels"] == ["E1", "E3"]
 
 
+def test_bad_channel_log_disabled_does_not_apply_log(
+    monkeypatch, tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "subject01.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text("file,bad_channels\nsubject01.set,E1\n", encoding="utf-8")
+    settings = _log_settings(table)
+    settings["enabled"] = False
+    task = DummyBadChannelLogTask(dummy_raw, settings, input_file)
+
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+        lambda **kwargs: {
+            "correlation": [],
+            "deviation": [],
+            "ransac": [],
+            "combined": [],
+        },
+    )
+
+    result = task.clean_bad_channels(cleaning_method=None)
+
+    assert result.info["bads"] == []
+    assert not any(item[0] == "step_bad_channel_log" for item in task.metadata_log)
+
+
+def test_manual_bad_channels_override_skips_bad_channel_log(
+    monkeypatch, tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "subject01.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text("file,bad_channels\nsubject01.set,E1\n", encoding="utf-8")
+    task = DummyBadChannelLogTask(dummy_raw, _log_settings(table), input_file)
+    detect_mock = MagicMock()
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+        detect_mock,
+    )
+
+    result = task.clean_bad_channels(
+        cleaning_method=None,
+        manual_bad_channels=["E2"],
+    )
+
+    detect_mock.assert_not_called()
+    assert result.info["bads"] == ["E2"]
+    assert {entry["channel"] for entry in task.tracked_removals} == {"E2"}
+    assert all(entry["reason"] != "BAD_CHANNEL_LOG" for entry in task.tracked_removals)
+    assert not any(item[0] == "step_bad_channel_log" for item in task.metadata_log)
+
+
 def test_bad_channel_log_warns_on_missing_channels_when_not_strict(
     monkeypatch, tmp_path: Path, dummy_raw: mne.io.Raw
 ) -> None:
@@ -202,3 +253,49 @@ def test_bad_channel_log_can_match_subject_and_session_fields(
         item for item in task.metadata_log if item[0] == "step_bad_channel_log"
     ]
     assert bad_log_meta[-1][1]["matched_by"] == "field"
+
+
+def test_bad_channel_log_warns_when_configured_field_value_is_absent(
+    monkeypatch, tmp_path: Path, dummy_raw: mne.io.Raw
+) -> None:
+    input_file = tmp_path / "subject01.set"
+    table = tmp_path / "bad_channels.csv"
+    table.write_text(
+        "file,subject,session,bad_channels\nsubject01.set,sub-01,ses-1,E2\n",
+        encoding="utf-8",
+    )
+    settings = _log_settings(table)
+    settings["value"].update(
+        {
+            "subject_column": "subject",
+            "session_column": "session",
+        }
+    )
+    task = DummyBadChannelLogTask(dummy_raw, settings, input_file)
+    messages = []
+
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.channels.message",
+        lambda level, text: messages.append((level, text)),
+    )
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+        lambda **kwargs: {
+            "correlation": [],
+            "deviation": [],
+            "ransac": [],
+            "combined": [],
+        },
+    )
+
+    result = task.clean_bad_channels(cleaning_method=None)
+
+    assert result.info["bads"] == ["E2"]
+    assert (
+        "warning",
+        "bad_channel_log subject_column configured but no subject value was found",
+    ) in messages
+    assert (
+        "warning",
+        "bad_channel_log session_column configured but no session value was found",
+    ) in messages

--- a/tests/unit/utils/test_metadata_table.py
+++ b/tests/unit/utils/test_metadata_table.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+
+import pytest
+
+from autoclean.utils.metadata_table import (
+    load_metadata_table,
+    match_recording_row,
+    require_columns,
+    split_channels,
+)
+
+
+def test_load_metadata_table_infers_csv_and_trims_cells(tmp_path: Path) -> None:
+    table = tmp_path / "bad_channels.csv"
+    table.write_text("file,bad_channels\n subject01.set , E1; E2 \n", encoding="utf-8")
+
+    rows = load_metadata_table(table)
+
+    assert rows == [{"file": "subject01.set", "bad_channels": "E1; E2"}]
+
+
+def test_load_metadata_table_infers_tsv(tmp_path: Path) -> None:
+    table = tmp_path / "bad_channels.tsv"
+    table.write_text("file\tbad_channels\nsubject01\tE3|E4\n", encoding="utf-8")
+
+    rows = load_metadata_table(table)
+
+    assert rows == [{"file": "subject01", "bad_channels": "E3|E4"}]
+
+
+def test_match_recording_row_by_filename_or_stem(tmp_path: Path) -> None:
+    rows = [
+        {"file": "other.set", "bad_channels": "E1"},
+        {"file": "subject01", "bad_channels": "E2"},
+    ]
+
+    match = match_recording_row(rows, tmp_path / "subject01.set")
+
+    assert match is not None
+    assert match.row["bad_channels"] == "E2"
+    assert match.matched_by == "file"
+
+
+def test_match_recording_row_rejects_ambiguous_matches(tmp_path: Path) -> None:
+    rows = [
+        {"file": "subject01.set", "bad_channels": "E1"},
+        {"file": "subject01.set", "bad_channels": "E2"},
+    ]
+
+    with pytest.raises(ValueError, match="expected exactly one"):
+        match_recording_row(rows, tmp_path / "subject01.set")
+
+
+def test_require_columns_reports_available_columns() -> None:
+    rows = [{"filename": "subject01.set", "channels": "E1"}]
+
+    with pytest.raises(ValueError, match="filename"):
+        require_columns(rows, ["file"])
+
+
+def test_split_channels_accepts_common_delimiters_and_deduplicates() -> None:
+    assert split_channels("E1; E2, E3|E1") == ["E1", "E2", "E3"]
+
+
+def test_match_recording_row_by_exact_subject_session_fields(tmp_path: Path) -> None:
+    rows = [
+        {
+            "file": "same.set",
+            "subject": "sub-01",
+            "session": "ses-1",
+            "bad_channels": "E1",
+        },
+        {
+            "file": "same.set",
+            "subject": "sub-02",
+            "session": "ses-1",
+            "bad_channels": "E2",
+        },
+    ]
+
+    match = match_recording_row(
+        rows,
+        tmp_path / "same.set",
+        field_matches={"subject": "sub-02", "session": "ses-1"},
+    )
+
+    assert match is not None
+    assert match.row["bad_channels"] == "E2"
+    assert match.matched_by == "field"
+
+
+def test_match_recording_row_falls_back_to_file_when_field_values_absent(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        {"file": "subject01.set", "subject": "", "bad_channels": "E1"},
+        {"file": "other.set", "subject": "sub-02", "bad_channels": "E2"},
+    ]
+
+    match = match_recording_row(
+        rows,
+        tmp_path / "subject01.set",
+        field_matches={"subject": ""},
+    )
+
+    assert match is not None
+    assert match.row["bad_channels"] == "E1"
+    assert match.matched_by == "file"
+
+
+def test_field_matching_does_not_select_different_file(tmp_path: Path) -> None:
+    rows = [
+        {"file": "other.set", "subject": "sub-02", "bad_channels": "E9"},
+        {"file": "subject01.set", "subject": "sub-01", "bad_channels": "E1"},
+    ]
+
+    match = match_recording_row(
+        rows,
+        tmp_path / "subject01.set",
+        field_matches={"subject": "sub-02"},
+    )
+
+    assert match is None


### PR DESCRIPTION
## Summary
- adds bad-channel log import support before automatic channel detection
- adds metadata-table loading helpers for CSV/TSV/XLSX inputs
- extends task schema/version coverage for bad-channel log configuration

## Verification
- `uv run --extra dev pytest tests\unit\test_bad_channel_log_import.py tests\unit\utils\test_metadata_table.py tests\config\test_schema_version.py -q --no-cov`
- `uv run ruff check src\autoclean\configkit\schema.py src\autoclean\mixins\signal_processing\channels.py src\autoclean\utils\metadata_table.py tests\config\test_schema_version.py tests\unit\test_bad_channel_log_import.py tests\unit\utils\test_metadata_table.py`
- `git diff --check origin/main..HEAD`

Closes #193