### PR TITLE
fix: skip generated built-in reference task copies during custom disc…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 25.9.0
     hooks:
       - id: black
         args: [--line-length=88]

--- a/src/autoclean/utils/task_discovery.py
+++ b/src/autoclean/utils/task_discovery.py
@@ -68,6 +68,9 @@ class TaskOverride(NamedTuple):
 
 # Folder names under the workspace tasks directory that are reserved for
 # generated/reference content and must never be discovered as user tasks.
+# "builtin" is the actual folder _copy_builtin_tasks() writes reference copies
+# to; ".cache" and "__pycache__" aren't created there today but are excluded
+# preemptively since nothing under them should ever be a real user task.
 RESERVED_TASK_DISCOVERY_DIRS = {"builtin", ".cache", "__pycache__"}
 
 

--- a/src/autoclean/utils/task_discovery.py
+++ b/src/autoclean/utils/task_discovery.py
@@ -66,6 +66,11 @@ class TaskOverride(NamedTuple):
     description: str
 
 
+# Folder names under the workspace tasks directory that are reserved for
+# generated/reference content and must never be discovered as user tasks.
+RESERVED_TASK_DISCOVERY_DIRS = {"builtin", ".cache", "__pycache__"}
+
+
 def _extract_task_description(task_class: Type[Task]) -> str:
     """Extract a clean description from a task's docstring."""
     if not task_class.__doc__:
@@ -175,6 +180,17 @@ def _discover_custom_tasks() -> (
 
     # Scan for Python files recursively (including subdirectories)
     for task_file in user_config.tasks_dir.rglob("*.py"):
+        # Skip generated built-in/reference task copies stored under a reserved
+        # subfolder (e.g. tasks/builtin/) so they aren't discovered as user tasks
+        relative_parts = task_file.relative_to(user_config.tasks_dir).parts
+        if RESERVED_TASK_DISCOVERY_DIRS.intersection(relative_parts):
+            skipped_files.append(
+                SkippedTaskFile(
+                    source=str(task_file),
+                    reason="Generated built-in reference task",
+                )
+            )
+            continue
         # Skip macOS resource fork files, private files, templates, and test fixtures
         if task_file.name.startswith("._"):
             skipped_files.append(
@@ -327,23 +343,20 @@ def safe_discover_tasks() -> (
         else:
             # Found duplicate - workspace task overrides built-in task
             existing_task = seen_names[task.name]
-            existing_source = Path(existing_task.source).name
             override_source = Path(task.source).name
 
             # Determine if this is a workspace override of a built-in task
             # Check if sources are workspace vs built-in by checking if they're in the workspace tasks dir
-            existing_is_workspace = (
-                USER_CONFIG_AVAILABLE
-                and str(existing_task.source).startswith(str(user_config.tasks_dir))
-            )
-            current_is_workspace = (
-                USER_CONFIG_AVAILABLE
-                and str(task.source).startswith(str(user_config.tasks_dir))
-            )
+            existing_is_workspace = USER_CONFIG_AVAILABLE and str(
+                existing_task.source
+            ).startswith(str(user_config.tasks_dir))
+            current_is_workspace = USER_CONFIG_AVAILABLE and str(
+                task.source
+            ).startswith(str(user_config.tasks_dir))
             # If it's not a workspace task, it's a built-in task (since we discover custom tasks first)
             existing_is_builtin = not existing_is_workspace
             current_is_builtin = not current_is_workspace
-            
+
             if existing_is_workspace and current_is_builtin:
                 # Workspace task is already loaded, built-in task is being skipped
                 # This is expected behavior - workspace tasks override built-in ones
@@ -363,10 +376,10 @@ def safe_discover_tasks() -> (
                 if task.name not in duplicate_workspace_tasks:
                     duplicate_workspace_tasks[task.name] = [existing_task]
                 duplicate_workspace_tasks[task.name].append(task)
-                
+
                 # Remove the first occurrence from unique_tasks since it's actually a duplicate
                 unique_tasks = [t for t in unique_tasks if t.name != task.name]
-                
+
                 # Flag the second file as invalid (first will be flagged after the loop)
                 override_info.append(
                     InvalidTaskFile(
@@ -374,7 +387,7 @@ def safe_discover_tasks() -> (
                         error=f"Duplicate task definition detected. Class '{task.name}' exists in multiple files. Update the class name in {override_source} to a unique value.",
                     )
                 )
-    
+
     # Flag the first file in each duplicate pair (after loop to avoid double-processing)
     for task_name, duplicate_files in duplicate_workspace_tasks.items():
         if len(duplicate_files) > 1:

--- a/tests/unit/test_task_discovery.py
+++ b/tests/unit/test_task_discovery.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 from autoclean.utils.task_discovery import (
     DiscoveredTask,
     InvalidTaskFile,
@@ -131,7 +130,9 @@ class DuplicateTask(Task):
     # picking an arbitrary file.
     duplicate_tasks = [t for t in valid_tasks if t.name == "DuplicateTask"]
     assert duplicate_tasks == []
-    duplicate_errors = [f for f in invalid_files if "Duplicate task definition" in f.error]
+    duplicate_errors = [
+        f for f in invalid_files if "Duplicate task definition" in f.error
+    ]
     assert len(duplicate_errors) >= 2
 
 
@@ -231,9 +232,7 @@ class NormalTask(Task):
 
     custom_tasks = [t for t in valid_tasks if str(tasks_dir) in t.source]
     skipped_sources = {Path(entry.source).name for entry in skipped_files}
-    skipped_reasons = {
-        Path(entry.source).name: entry.reason for entry in skipped_files
-    }
+    skipped_reasons = {Path(entry.source).name: entry.reason for entry in skipped_files}
 
     assert [task.name for task in custom_tasks] == ["NormalTask"]
     assert "._resource_task.py" in skipped_sources
@@ -242,6 +241,65 @@ class NormalTask(Task):
         == "macOS resource fork file (starts with '._')"
     )
     assert not any("._resource_task.py" in entry.source for entry in invalid_files)
+
+
+def test_reserved_builtin_folder_skipped(monkeypatch, tmp_path):
+    """Files under a reserved built-in/reference subfolder are skipped, not loaded."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+
+    # Real user task, nested a level deep - should still be discovered.
+    nested_dir = tasks_dir / "custom"
+    nested_dir.mkdir()
+    nested_task = nested_dir / "MyCustomTask.py"
+    nested_task.write_text(
+        """
+from autoclean.core.task import Task
+
+class MyCustomTask(Task):
+    def run(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+
+    # Generated built-in reference copies under tasks/builtin/ - should be skipped.
+    builtin_dir = tasks_dir / "builtin"
+    builtin_dir.mkdir()
+    builtin_task = builtin_dir / "RestingEyesOpen.py"
+    builtin_task.write_text(
+        """
+from autoclean.core.task import Task
+
+class RestingEyesOpen(Task):
+    def run(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "autoclean.utils.user_config.user_config.tasks_dir",
+        tasks_dir,
+    )
+
+    valid_tasks, invalid_files, skipped_files = safe_discover_tasks()
+
+    custom_tasks = [t for t in valid_tasks if str(tasks_dir) in t.source]
+    task_names = {t.name for t in custom_tasks}
+
+    # Real user task discovered recursively.
+    assert "MyCustomTask" in task_names
+    # Built-in reference copy not treated as a user task.
+    assert "RestingEyesOpen" not in task_names
+
+    skipped_reasons = {Path(entry.source).name: entry.reason for entry in skipped_files}
+    assert (
+        skipped_reasons.get("RestingEyesOpen.py") == "Generated built-in reference task"
+    )
+
+    # Skipped, not flagged as invalid.
+    assert not any("RestingEyesOpen.py" in entry.source for entry in invalid_files)
 
 
 def test_error_messages_are_helpful(monkeypatch, tmp_path):


### PR DESCRIPTION

Files under a reserved workspace tasks subfolder (builtin, .cache, __pycache__) were being discovered as user custom tasks, cluttering task lists with generated reference copies. These are now reported as skipped rather than loaded or flagged invalid.

Also bumps the black pre-commit hook to 25.9.0 to match the pyproject.toml/CI pin (23.12.1 doesn't support target-version py313) and drops an unused local variable flagged by ruff, both needed to get pre-commit hooks passing on this branch.

## Summary
  - Custom task discovery no longer treats files under reserved subfolders (`builtin`, `.cache`, `__pycache__`) of the workspace tasks directory as user tasks; they're now reported as skipped with reason "Generated
  built-in reference task".
  - Real user tasks nested in other subfolders continue to be discovered recursively as before.
  - Bumped the `black` pre-commit hook to `25.9.0` to match the `pyproject.toml`/CI pin (the prior `23.12.1` pin doesn't support `target-version = py313`), and removed an unused local variable flagged by `ruff` —
  both were blocking pre-commit hooks on this branch, unrelated to the discovery fix itself.

  ## Test plan
  - [x] `pytest tests/unit/test_task_discovery.py -q` — 9 passed, including new `test_reserved_builtin_folder_skipped`
  - [x] Pre-commit hooks (black/isort/ruff) pass on the changed files