### PR TITLE
fix: preserve pre-rejection data for ICA component reports

### DIFF
--- a/src/autoclean/mixins/signal_processing/ica.py
+++ b/src/autoclean/mixins/signal_processing/ica.py
@@ -406,6 +406,13 @@ class IcaMixin:
             meaning both `run_ica` and `classify_ica_components` have run.
         """
         message("header", "Applying ICA component rejection")
+        # Snapshot pre-rejection data so ICA reports can show original component
+        # activity/PSD even for components that get rejected below. Only do this
+        # when we're operating on self.raw (not an arbitrary externally-provided
+        # data object), since that's the object generate_ica_reports() reads from.
+
+        if data_to_clean is None:
+            self.raw_prerejection = self.raw.copy()
 
         if not hasattr(self, "final_ica") or self.final_ica is None:
             message(
@@ -513,6 +520,8 @@ class IcaMixin:
 
         # Determine data to clean
         target_data = data_to_clean if data_to_clean is not None else self.raw
+        
+    
         data_source_name = (
             "provided data object" if data_to_clean is not None else "self.raw"
         )

--- a/src/autoclean/mixins/signal_processing/ica.py
+++ b/src/autoclean/mixins/signal_processing/ica.py
@@ -406,13 +406,6 @@ class IcaMixin:
             meaning both `run_ica` and `classify_ica_components` have run.
         """
         message("header", "Applying ICA component rejection")
