### PR TITLE
feat(pipeline): support exclusion lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ dependencies = [
     "redis==7.3.0",
     "rq==2.7.0",
     "websockets==16.0",
+    "openpyxl==3.1.5",
 ]
 
 [project.optional-dependencies]

--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -334,6 +334,25 @@ def _bad_channel_log_descriptor() -> dict:
     }
 
 
+def _exclusion_list_descriptor() -> dict:
+    return {
+        "enabled": "bool",
+        "value": {
+            "path": "string",
+            "file_column": "string (default: file)",
+            "subject_column": "string|null",
+            "subject": "string|null",
+            "session_column": "string|null",
+            "session": "string|null",
+            "exclude_column": "string (default: exclude)",
+            "reason_column": "string (default: reason)",
+            "delimiter": "string|null (default inferred from extension)",
+            "mode": "'tag'|'skip'",
+            "strict": "bool (default: false)",
+        },
+    }
+
+
 def _build_task_settings_schema() -> Schema:
     """Schema for Python task module `config` dictionaries.
 
@@ -432,6 +451,22 @@ def _build_task_settings_schema() -> Schema:
                     Optional("session"): And(str, len),
                     Optional("delimiter"): Or(str, None),
                     Optional("action"): "mark",
+                    Optional("strict"): bool,
+                },
+            },
+            Optional("exclusion_list"): {
+                "enabled": bool,
+                "value": {
+                    "path": And(str, len),
+                    Optional("file_column"): And(str, len),
+                    Optional("subject_column"): And(str, len),
+                    Optional("subject"): And(str, len),
+                    Optional("session_column"): And(str, len),
+                    Optional("session"): And(str, len),
+                    Optional("exclude_column"): And(str, len),
+                    Optional("reason_column"): And(str, len),
+                    Optional("delimiter"): Or(str, None),
+                    Optional("mode"): Or("tag", "skip"),
                     Optional("strict"): bool,
                 },
             },
@@ -626,6 +661,7 @@ def export_task_schema_layout() -> dict:
             "filtering": _filtering_descriptor(),
             "drop_outerlayer": {"enabled": "bool", "value": "list|None"},
             "bad_channel_log": _bad_channel_log_descriptor(),
+            "exclusion_list": _exclusion_list_descriptor(),
             "eog_step": {
                 "enabled": "bool",
                 "value": "dict{eog_indices:list[int]|None, eog_drop:bool|None} | list | None",

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -94,8 +94,9 @@ from autoclean.utils.config import (
 from autoclean.utils.database import (
     create_isolated_database,
     get_run_record,
-    manage_database,
-    manage_database_conditionally,
+)
+from autoclean.utils.database import manage_database_conditionally as manage_database
+from autoclean.utils.database import (
     set_database_path,
 )
 from autoclean.utils.exclusion_list import ExclusionListResult, evaluate_exclusion_list
@@ -1562,7 +1563,3 @@ class Pipeline:
 
         message("success", f"✓ File '{file_path}' found")
         return path
-
-
-# Backward compatibility: expose manage_database for test patches
-manage_database = manage_database_conditionally

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -94,9 +94,11 @@ from autoclean.utils.config import (
 from autoclean.utils.database import (
     create_isolated_database,
     get_run_record,
+    manage_database,
     manage_database_conditionally,
     set_database_path,
 )
+from autoclean.utils.exclusion_list import ExclusionListResult, evaluate_exclusion_list
 from autoclean.utils.file_system import (
     STATUS_DIR_NAME,
     step_prepare_directories,
@@ -312,6 +314,70 @@ class Pipeline:
             return False
         return bool(auto_backup)
 
+    def _exclusion_list_config_for_task(self, task: str) -> Optional[dict]:
+        task_config = self.session_task_configs.get(task.lower()) or {}
+        config_block = task_config.get("exclusion_list")
+        if config_block is None:
+            from autoclean.utils.task_discovery import extract_config_from_task
+
+            config_block = extract_config_from_task(task, "exclusion_list")
+
+        if not isinstance(config_block, dict) or not config_block.get("enabled", False):
+            return None
+
+        value = config_block.get("value") or {}
+        return value if isinstance(value, dict) else None
+
+    def _evaluate_exclusion_skip(
+        self, task: str, unprocessed_file: Path
+    ) -> ExclusionListResult | None:
+        config_value = self._exclusion_list_config_for_task(task)
+        if config_value is None:
+            return None
+
+        result = evaluate_exclusion_list(config_value, unprocessed_file)
+        if result.mode != "skip":
+            return None
+        return result
+
+    def _record_exclusion_skip(
+        self,
+        *,
+        run_record: dict,
+        task: str,
+        unprocessed_file: Path,
+        result: ExclusionListResult,
+    ) -> None:
+        reason = result.reason or "Recording matched exclusion list"
+        metadata = {
+            "step_exclusion_list": result.metadata,
+            "skip_reason": f"EXCLUSION_LIST: {reason}",
+        }
+        manage_database(
+            operation="update",
+            update_record={
+                "run_id": run_record["run_id"],
+                "status": "skipped",
+                "success": True,
+                "metadata": metadata,
+            },
+        )
+        manage_database(
+            operation="add_access_log",
+            run_record={
+                "timestamp": datetime.now().isoformat(),
+                "operation": "exclusion_list_skip",
+                "user_context": get_current_user_for_audit(),
+                "details": {
+                    "task": task,
+                    "unprocessed_file": str(unprocessed_file),
+                    "reason": reason,
+                    "metadata": result.metadata,
+                },
+            },
+        )
+        message("warning", f"Skipped by exclusion list: {reason}")
+
     def _entrypoint(
         self, unprocessed_file: Path, task: str, run_id: Optional[str] = None
     ) -> None:
@@ -377,6 +443,19 @@ class Pipeline:
         try:
             # Perform core validation steps
             self._validate_file(unprocessed_file)
+
+            skip_decision = self._evaluate_exclusion_skip(task, unprocessed_file)
+            if skip_decision is not None:
+                if skip_decision.warning:
+                    message("warning", skip_decision.warning)
+                if skip_decision.excluded:
+                    self._record_exclusion_skip(
+                        run_record=run_record,
+                        task=task,
+                        unprocessed_file=unprocessed_file,
+                        result=skip_decision,
+                    )
+                    return
 
             # Extract dataset_name from task configuration if available
             # First check session configs (for tasks loaded via --task-file)

--- a/src/autoclean/core/task.py
+++ b/src/autoclean/core/task.py
@@ -11,6 +11,7 @@ import mne  # Core EEG processing library for data containers and processing
 
 from autoclean.io.export import save_epochs_to_set, save_raw_to_set
 from autoclean.io.import_ import import_eeg
+from autoclean.utils.exclusion_list import evaluate_exclusion_list
 from autoclean.utils.logging import message
 
 # Local imports
@@ -175,11 +176,12 @@ class Task(ABC, *DISCOVERED_MIXINS):
         """
 
         self.raw = import_eeg(self.config)
+        self._apply_exclusion_list_tag()
         if self.raw.duration < 60:
-            self.flagged = True
-            self.flagged_reasons = [
-                f"WARNING: Initial duration ({float(self.raw.duration):.1f}s) less than 1 minute"
-            ]
+            self._update_flagged_status(
+                flagged=True,
+                reason=f"WARNING: Initial duration ({float(self.raw.duration):.1f}s) less than 1 minute",
+            )
 
         self.create_bids_path()
 
@@ -201,6 +203,7 @@ class Task(ABC, *DISCOVERED_MIXINS):
         """
 
         self.epochs = import_eeg(self.config)
+        self._apply_exclusion_list_tag()
 
         self.create_bids_path(use_epochs=True)
 
@@ -210,6 +213,30 @@ class Task(ABC, *DISCOVERED_MIXINS):
             stage="post_import",
             flagged=self.flagged,
         )
+
+    def _apply_exclusion_list_tag(self) -> None:
+        """Tag recordings listed in a configured user exclusion table."""
+
+        is_enabled, config_value = self._check_step_enabled("exclusion_list")
+        if not is_enabled:
+            return
+
+        value = (config_value or {}).get("value") or {}
+        result = evaluate_exclusion_list(value, self.config.get("unprocessed_file", ""))
+        if result.mode != "tag":
+            return
+
+        self._update_metadata("step_exclusion_list", result.metadata)
+
+        if result.warning:
+            message("warning", result.warning)
+
+        if result.excluded:
+            reason = result.reason or "Recording matched exclusion list"
+            self._update_flagged_status(
+                flagged=True,
+                reason=f"EXCLUSION_LIST: {reason}",
+            )
 
     @abstractmethod
     @require_authentication

--- a/src/autoclean/utils/exclusion_list.py
+++ b/src/autoclean/utils/exclusion_list.py
@@ -1,0 +1,119 @@
+"""Helpers for applying user-provided recording exclusion lists."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from autoclean.utils.metadata_table import load_metadata_table, match_recording_row
+
+_TRUE_VALUES = {"1", "true", "yes", "y", "exclude", "excluded", "skip", "x"}
+_FALSE_VALUES = {"", "0", "false", "no", "n", "include", "included", "keep"}
+
+
+@dataclass(frozen=True)
+class ExclusionListResult:
+    """Resolved exclusion-list decision for one recording."""
+
+    mode: str
+    excluded: bool
+    reason: str | None
+    warning: str | None
+    metadata: dict[str, Any]
+
+
+def evaluate_exclusion_list(
+    config_value: dict[str, Any], recording_path: str | Path
+) -> ExclusionListResult:
+    """Evaluate a configured exclusion table for one recording.
+
+    ``tag`` mode flags and reports matching recordings while still processing them.
+    ``skip`` mode returns the same match decision so dispatch code can avoid
+    starting the task run at all.
+    """
+
+    table_path = config_value.get("path")
+    if not table_path:
+        raise ValueError("exclusion_list is enabled but no value.path was set")
+
+    mode = str(config_value.get("mode", "tag")).strip().casefold()
+    if mode not in {"tag", "skip"}:
+        raise ValueError("exclusion_list mode must be 'tag' or 'skip'.")
+
+    file_column = config_value.get("file_column", "file")
+    subject_column = config_value.get("subject_column")
+    session_column = config_value.get("session_column")
+    exclude_column = config_value.get("exclude_column", "exclude")
+    reason_column = config_value.get("reason_column", "reason")
+    strict = bool(config_value.get("strict", False))
+
+    rows = load_metadata_table(table_path, delimiter=config_value.get("delimiter"))
+    field_matches: dict[str, str] = {}
+    if subject_column and config_value.get("subject"):
+        field_matches[subject_column] = str(config_value["subject"])
+    if session_column and config_value.get("session"):
+        field_matches[session_column] = str(config_value["session"])
+
+    match = match_recording_row(
+        rows,
+        recording_path,
+        file_column=file_column,
+        field_matches=field_matches,
+    )
+
+    metadata: dict[str, Any] = {
+        "path": str(table_path),
+        "mode": mode,
+        "matched": False,
+        "matched_by": None,
+        "excluded": False,
+        "reason": None,
+    }
+
+    if match is None:
+        warning = f"No exclusion-list row matched input file {recording_path!s}"
+        if strict:
+            raise ValueError(warning)
+        metadata["warning"] = warning
+        return ExclusionListResult(
+            mode=mode,
+            excluded=False,
+            reason=None,
+            warning=warning,
+            metadata=metadata,
+        )
+
+    if exclude_column not in match.row:
+        raise ValueError(f"Exclusion list is missing exclude column {exclude_column!r}")
+
+    excluded = _parse_excluded(match.row.get(exclude_column), exclude_column)
+    reason = str(match.row.get(reason_column, "")).strip() or None
+
+    metadata.update(
+        {
+            "matched": True,
+            "matched_by": match.matched_by,
+            "excluded": excluded,
+            "reason": reason,
+        }
+    )
+    return ExclusionListResult(
+        mode=mode,
+        excluded=excluded,
+        reason=reason,
+        warning=None,
+        metadata=metadata,
+    )
+
+
+def _parse_excluded(value: object, column: str) -> bool:
+    text = "" if value is None else str(value).strip().casefold()
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    raise ValueError(
+        f"Exclusion list column {column!r} must contain a boolean-like value; "
+        f"got {value!r}."
+    )