-        # Snapshot pre-rejection data so ICA reports can show original component
-        # activity/PSD even for components that get rejected below. Only do this
-        # when we're operating on self.raw (not an arbitrary externally-provided
-        # data object), since that's the object generate_ica_reports() reads from.
-
-        if data_to_clean is None:
-            self.raw_prerejection = self.raw.copy()
 
         if not hasattr(self, "final_ica") or self.final_ica is None:
             message(
@@ -520,8 +513,15 @@ class IcaMixin:
 
         # Determine data to clean
         target_data = data_to_clean if data_to_clean is not None else self.raw
-        
-    
+
+        # Snapshot pre-rejection data so ICA reports can show original component
+        # activity/PSD even for components that get rejected below. Only do this
+        # when we're operating on self.raw (not an arbitrary externally-provided
+        # data object), and only take the snapshot once per task instance so a
+        # second call can't overwrite it with already-partially-rejected data.
+        if data_to_clean is None and not hasattr(self, "raw_prerejection"):
+            self.raw_prerejection = self.raw.copy()
+
         data_source_name = (
             "provided data object" if data_to_clean is not None else "self.raw"
         )

--- a/src/autoclean/mixins/viz/ica.py
+++ b/src/autoclean/mixins/viz/ica.py
@@ -91,7 +91,7 @@ class ICAReportingMixin:
             - The method respects configuration settings via the `ica_full_plot_step` config
         """
         # Get raw and ICA from pipeline
-        raw = self.raw.copy()
+        raw = self._get_ica_report_data().copy()
         ica = self.final_ica
         ic_labels = self.ica_flags
 
@@ -300,7 +300,7 @@ class ICAReportingMixin:
             )
             return None
 
-        raw = self.raw
+        raw = self._get_ica_report_data()
         ica = self.final_ica
         ic_labels = getattr(self, "ica_flags", None)
         psd_fmax = self._resolve_psd_fmax()
@@ -597,6 +597,17 @@ class ICAReportingMixin:
             Cache statistics including size, entries, and utilization
         """
         return get_ica_cache_stats()
+    
+    def _get_ica_report_data(self):
+        """Return the data object to use for ICA report plotting.
+
+        Prefers the pre-rejection snapshot (if available) so that rejected
+        components still show their original activity/PSD instead of the
+        zeroed-out values left behind after ICA.apply() runs.
+        """
+        return getattr(self, "raw_prerejection", None) or self.raw
+
+
 
     def clear_ica_sources_cache(self):
         """Clear all cached ICA sources to free memory."""

--- a/src/autoclean/mixins/viz/ica.py
+++ b/src/autoclean/mixins/viz/ica.py
@@ -597,7 +597,7 @@ class ICAReportingMixin:
             Cache statistics including size, entries, and utilization
         """
         return get_ica_cache_stats()
-    
+
     def _get_ica_report_data(self):
         """Return the data object to use for ICA report plotting.
 
@@ -605,9 +605,8 @@ class ICAReportingMixin:
         components still show their original activity/PSD instead of the
         zeroed-out values left behind after ICA.apply() runs.
         """
-        return getattr(self, "raw_prerejection", None) or self.raw
-
-
+        snapshot = getattr(self, "raw_prerejection", None)
+        return snapshot if snapshot is not None else self.raw
 
     def clear_ica_sources_cache(self):
         """Clear all cached ICA sources to free memory."""

--- a/tests/integration/test_ica_prerejection_report.py
+++ b/tests/integration/test_ica_prerejection_report.py
@@ -58,7 +58,7 @@ def test_rejected_component_retains_activity_after_manual_rejection(
     """
     task = ica_integration_task
 
-   # Step 1 & 2: Real ICA fit + manual rejection, with database writes
+    # Step 1 & 2: Real ICA fit + manual rejection, with database writes
     # patched out (this test cares about ICA data flow, not persistence).
     with patch("autoclean.utils.database.manage_database", return_value=None):
         task.run_ica()

--- a/tests/integration/test_ica_prerejection_report.py
+++ b/tests/integration/test_ica_prerejection_report.py
@@ -1,0 +1,90 @@
+"""Integration test: rejected ICA components retain real activity for reporting.
+
+Regression test for the bug where rejected ICA component report pages showed
+blank/flat diagnostic panels. Root cause: ICA.apply() mutates self.raw in
+place, zeroing out rejected components' contribution to the signal, and the
+report generator read from self.raw *after* that mutation. The fix snapshots
+self.raw before rejection runs and points report generation at that snapshot.
+"""
+
+from typing import Any, Dict
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from autoclean.core.task import Task
+from tests.fixtures.synthetic_data import create_synthetic_raw
+
+
+class _ICAIntegrationTask(Task):
+    """Minimal real Task exposing ICA fit/rejection/reporting for integration testing."""
+
+    def run(self):
+        pass
+
+
+@pytest.fixture
+def ica_integration_task(tmp_path):
+    settings: Dict[str, Any] = {
+        "ICA": {
+            "enabled": True,
+            "value": {
+                "n_components": 5,
+                "method": "fastica",
+                "max_iter": 500,
+            },
+        }
+    }
+    config = {
+        "run_id": "ica-prerejection-integration-test",
+        "unprocessed_file": tmp_path / "test.fif",
+        "task": "ica-prerejection-integration-test",
+        "tasks": {"ica-prerejection-integration-test": {"settings": settings}},
+    }
+    task = _ICAIntegrationTask(config)
+    task.raw = create_synthetic_raw(
+        montage="standard_1020", n_channels=16, duration=30.0, sfreq=250.0
+    )
+    return task
+
+
+def test_rejected_component_retains_activity_after_manual_rejection(
+    ica_integration_task,
+):
+    """After a real ICA fit + manual rejection, the rejected component's real
+    activity should still be recoverable from the pre-rejection snapshot,
+    even though it is zeroed out in self.raw itself.
+    """
+    task = ica_integration_task
+
+   # Step 1 & 2: Real ICA fit + manual rejection, with database writes
+    # patched out (this test cares about ICA data flow, not persistence).
+    with patch("autoclean.utils.database.manage_database", return_value=None):
+        task.run_ica()
+        assert task.final_ica is not None
+        assert task.final_ica.n_components_ == 5
+
+        # Reject component 0 manually, skipping classification entirely
+        task.apply_ica_component_rejection(manual_rejected_components=[0])
+
+    # Step 3: Confirm the pre-rejection snapshot exists and is a distinct object
+    assert hasattr(task, "raw_prerejection")
+    assert task.raw_prerejection is not None
+    assert task.raw_prerejection is not task.raw
+
+    # Step 4: Extract component 0's source activity from both versions
+    sources_prerejection = task.final_ica.get_sources(task.raw_prerejection)
+    sources_postrejection = task.final_ica.get_sources(task.raw)
+
+    prerejection_component_0 = sources_prerejection.get_data()[0]
+    postrejection_component_0 = sources_postrejection.get_data()[0]
+
+    # The actual bug assertion: pre-rejection data must retain real variance,
+    # while self.raw (post-rejection) collapses to ~0 for the rejected IC.
+    assert np.var(prerejection_component_0) > 1e-10
+    assert np.var(postrejection_component_0) < 1e-10
+
+    # Step 5: Confirm the reporting helper selects the correct data source
+    report_data = task._get_ica_report_data()
+    assert report_data is task.raw_prerejection

--- a/tests/unit/mixins/test_ica.py
+++ b/tests/unit/mixins/test_ica.py
@@ -197,6 +197,27 @@ class TestApplyICAComponentRejection:
 
         mock_ica.apply.assert_not_called()  # Nothing applied when disabled
 
+class TestGetIcaReportData:
+    def test_uses_prerejection_snapshot_when_present(self, task):
+        """Report data should come from the pre-rejection snapshot, not self.raw."""
+        original_raw = task.raw
+        task.raw_prerejection = original_raw.copy()
+
+        # Mutate self.raw to simulate what ica.apply() does in place
+        task.raw._data[:] = 0
+
+        result = task._get_ica_report_data()
+
+        assert result is task.raw_prerejection
+        assert not np.allclose(result.get_data(), task.raw.get_data())
+
+    def test_falls_back_to_raw_when_no_snapshot(self, task):
+        """Without a snapshot, report data should just be self.raw."""
+        assert not hasattr(task, "raw_prerejection")
+
+        result = task._get_ica_report_data()
+
+        assert result is task.raw
 
 # ---------------------------------------------------------------------------
 # classify_ica_components

--- a/tests/unit/mixins/test_ica.py
+++ b/tests/unit/mixins/test_ica.py
@@ -18,9 +18,7 @@ except ImportError:
     TASK_AVAILABLE = False
 
 
-pytestmark = pytest.mark.skipif(
-    not TASK_AVAILABLE, reason="Task module not available"
-)
+pytestmark = pytest.mark.skipif(not TASK_AVAILABLE, reason="Task module not available")
 
 
 class _ICATask(Task):
@@ -128,12 +126,11 @@ class TestApplyICAComponentRejection:
         mock_ica.apply = MagicMock()
         task.final_ica = mock_ica
 
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_auto_export_if_enabled"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_auto_export_if_enabled"),
         ):