--- a/src/autoclean/utils/metadata_table.py
+++ b/src/autoclean/utils/metadata_table.py
@@ -27,6 +27,9 @@ def load_metadata_table(
     if not table_path.exists():
         raise FileNotFoundError(f"Metadata table not found: {table_path}")
 
+    if table_path.suffix.lower() in {".xlsx", ".xls"}:
+        return _load_excel_metadata_table(table_path)
+
     resolved_delimiter = delimiter or _delimiter_for_path(table_path)
     with table_path.open("r", encoding="utf-8-sig", newline="") as handle:
         reader = csv.DictReader(handle, delimiter=resolved_delimiter)
@@ -35,14 +38,37 @@ def load_metadata_table(
 
         rows: list[dict[str, str]] = []
         for raw_row in reader:
-            rows.append(
-                {
-                    str(key).strip(): "" if value is None else str(value).strip()
-                    for key, value in raw_row.items()
-                    if key is not None
-                }
-            )
+            rows.append(_normalise_row(raw_row))
     return rows
+
+
+def _load_excel_metadata_table(path: Path) -> list[dict[str, str]]:
+    try:
+        import pandas as pd
+    except ImportError as exc:  # pragma: no cover - pandas is a project dependency
+        raise ImportError("Reading Excel metadata tables requires pandas.") from exc
+
+    try:
+        frame = pd.read_excel(path, dtype=str).fillna("")
+    except ImportError as exc:
+        raise ImportError(
+            "Reading Excel metadata tables requires an installed pandas Excel engine "
+            "such as openpyxl."
+        ) from exc
+
+    if frame.columns.empty:
+        raise ValueError(f"Metadata table has no header row: {path}")
+
+    frame.columns = [str(column).strip() for column in frame.columns]
+    return [_normalise_row(row) for row in frame.to_dict(orient="records")]
+
+
+def _normalise_row(row: Mapping[object, object]) -> dict[str, str]:
+    return {
+        str(key).strip(): "" if value is None else str(value).strip()
+        for key, value in row.items()
+        if key is not None
+    }
 
 
 def require_columns(rows: list[dict[str, str]], columns: Iterable[str]) -> None:

--- a/tests/config/test_schema_version.py
+++ b/tests/config/test_schema_version.py
@@ -139,3 +139,59 @@ def test_schema_accepts_bad_channel_log_block():
     }
 
     schema.validate(config)
+
+
+def test_schema_accepts_exclusion_list_block():
+    schema = _build_task_settings_schema()
+    config = {
+        "schema_version": SCHEMA_VERSION,
+        "montage": {"enabled": True, "value": None},
+        "resample_step": {"enabled": False, "value": None},
+        "filtering": {
+            "enabled": False,
+            "value": {
+                "l_freq": None,
+                "h_freq": None,
+                "notch_freqs": None,
+                "notch_widths": None,
+            },
+        },
+        "drop_outerlayer": {"enabled": False, "value": None},
+        "exclusion_list": {
+            "enabled": True,
+            "value": {
+                "path": "exclusions.csv",
+                "file_column": "file",
+                "subject_column": "subject",
+                "subject": "sub-01",
+                "session_column": "session",
+                "session": "ses-1",
+                "exclude_column": "exclude",
+                "reason_column": "reason",
+                "mode": "skip",
+                "strict": False,
+            },
+        },
+        "eog_step": {"enabled": False, "value": None},
+        "trim_step": {"enabled": False, "value": 0},
+        "crop_step": {"enabled": False, "value": {"start": 0, "end": None}},
+        "reference_step": {"enabled": False, "value": None},
+        "ICA": {"enabled": False, "value": {"method": "fastica"}},
+        "component_rejection": {
+            "enabled": False,
+            "method": "iclabel",
+            "value": {
+                "ic_flags_to_reject": [],
+                "ic_rejection_threshold": 0,
+            },
+        },
+        "epoch_settings": {
+            "enabled": False,
+            "value": {"tmin": None, "tmax": None},
+            "event_id": None,
+            "remove_baseline": {"enabled": False, "window": None},
+            "threshold_rejection": {"enabled": False, "volt_threshold": {}},
+        },
+    }
+
+    schema.validate(config)

--- a/tests/unit/core/test_task.py
+++ b/tests/unit/core/test_task.py
@@ -439,9 +439,6 @@ class TestTaskConcrete:
             task.get_epochs()
 
 
-
-
-
 @pytest.mark.skipif(not TASK_AVAILABLE, reason="Task module not available for import")
 class TestTaskMixinIntegration:
     """Test that Task correctly integrates with the mixin system."""
@@ -449,10 +446,13 @@ class TestTaskMixinIntegration:
     def test_task_inherits_from_all_discovered_mixins(self):
         """Task should be a subclass of every mixin returned by the discovery system."""
         for mixin in DISCOVERED_MIXINS:
-            assert issubclass(Task, mixin), f"Task should inherit from discovered mixin {mixin}"
+            assert issubclass(
+                Task, mixin
+            ), f"Task should inherit from discovered mixin {mixin}"
 
     def test_subclass_run_override_is_called(self):
         """A concrete subclass's run() should be what gets invoked, not Task.run."""
+
         class CustomTask(Task):
             def run(self):
                 return "custom implementation"
@@ -595,3 +595,66 @@ class TestTaskErrorHandling:
 
         with pytest.raises(TypeError):
             TestTask(invalid_config)
+
+
+@pytest.mark.skipif(not TASK_AVAILABLE, reason="Task module not available for import")
+def test_pipeline_records_exclusion_list_skip_without_task_start(
+    monkeypatch, tmp_path: Path
+):
+    from autoclean.core.pipeline import Pipeline
+
+    table = tmp_path / "exclusions.csv"
+    table.write_text(
+        "file,exclude,reason\nsubject01.set,yes,withdrawn\n",
+        encoding="utf-8",
+    )
+    input_file = tmp_path / "subject01.set"
+    input_file.write_text("placeholder", encoding="utf-8")
+
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.session_task_registry = {"dummy": object}
+    pipeline.session_task_configs = {
+        "dummy": {
+            "exclusion_list": {
+                "enabled": True,
+                "value": {"path": str(table), "mode": "skip"},
+            }
+        }
+    }
+
+    updates = []
+
+    def fake_manage_database(*, operation, run_record=None, update_record=None):
+        if operation == "store":
+            return 1
+        updates.append(
+            {
+                "operation": operation,
+                "run_record": run_record,
+                "update_record": update_record,
+            }
+        )
+        return None
+
+    monkeypatch.setattr("autoclean.core.pipeline.manage_database", fake_manage_database)
+    monkeypatch.setattr(
+        "autoclean.core.pipeline.get_current_user_for_audit", lambda: {}
+    )
+    monkeypatch.setattr(
+        "autoclean.core.pipeline.Pipeline._validate_file",
+        lambda self, file_path: None,
+    )
+
+    pipeline._entrypoint(input_file, "dummy")
+
+    status_update = next(
+        item["update_record"]
+        for item in updates
+        if item["operation"] == "update"
+        and item["update_record"]
+        and item["update_record"].get("status") == "skipped"
+    )
+    assert status_update["success"] is True
+    assert status_update["metadata"]["step_exclusion_list"]["mode"] == "skip"
+    assert status_update["metadata"]["skip_reason"] == "EXCLUSION_LIST: withdrawn"
+    assert any(item["operation"] == "add_access_log" for item in updates)

--- a/tests/unit/test_exclusion_list.py
+++ b/tests/unit/test_exclusion_list.py
@@ -1,0 +1,177 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from autoclean.core.task import Task
+from autoclean.utils.exclusion_list import evaluate_exclusion_list
+
+
+def _table(path: Path, contents: str) -> Path:
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+def test_exclusion_list_tags_matching_recording(tmp_path: Path) -> None:
+    table = _table(
+        tmp_path / "exclusions.csv",
+        "file,exclude,reason\nsubject01.set,yes,participant withdrew\n",
+    )
+
+    result = evaluate_exclusion_list({"path": str(table)}, tmp_path / "subject01.set")
+
+    assert result.excluded is True
+    assert result.reason == "participant withdrew"
+    assert result.warning is None
+    assert result.metadata["matched"] is True
+    assert result.metadata["matched_by"] == "file"
+
+
+def test_exclusion_list_keeps_non_excluded_recording(tmp_path: Path) -> None:
+    table = _table(
+        tmp_path / "exclusions.csv",
+        "file,exclude,reason\nsubject01.set,no,usable\n",
+    )
+
+    result = evaluate_exclusion_list({"path": str(table)}, tmp_path / "subject01.set")
+
+    assert result.excluded is False
+    assert result.reason == "usable"
+    assert result.metadata["excluded"] is False
+
+
+def test_exclusion_list_warns_when_unmatched_unless_strict(tmp_path: Path) -> None:
+    table = _table(
+        tmp_path / "exclusions.csv",
+        "file,exclude,reason\nother.set,yes,bad task\n",
+    )
+
+    result = evaluate_exclusion_list({"path": str(table)}, tmp_path / "subject01.set")
+
+    assert result.excluded is False
+    assert result.metadata["matched"] is False
+    assert "No exclusion-list row matched" in result.warning
+
+    with pytest.raises(ValueError, match="No exclusion-list row matched"):
+        evaluate_exclusion_list(
+            {"path": str(table), "strict": True}, tmp_path / "subject01.set"
+        )
+
+
+def test_exclusion_list_can_match_subject_and_session_fields(tmp_path: Path) -> None:
+    table = _table(
+        tmp_path / "exclusions.csv",
+        "file,subject,session,exclude,reason\n"
+        "ambiguous.set,sub-01,ses-1,no,include\n"
+        "ambiguous.set,sub-02,ses-1,yes,artifact\n",
+    )
+
+    result = evaluate_exclusion_list(
+        {
+            "path": str(table),
+            "subject_column": "subject",
+            "subject": "sub-02",
+            "session_column": "session",
+            "session": "ses-1",
+        },
+        tmp_path / "ambiguous.set",
+    )
+
+    assert result.excluded is True
+    assert result.reason == "artifact"
+    assert result.metadata["matched_by"] == "field"
+
+
+def test_exclusion_list_supports_skip_mode_decision(tmp_path: Path) -> None:
+    table = _table(
+        tmp_path / "exclusions.csv",
+        "file,exclude,reason\nsubject01.set,yes,skip me\n",
+    )
+
+    result = evaluate_exclusion_list(
+        {"path": str(table), "mode": "skip"}, tmp_path / "subject01.set"
+    )
+
+    assert result.mode == "skip"
+    assert result.excluded is True
+    assert result.reason == "skip me"
+
+
+class TestExclusionTask(Task):
+    def __init__(self, config, settings):
+        self.settings = settings
+        super().__init__(config)
+        self.metadata_log = []
+
+    def _update_metadata(self, operation, metadata_dict):
+        self.metadata_log.append((operation, metadata_dict))
+
+    def create_bids_path(self, *args, **kwargs):
+        return None
+
+    def run(self):
+        pass
+
+
+@patch("autoclean.core.task.save_raw_to_set")
+@patch("autoclean.core.task.import_eeg")
+def test_import_raw_applies_exclusion_tag_without_losing_short_duration_warning(
+    mock_import_eeg, mock_save_raw_to_set, tmp_path: Path
+) -> None:
+    table = _table(
+        tmp_path / "exclusions.csv",
+        "file,exclude,reason\nsubject01.set,yes,known artifact\n",
+    )
+    settings = {
+        "montage": {"enabled": False},
+        "exclusion_list": {"enabled": True, "value": {"path": str(table)}},
+    }
+    config = {
+        "run_id": "test_run_200",
+        "unprocessed_file": tmp_path / "subject01.set",
+        "task": "TestExclusionTask",
+    }
+    task = TestExclusionTask(config, settings)
+    mock_import_eeg.return_value = SimpleNamespace(duration=30.0)
+
+    task.import_raw()
+
+    assert task.flagged is True
+    assert "EXCLUSION_LIST: known artifact" in task.flagged_reasons
+    assert any("less than 1 minute" in reason for reason in task.flagged_reasons)
+    assert task.metadata_log[-1][0] == "step_exclusion_list"
+    assert task.metadata_log[-1][1]["excluded"] is True
+    mock_save_raw_to_set.assert_called_once()
+
+
+@patch("autoclean.core.task.save_raw_to_set")
+@patch("autoclean.core.task.import_eeg")
+def test_import_raw_ignores_skip_mode_because_pipeline_owns_dispatch_skip(
+    mock_import_eeg, mock_save_raw_to_set, tmp_path: Path
+) -> None:
+    table = _table(
+        tmp_path / "exclusions.csv",
+        "file,exclude,reason\nsubject01.set,yes,skip before task\n",
+    )
+    settings = {
+        "montage": {"enabled": False},
+        "exclusion_list": {
+            "enabled": True,
+            "value": {"path": str(table), "mode": "skip"},
+        },
+    }
+    config = {
+        "run_id": "test_run_200_skip",
+        "unprocessed_file": tmp_path / "subject01.set",
+        "task": "TestExclusionTask",
+    }
+    task = TestExclusionTask(config, settings)
+    mock_import_eeg.return_value = SimpleNamespace(duration=120.0)
+
+    task.import_raw()
+
+    assert task.flagged is False
+    assert task.flagged_reasons == []
+    assert task.metadata_log == []
+    mock_save_raw_to_set.assert_called_once()

--- a/tests/unit/utils/test_metadata_table.py
+++ b/tests/unit/utils/test_metadata_table.py
@@ -28,6 +28,20 @@ def test_load_metadata_table_infers_tsv(tmp_path: Path) -> None:
     assert rows == [{"file": "subject01", "bad_channels": "E3|E4"}]
 
 
+def test_load_metadata_table_reads_xlsx(tmp_path: Path) -> None:
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    table = tmp_path / "exclusions.xlsx"
+    pd.DataFrame(
+        [{"file": " subject01.set ", "exclude": " yes ", "reason": " artifact "}]
+    ).to_excel(table, index=False)
+
+    rows = load_metadata_table(table)
+
+    assert rows == [{"file": "subject01.set", "exclude": "yes", "reason": "artifact"}]
+
+
 def test_match_recording_row_by_filename_or_stem(tmp_path: Path) -> None:
     rows = [
         {"file": "other.set", "bad_channels": "E1"},


### PR DESCRIPTION
## Summary
- add reusable exclusion-list loading/matching helpers for CSV/TSV/XLSX metadata tables
- let pipeline/task config skip or tag matching recordings before task execution
- add focused schema, task, pipeline, and metadata table coverage

## Verification
- uv run --extra dev black --check changed #200 Python files
- uv run --extra dev isort --check-only changed #200 Python files
- uv run ruff check changed #200 Python files
- uv run --extra dev pytest tests\\unit\\test_exclusion_list.py tests\\unit\\utils\\test_metadata_table.py tests\\config\\test_schema_version.py tests\\unit\\core\\test_task.py -q --no-cov

Closes #200