-            task.apply_ica_component_rejection(
-                manual_rejected_components=[0, 2]
-            )
+            task.apply_ica_component_rejection(manual_rejected_components=[0, 2])
 
         assert task.final_ica.exclude == [0, 2]
         mock_ica.apply.assert_called_once()
@@ -144,8 +141,9 @@ class TestApplyICAComponentRejection:
         mock_ica.apply = MagicMock()
         task.final_ica = mock_ica
 
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_auto_export_if_enabled"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_auto_export_if_enabled"),
         ):
             task.apply_ica_component_rejection(manual_rejected_components=[])
 
@@ -157,8 +155,9 @@ class TestApplyICAComponentRejection:
         mock_ica.apply = MagicMock()
         task.final_ica = mock_ica
 
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_auto_export_if_enabled"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_auto_export_if_enabled"),
         ):
             task.apply_ica_component_rejection(
                 manual_rejected_components=[3, 1, 1, 3, 0]
@@ -197,6 +196,7 @@ class TestApplyICAComponentRejection:
 
         mock_ica.apply.assert_not_called()  # Nothing applied when disabled
 
+
 class TestGetIcaReportData:
     def test_uses_prerejection_snapshot_when_present(self, task):
         """Report data should come from the pre-rejection snapshot, not self.raw."""
@@ -218,6 +218,7 @@ class TestGetIcaReportData:
         result = task._get_ica_report_data()
 
         assert result is task.raw
+
 
 # ---------------------------------------------------------------------------
 # classify_ica_components
@@ -248,9 +249,7 @@ class TestClassifyICAComponents:
         assert result is None
 
     @patch("autoclean.mixins.signal_processing.ica.classify_ica_components")
-    def test_calls_classification_function_and_stores_flags(
-        self, mock_classify, task
-    ):
+    def test_calls_classification_function_and_stores_flags(self, mock_classify, task):
         """After classify, self.ica_flags is the DataFrame returned by the function."""
         mock_flags = pd.DataFrame({"label": ["brain", "eye blink"]})
         mock_classify.return_value = mock_flags
@@ -375,9 +374,7 @@ class TestRunICASettings:
 
     @patch("autoclean.mixins.signal_processing.ica.save_ica_to_fif")
     @patch("autoclean.mixins.signal_processing.ica.fit_ica")
-    def test_run_ica_uses_method_from_settings(
-        self, mock_fit, mock_save_fif, tmp_path
-    ):
+    def test_run_ica_uses_method_from_settings(self, mock_fit, mock_save_fif, tmp_path):
         """method from settings[ICA][value] must be forwarded to fit_ica."""
         settings = {
             "ICA": {
@@ -404,9 +401,7 @@ class TestRunICASettings:
 
     @patch("autoclean.mixins.signal_processing.ica.save_ica_to_fif")
     @patch("autoclean.mixins.signal_processing.ica.fit_ica")
-    def test_run_ica_saves_post_ica_stage_file(
-        self, mock_fit, mock_save_fif, task
-    ):
+    def test_run_ica_saves_post_ica_stage_file(self, mock_fit, mock_save_fif, task):
         """save_ica_to_fif must be called after a successful fit."""
         mock_fit.return_value = _make_mock_ica()
 
@@ -454,8 +449,6 @@ class TestApplyICAStageFile:
             patch.object(task, "_update_metadata"),
             patch.object(task, "_auto_export_if_enabled") as mock_export,
         ):
-            task.apply_ica_component_rejection(
-                manual_rejected_components=[0]
-            )
+            task.apply_ica_component_rejection(manual_rejected_components=[0])
 
         mock_export.assert_called_once()

--- a/tests/unit/test_apply_ica_component_rejection_manual_override.py
+++ b/tests/unit/test_apply_ica_component_rejection_manual_override.py
@@ -47,7 +47,6 @@ class DummyICATask(IcaMixin, BaseMixin):
     def _auto_export_if_enabled(self, *args, **kwargs):
         # Disable export side effects during tests
         return None
-    
 
 
 @pytest.fixture
@@ -105,6 +104,7 @@ def test_manual_ica_override_empty_list(monkeypatch, dummy_raw):
     assert nested["method"] == "ManualOverride"
     assert nested["final_excluded_indices"] == []
 
+
 def test_prerejection_snapshot_created_before_apply(monkeypatch, dummy_raw):
     task = DummyICATask(dummy_raw)
 
@@ -129,9 +129,7 @@ def test_prerejection_snapshot_created_before_apply(monkeypatch, dummy_raw):
     assert task.raw_prerejection is not task.raw
 
     # Its data should match what self.raw contained before rejection ran
-    np.testing.assert_array_equal(
-        task.raw_prerejection.get_data(), original_data
-    )
+    np.testing.assert_array_equal(task.raw_prerejection.get_data(), original_data)
 
     # The actual rejection should still have been applied to self.raw itself
     assert task.final_ica.applied_to == [task.raw]

--- a/tests/unit/test_apply_ica_component_rejection_manual_override.py
+++ b/tests/unit/test_apply_ica_component_rejection_manual_override.py
@@ -47,6 +47,7 @@ class DummyICATask(IcaMixin, BaseMixin):
     def _auto_export_if_enabled(self, *args, **kwargs):
         # Disable export side effects during tests
         return None
+    
 
 
 @pytest.fixture
@@ -103,3 +104,34 @@ def test_manual_ica_override_empty_list(monkeypatch, dummy_raw):
     nested = metadata["ica"]
     assert nested["method"] == "ManualOverride"
     assert nested["final_excluded_indices"] == []
+
+def test_prerejection_snapshot_created_before_apply(monkeypatch, dummy_raw):
+    task = DummyICATask(dummy_raw)
+
+    auto_rejection_mock = MagicMock()
+    monkeypatch.setattr(
+        "autoclean.mixins.signal_processing.ica.apply_ica_component_rejection",
+        auto_rejection_mock,
+    )
+    monkeypatch.setattr(ica_module, "CACHE_AVAILABLE", False)
+
+    original_data = task.raw.get_data().copy()
+
+    task.apply_ica_component_rejection(
+        manual_rejected_components=[0],
+    )
+
+    # A pre-rejection snapshot should now exist
+    assert hasattr(task, "raw_prerejection")
+    assert task.raw_prerejection is not None
+
+    # It must be a distinct object, not the same reference as self.raw
+    assert task.raw_prerejection is not task.raw
+
+    # Its data should match what self.raw contained before rejection ran
+    np.testing.assert_array_equal(
+        task.raw_prerejection.get_data(), original_data
+    )
+
+    # The actual rejection should still have been applied to self.raw itself
+    assert task.final_ica.applied_to == [task.raw]


### PR DESCRIPTION
Rejected ICA components were showing blank/flat continuous-data and PSD panels in generated report PDFs. This happened because ICA.apply() mutates self.raw in place, zeroing out rejected components' contribution before generate_ica_reports() ran against that same self.raw object.

This fix snapshots self.raw (as self.raw_prerejection) at the top of apply_ica_component_rejection(), before any rejection is applied, and adds a _get_ica_report_data() helper in the reporting mixin that prefers this snapshot over self.raw when generating report plots. Rejected components are still correctly marked as rejected in the report tables; only their diagnostic panels now reflect real pre-rejection activity instead of zeroed-out data.

Tests added:
- Unit tests confirming the snapshot is created, is a real independent copy, and does not interfere with rejection itself
- Unit tests confirming _get_ica_report_data() prefers the snapshot when present and falls back to self.raw otherwise
- An integration test that fits a real ICA, rejects a component, and directly measures via ica.get_sources() that the rejected component's variance collapses in self.raw but is preserved in self.raw_prerejection

Fixes #224

## Summary

Rejected ICA components were showing blank/flat continuous-data and PSD
panels in generated report PDFs, even though the topography and
classification table still rendered correctly.

## Root cause

`ICA.apply()` mutates the target data object in place, zeroing out the
contribution of rejected components. `apply_ica_component_rejection()`
applies this directly to `self.raw`, and `generate_ica_reports()` runs
*after* that mutation, reading from the same now-mutated `self.raw`.
Any component recomputed for reporting after rejection has no real
signal left, producing the flat/blank panels described in the issue.

## Fix

- `apply_ica_component_rejection()` now snapshots `self.raw` as
  `self.raw_prerejection` at the very start of the method, before any
  rejection (manual or automatic) is applied.
- A new `_get_ica_report_data()` helper in `ICAReportingMixin` prefers
  this snapshot when generating report plots (`_plot_ica_components`,
  `plot_ica_full`), falling back to `self.raw` if no snapshot exists
  (e.g. rejection was never run).
- Rejected components are still correctly labeled as rejected in the
  report tables/overlays; only the diagnostic panels themselves now
  reflect real pre-rejection activity instead of zeroed data.

## Testing

- **Unit** (`tests/unit/test_apply_ica_component_rejection_manual_override.py`):
  confirms the snapshot is created, is a genuinely distinct copy (not
  an alias), and doesn't interfere with the actual rejection applied to
  `self.raw`.
- **Unit** (`tests/unit/mixins/test_ica.py`): confirms
  `_get_ica_report_data()` returns the snapshot when present and falls
  back to `self.raw` when it isn't.
- **Integration** (`tests/integration/test_ica_prerejection_report.py`):
  fits a real ICA on synthetic EEG data, manually rejects a component,
  and directly measures via `ica.get_sources()` that the rejected
  component's variance collapses to ~0 in `self.raw` but is preserved
  in `self.raw_prerejection` — reproducing the actual bug mechanism and
  proving the fix resolves it.

All existing ICA-related tests (unit, function-level, and mixin tests)
continue to pass unchanged; this is an additive fix.