### PR TITLE
218 bug support ica on epoched data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 25.9.0
     hooks:
       - id: black
         args: [--line-length=88]

--- a/src/autoclean/functions/ica/ica_processing.py
+++ b/src/autoclean/functions/ica/ica_processing.py
@@ -25,7 +25,7 @@ except ImportError:
 
 
 def fit_ica(
-    raw: mne.io.Raw,
+    raw: Union[mne.io.BaseRaw, mne.BaseEpochs],
     n_components: Optional[int] = None,
     method: str = "fastica",
     max_iter: Union[int, str] = "auto",
@@ -42,8 +42,8 @@ def fit_ica(
 
     Parameters
     ----------
-    raw : mne.io.Raw
-        The raw EEG data to decompose with ICA.
+    raw : mne.io.Raw | mne.BaseEpochs
+        The raw or epoched EEG data to decompose with ICA.
     n_components : int or None, default None
         Number of principal components to use. If None, uses all available
         components based on the data rank.
@@ -77,8 +77,10 @@ def fit_ica(
     mne.preprocessing.ICA : MNE ICA implementation
     """
     # Input validation
-    if not isinstance(raw, mne.io.BaseRaw):
-        raise TypeError(f"Data must be an MNE Raw object, got {type(raw).__name__}")
+    if not isinstance(raw, (mne.io.BaseRaw, mne.BaseEpochs)):
+        raise TypeError(
+            f"Data must be an MNE Raw or Epochs object, got {type(raw).__name__}"
+        )
 
     if method not in ["fastica", "infomax", "picard"]:
         raise ValueError(
@@ -121,7 +123,7 @@ def fit_ica(
 
 
 def classify_ica_components(
-    raw: mne.io.Raw,
+    raw: Union[mne.io.BaseRaw, mne.BaseEpochs],
     ica: ICA,
     method: str = "iclabel",
     verbose: Optional[bool] = None,
@@ -135,8 +137,8 @@ def classify_ica_components(
 
     Parameters
     ----------
-    raw : mne.io.Raw
-        The raw EEG data used for ICA fitting.
+    raw : mne.io.Raw | mne.BaseEpochs
+        The raw or epoched EEG data used for ICA fitting.
     ica : mne.preprocessing.ICA
         The fitted ICA object to classify.
     method : str, default "iclabel"
@@ -175,8 +177,10 @@ def classify_ica_components(
     mne_icalabel.label_components : ICLabel implementation
     """
     # Input validation
-    if not isinstance(raw, mne.io.BaseRaw):
-        raise TypeError(f"Raw data must be an MNE Raw object, got {type(raw).__name__}")
+    if not isinstance(raw, (mne.io.BaseRaw, mne.BaseEpochs)):
+        raise TypeError(
+            f"Data must be an MNE Raw or Epochs object, got {type(raw).__name__}"
+        )
 
     if not isinstance(ica, ICA):
         raise TypeError(f"ICA must be an MNE ICA object, got {type(ica).__name__}")
@@ -274,7 +278,9 @@ def classify_ica_components(
             # Default to strip layout for ~88% API cost reduction
             icvision_kwargs = {"layout": "strip", **kwargs}  # Allow user override
             try:
-                label_components(raw, ica, component_indices=component_indices, **icvision_kwargs)
+                label_components(
+                    raw, ica, component_indices=component_indices, **icvision_kwargs
+                )
 
                 # Prepare containers for vision-only metadata
                 vision_ic_type = [None] * n_comp
@@ -300,7 +306,8 @@ def classify_ica_components(
                 # Build merged confidence matrix: start from ICLabel scores, then replace subset rows with ICVision
                 # If ICLabel didn't provide scores, initialize to ones
                 if iclabel_scores is None or (
-                    hasattr(iclabel_scores, "shape") and iclabel_scores.shape[0] != n_comp
+                    hasattr(iclabel_scores, "shape")
+                    and iclabel_scores.shape[0] != n_comp
                 ):
                     # Initialize with 1.0 confidence for lack of better info
                     merged_scores = _np.ones((n_comp, 7), dtype=float)
@@ -321,7 +328,9 @@ def classify_ica_components(
                                 vision_confidence[comp_idx] = max_prob
                                 # Ensure number of classes aligns; if not, take max prob only
                                 if icvision_scores.shape[1] == merged_scores.shape[1]:
-                                    merged_scores[comp_idx, :] = icvision_scores[row_idx, :]
+                                    merged_scores[comp_idx, :] = icvision_scores[
+                                        row_idx, :
+                                    ]
                                 else:
                                     # Fallback: keep existing distribution but update max/confidence
                                     merged_scores[comp_idx, :] = max_prob
@@ -393,12 +402,12 @@ def classify_ica_components(
 
 
 def apply_ica_rejection(
-    raw: mne.io.Raw,
+    raw: Union[mne.io.BaseRaw, mne.BaseEpochs],
     ica: ICA,
     components_to_reject: List[int],
     copy: bool = True,
     verbose: Optional[bool] = None,
-) -> mne.io.Raw:
+) -> Union[mne.io.BaseRaw, mne.BaseEpochs]:
     """Apply ICA to remove specified components from EEG data.
 
     This function applies the ICA transformation to remove specified artifact
@@ -406,8 +415,8 @@ def apply_ica_rejection(
 
     Parameters
     ----------
-    raw : mne.io.Raw
-        The raw EEG data to clean.
+    raw : mne.io.Raw | mne.BaseEpochs
+        The raw or epoched EEG data to clean.
     ica : mne.preprocessing.ICA
         The fitted ICA object.
     components_to_reject : list of int
@@ -419,7 +428,7 @@ def apply_ica_rejection(
 
     Returns
     -------
-    raw_cleaned : mne.io.Raw
+    raw_cleaned : mne.io.Raw | mne.BaseEpochs
         The cleaned EEG data with artifact components removed.
 
     Examples
@@ -433,8 +442,10 @@ def apply_ica_rejection(
     mne.preprocessing.ICA.apply : Apply ICA transformation
     """
     # Input validation
-    if not isinstance(raw, mne.io.BaseRaw):
-        raise TypeError(f"Raw data must be an MNE Raw object, got {type(raw).__name__}")
+    if not isinstance(raw, (mne.io.BaseRaw, mne.BaseEpochs)):
+        raise TypeError(
+            f"Data must be an MNE Raw or Epochs object, got {type(raw).__name__}"
+        )
 
     if not isinstance(ica, ICA):
         raise TypeError(f"ICA must be an MNE ICA object, got {type(ica).__name__}")
@@ -580,14 +591,14 @@ def _attach_source_metadata(
 
 
 def apply_ica_component_rejection(
-    raw: mne.io.Raw,
+    raw: Union[mne.io.BaseRaw, mne.BaseEpochs],
     ica: ICA,
     labels_df: pd.DataFrame,
     ic_flags_to_reject: List[str] = ["eog", "muscle", "ecg"],
     ic_rejection_threshold: float = 0.8,
     ic_rejection_overrides: Optional[Dict[str, float]] = None,
     verbose: Optional[bool] = None,
-) -> tuple[mne.io.Raw, List[int]]:
+) -> tuple[Union[mne.io.BaseRaw, mne.BaseEpochs], List[int]]:
     """Apply ICA rejection based on component classifications and criteria.
 
     This function combines the classification results with rejection criteria
@@ -596,8 +607,8 @@ def apply_ica_component_rejection(
 
     Parameters
     ----------
-    raw : mne.io.Raw
-        The raw EEG data to clean.
+    raw : mne.io.Raw | mne.BaseEpochs
+        The raw or epoched EEG data to clean.
     ica : mne.preprocessing.ICA
         The fitted ICA object with component classifications.
     labels_df : pd.DataFrame

--- a/src/autoclean/io/export.py
+++ b/src/autoclean/io/export.py
@@ -708,8 +708,8 @@ def save_ica_to_fif(ica, autoclean_dict, pre_ica_raw):
             ICA object
         autoclean_dict : dict
             Autoclean dictionary
-        pre_ica_raw : mne.io.Raw
-            Raw data before ICA
+        pre_ica_raw : mne.io.Raw | mne.BaseEpochs
+            Raw or epoched data before ICA
     """
     try:
         _derivatives_dir = Path(autoclean_dict["derivatives_dir"])
@@ -743,7 +743,10 @@ def save_ica_to_fif(ica, autoclean_dict, pre_ica_raw):
         components.append(ch for ch in ica.exclude)
 
     # Use standard pipeline saving for pre_ica data
-    pre_ica_path = save_raw_to_set(pre_ica_raw, autoclean_dict, stage="pre_ica")
+    if isinstance(pre_ica_raw, mne.BaseEpochs):
+        pre_ica_path = save_epochs_to_set(pre_ica_raw, autoclean_dict, stage="pre_ica")
+    else:
+        pre_ica_path = save_raw_to_set(pre_ica_raw, autoclean_dict, stage="pre_ica")
     metadata = {
         "save_ica_to_fif": {
             "creationDateTime": datetime.now().isoformat(),

--- a/src/autoclean/mixins/signal_processing/ica.py
+++ b/src/autoclean/mixins/signal_processing/ica.py
@@ -167,6 +167,7 @@ class IcaMixin:
                 "ica_kwargs": ica_kwargs,
                 "ica_components": self.final_ica.n_components_,
                 "temp_highpass_for_ica": temp_highpass_for_ica,
+                "ica_fit_data_type": "epochs" if use_epochs else "raw",
             }
         }
 

--- a/src/autoclean/mixins/signal_processing/ica.py
+++ b/src/autoclean/mixins/signal_processing/ica.py
@@ -2,6 +2,7 @@
 
 from typing import Dict
 
+import mne
 from mne.preprocessing import ICA
 
 from autoclean.functions.ica.ica_processing import (
@@ -26,6 +27,36 @@ except ImportError:
 
 class IcaMixin:
     """Mixin for ICA processing."""
+
+    def _get_ica_fit_data(self):
+        """Return the data object ICA was fit on (self.raw or self.epochs).
+
+        Tracks the ``use_epochs`` flag passed to the most recent `run_ica`
+        call so that `classify_ica_components` and
+        `apply_ica_component_rejection` operate on the same data type ICA was
+        actually fit on, instead of assuming `self.raw`. Falls back to
+        whichever of `self.raw` / `self.epochs` is available if the
+        fit-time preference is no longer set.
+        """
+        use_epochs = getattr(self, "_ica_used_epochs", False)
+        attrs = ("epochs", "raw") if use_epochs else ("raw", "epochs")
+
+        for i, attr in enumerate(attrs):
+            obj = getattr(self, attr, None)
+            if obj is not None:
+                if i > 0:
+                    message(
+                        "warning",
+                        f"ICA was fit with use_epochs={use_epochs}, but self.{attrs[0]} "
+                        f"is unavailable; falling back to self.{attr}, which may not "
+                        "be the data ICA was actually fit on.",
+                    )
+                return obj
+
+        raise AttributeError(
+            "No data object (self.raw or self.epochs) available for ICA "
+            "operations. Please run `run_ica` first."
+        )
 
     def run_ica(
         self,
@@ -81,6 +112,7 @@ class IcaMixin:
             return
 
         data = self._get_data_object(data=None, use_epochs=use_epochs)
+        self._ica_used_epochs = use_epochs
 
         # Run ICA using standalone function
         if is_enabled:
@@ -292,7 +324,7 @@ class IcaMixin:
                     if base_url is None and "base_url" in step_config_main_dict:
                         base_url = step_config_main_dict.get("base_url")
                     if base_url is not None:
-                        message("info", f"Using base_url from config")
+                        message("info", "Using base_url from config")
 
                 if model_name is None:
                     model_name = config_params_nested.get("model_name")
@@ -316,8 +348,10 @@ class IcaMixin:
             extra_kwargs["generate_report"] = True
             extra_kwargs["output_dir"] = self.config.get("derivatives_dir", {})
 
+        fit_data = self._get_ica_fit_data()
+
         self.ica_flags = classify_ica_components(
-            self.raw, self.final_ica, method=method, **extra_kwargs
+            fit_data, self.final_ica, method=method, **extra_kwargs
         )
 
         vision_attr = None
@@ -361,7 +395,7 @@ class IcaMixin:
                     message("warning", f"Failed to generate ICA component report: {e}")
 
         # Export if requested
-        self._auto_export_if_enabled(self.raw, stage_name, export)
+        self._auto_export_if_enabled(fit_data, stage_name, export)
 
         return self.ica_flags
 
@@ -380,12 +414,14 @@ class IcaMixin:
         the data.
 
         It updates `self.final_ica.exclude` and modifies the data object
-        (e.g., `self.raw`) in-place. The updated ICA object is also saved.
+        (`self.raw` or `self.epochs`) in-place. The updated ICA object is
+        also saved.
 
         Parameters
         ----------
         data_to_clean : mne.io.Raw | mne.Epochs, optional
-            The data to apply the ICA to. If None, defaults to `self.raw`.
+            The data to apply the ICA to. If None, defaults to whichever of
+            `self.raw` / `self.epochs` ICA was fit on (see `run_ica`).
             This should ideally be the same data object that classification was
             performed on, or is compatible with `self.final_ica`.
         manual_rejected_components : list[int], optional
@@ -511,19 +547,30 @@ class IcaMixin:
                     f"Will reject ICs of types: {flags_to_reject} with confidence > {rejection_threshold}",
                 )
 
-        # Determine data to clean
-        target_data = data_to_clean if data_to_clean is not None else self.raw
+        # Determine data to clean - defaults to whichever object ICA was fit on
+        target_data = (
+            data_to_clean if data_to_clean is not None else self._get_ica_fit_data()
+        )
 
         # Snapshot pre-rejection data so ICA reports can show original component
         # activity/PSD even for components that get rejected below. Only do this
         # when we're operating on self.raw (not an arbitrary externally-provided
-        # data object), and only take the snapshot once per task instance so a
-        # second call can't overwrite it with already-partially-rejected data.
-        if data_to_clean is None and not hasattr(self, "raw_prerejection"):
+        # data object, and not self.epochs - ICA reports are raw-only), and only
+        # take the snapshot once per task instance so a second call can't
+        # overwrite it with already-partially-rejected data.
+        if (
+            data_to_clean is None
+            and target_data is getattr(self, "raw", None)
+            and not hasattr(self, "raw_prerejection")
+        ):
             self.raw_prerejection = self.raw.copy()
 
         data_source_name = (
-            "provided data object" if data_to_clean is not None else "self.raw"
+            "provided data object"
+            if data_to_clean is not None
+            else (
+                "self.epochs" if isinstance(target_data, mne.BaseEpochs) else "self.raw"
+            )
         )
         message("debug", f"Applying ICA to {data_source_name}")
 
@@ -561,9 +608,9 @@ class IcaMixin:
             }
         else:
             # Run automatic rejection on a copy to get suggested components
-            temp_raw = target_data.copy()
+            temp_data = target_data.copy()
             _, rejected_ic_indices_this_step = apply_ica_component_rejection(
-                raw=temp_raw,
+                raw=temp_data,
                 ica=self.final_ica,
                 labels_df=self.ica_flags,
                 ic_flags_to_reject=flags_to_reject,

--- a/src/autoclean/mixins/viz/ica.py
+++ b/src/autoclean/mixins/viz/ica.py
@@ -26,14 +26,14 @@ import numpy as np
 from matplotlib.backends.backend_pdf import PdfPages
 from mne.preprocessing import ICA
 
-from autoclean.functions.visualization.icvision_layouts import (
-    plot_component_for_classification,
-    plot_ica_topographies_overview,
-)
 from autoclean.functions.visualization._ica_sources_cache import (
     get_cached_ica_sources,
     get_ica_cache_stats,
     invalidate_ica_cache,
+)
+from autoclean.functions.visualization.icvision_layouts import (
+    plot_component_for_classification,
+    plot_ica_topographies_overview,
 )
 from autoclean.utils.logging import message
 
@@ -62,7 +62,7 @@ class ICAReportingMixin:
     - `verify_topography_plot`: Use a basicica topograph to verify MEA channel placement.
     """
 
-    def plot_ica_full(self) -> plt.Figure:
+    def plot_ica_full(self) -> Optional[plt.Figure]:
         """Plot ICA components over the full time series with their labels and probabilities.
 
         This method creates a figure showing each ICA component's time course over the full
@@ -71,8 +71,9 @@ class ICAReportingMixin:
 
         Returns
         -------
-        matplotlib.figure.Figure
-            The generated figure with ICA components.
+        matplotlib.figure.Figure or None
+            The generated figure with ICA components, or None if raw/ICA data
+            is unavailable (e.g. ICA was fit on epochs - this plot is raw-only).
 
         Raises
         ------
@@ -91,7 +92,15 @@ class ICAReportingMixin:
             - The method respects configuration settings via the `ica_full_plot_step` config
         """
         # Get raw and ICA from pipeline
-        raw = self._get_ica_report_data().copy()
+        report_data = self._get_ica_report_data()
+        if report_data is None:
+            message(
+                "warning",
+                "plot_ica_full skipped because raw or ICA data is missing "
+                "(this plot is raw-only; epochs-only tasks are not supported).",
+            )
+            return None
+        raw = report_data.copy()
         ica = self.final_ica
         ic_labels = self.ica_flags
 
@@ -287,7 +296,8 @@ class ICAReportingMixin:
             'all' to plot all components, 'rejected' to plot only rejected components.
         """
         # Safety guards - input validation
-        if self.raw is None or self.final_ica is None:
+        report_data = self._get_ica_report_data()
+        if report_data is None or self.final_ica is None:
             message(
                 "warning", "ICA plotting skipped because raw or ICA data is missing."
             )
@@ -300,7 +310,7 @@ class ICAReportingMixin:
             )
             return None
 
-        raw = self._get_ica_report_data()
+        raw = report_data
         ica = self.final_ica
         ic_labels = getattr(self, "ica_flags", None)
         psd_fmax = self._resolve_psd_fmax()
@@ -494,9 +504,6 @@ class ICAReportingMixin:
             from autoclean.functions.visualization._ica_psd_cache import (
                 get_cached_component_psds,
             )
-            from autoclean.functions.visualization._ica_topography_cache import (
-                get_cached_topographies,
-            )
 
             try:
                 # Pre-compute all PSDs for the components we'll plot
@@ -604,9 +611,16 @@ class ICAReportingMixin:
         Prefers the pre-rejection snapshot (if available) so that rejected
         components still show their original activity/PSD instead of the
         zeroed-out values left behind after ICA.apply() runs.
+
+        ICA reports currently only support raw-based plotting. If ICA was fit
+        on epochs (`self._ica_used_epochs`), there is no raw-shaped data to
+        report on, so this returns None rather than silently falling back to
+        a stale/incompatible `self.raw` left over from an earlier step.
         """
+        if getattr(self, "_ica_used_epochs", False):
+            return None
         snapshot = getattr(self, "raw_prerejection", None)
-        return snapshot if snapshot is not None else self.raw
+        return snapshot if snapshot is not None else getattr(self, "raw", None)
 
     def clear_ica_sources_cache(self):
         """Clear all cached ICA sources to free memory."""

--- a/tests/functions/test_ica.py
+++ b/tests/functions/test_ica.py
@@ -27,6 +27,16 @@ def mock_raw():
 
 
 @pytest.fixture
+def mock_epochs():
+    """Create a mock epochs object for testing."""
+    epochs = MagicMock(spec=mne.BaseEpochs)
+    epochs.info = {"sfreq": 500.0, "nchan": 64}
+    epochs.get_data.return_value = np.random.randn(20, 64, 500)
+    epochs.copy.return_value = epochs
+    return epochs
+
+
+@pytest.fixture
 def mock_ica():
     """Create a mock ICA object for testing."""
     ica = MagicMock(spec=ICA)
@@ -66,7 +76,7 @@ class TestFitIca:
         mock_ica_instance = MagicMock(spec=ICA)
         mock_ica_class.return_value = mock_ica_instance
 
-        result = fit_ica(
+        fit_ica(
             mock_raw,
             n_components=15,
             method="infomax",
@@ -109,6 +119,17 @@ class TestFitIca:
 
         with pytest.raises(RuntimeError, match="Failed to fit ICA"):
             fit_ica(mock_raw)
+
+    @patch("autoclean.functions.ica.ica_processing.ICA")
+    def test_accepts_epochs(self, mock_ica_class, mock_epochs):
+        """fit_ica should accept mne.BaseEpochs, not just Raw."""
+        mock_ica_instance = MagicMock(spec=ICA)
+        mock_ica_class.return_value = mock_ica_instance
+
+        result = fit_ica(mock_epochs)
+
+        mock_ica_instance.fit.assert_called_once()
+        assert result == mock_ica_instance
 
 
 class TestClassifyIcaComponents:
@@ -161,6 +182,27 @@ class TestClassifyIcaComponents:
 
         with pytest.raises(RuntimeError, match="Failed to classify ICA components"):
             classify_ica_components(mock_raw, mock_ica)
+
+    @patch("autoclean.functions.ica.ica_processing.mne_icalabel.label_components")
+    def test_accepts_epochs_when_raw_unavailable(
+        self, mock_label_components, mock_epochs, mock_ica
+    ):
+        """classify_ica_components should accept epochs (e.g. when only
+        epoched data was used to fit ICA and no raw object exists)."""
+
+        def side_effect(inst, ica, method="iclabel", verbose=None):
+            ica.labels_ = {"brain": list(range(ica.n_components_))}
+            ica.labels_scores_ = MagicMock()
+            ica.labels_scores_.max.return_value = np.ones(ica.n_components_)
+
+        mock_label_components.side_effect = side_effect
+
+        result = classify_ica_components(mock_epochs, mock_ica)
+
+        mock_label_components.assert_called_once_with(
+            mock_epochs, mock_ica, method="iclabel"
+        )
+        assert isinstance(result, pd.DataFrame)
 
     def test_dataframe_structure(self, mock_raw, mock_ica):
         """Test that returned DataFrame has correct structure."""
@@ -229,9 +271,7 @@ class TestClassifyIcaComponents:
             ica.labels_scores_ = MagicMock()
             ica.labels_scores_.max.return_value = np.ones(ica.n_components_)
 
-        def icvision_side_effect(
-            raw, ica, component_indices=None, **kwargs
-        ):
+        def icvision_side_effect(raw, ica, component_indices=None, **kwargs):
             ica.labels_ = {"brain": list(range(1, ica.n_components_)), "eog": [0]}
             ica.labels_scores_ = np.ones((len(component_indices or []), 7))
 
@@ -291,7 +331,7 @@ class TestApplyIcaRejection:
 
     def test_empty_component_list(self, mock_raw, mock_ica):
         """Test with empty component rejection list."""
-        result = apply_ica_rejection(mock_raw, mock_ica, [])
+        apply_ica_rejection(mock_raw, mock_ica, [])
 
         # Should still work with empty list
         mock_ica.copy.assert_called_once()
@@ -310,9 +350,7 @@ class TestApplyIcaRejection:
 
         # Test with copy=False
         apply_ica_rejection(mock_raw, mock_ica, components_to_reject, copy=False)
-        mock_ica.copy.return_value.apply.assert_called_with(
-            mock_raw, verbose=None
-        )
+        mock_ica.copy.return_value.apply.assert_called_with(mock_raw, verbose=None)
 
     def test_rejection_failure(self, mock_raw, mock_ica):
         """Test handling of ICA rejection failures."""
@@ -321,16 +359,23 @@ class TestApplyIcaRejection:
         with pytest.raises(RuntimeError, match="Failed to apply ICA rejection"):
             apply_ica_rejection(mock_raw, mock_ica, [0, 1])
 
+    def test_accepts_epochs(self, mock_epochs, mock_ica):
+        """apply_ica_rejection should accept mne.BaseEpochs, not just Raw."""
+        result = apply_ica_rejection(mock_epochs, mock_ica, [0, 2])
+
+        mock_ica.copy.assert_called_once()
+        mock_ica.copy.return_value.apply.assert_called_once()
+        assert result == mock_ica.copy.return_value.apply.return_value
+
 
 class TestIntegration:
     """Integration tests for ICA functions."""
 
     @patch("autoclean.functions.ica.ica_processing.ICA.fit", autospec=True)
     @patch("autoclean.functions.ica.ica_processing.mne_icalabel.label_components")
-    def test_complete_ica_workflow(
-        self, mock_label_components, mock_ica_fit, mock_raw
-    ):
+    def test_complete_ica_workflow(self, mock_label_components, mock_ica_fit, mock_raw):
         """Test complete ICA workflow: fit -> classify -> reject."""
+
         def fit_side_effect(self, raw, picks=None, verbose=None):
             self.n_components_ = 10
             return self

--- a/tests/unit/io/test_export_fallbacks.py
+++ b/tests/unit/io/test_export_fallbacks.py
@@ -1,12 +1,13 @@
 """Tests for export fallbacks used by large EEGLAB outputs."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
+import mne
 import numpy as np
 import pytest
 
-from autoclean.io.export import save_epochs_to_set, save_raw_to_set
+from autoclean.io.export import save_epochs_to_set, save_ica_to_fif, save_raw_to_set
 
 
 def _autoclean_dict(tmp_path: Path) -> dict:
@@ -78,3 +79,48 @@ def test_save_epochs_to_set_falls_back_to_chunked_for_eeglab_size_error(
     mock_loadmat.assert_called_once_with(chunk_path)
     mock_savemat.assert_called_once()
     assert mock_manage_database.call_count == 2  # metadata + status updates
+
+
+def _ica_autoclean_dict(tmp_path: Path) -> dict:
+    return {
+        "run_id": "run-001",
+        "unprocessed_file": str(tmp_path / "sample.set"),
+        "derivatives_dir": tmp_path / "derivatives",
+        "ica_dir": tmp_path / "ica",
+    }
+
+
+@patch("autoclean.io.export.manage_database_conditionally")
+@patch("autoclean.io.export.save_raw_to_set")
+@patch("autoclean.io.export.save_epochs_to_set")
+def test_save_ica_to_fif_dispatches_to_save_epochs_to_set_for_epochs(
+    mock_save_epochs, mock_save_raw, mock_manage_database, tmp_path: Path
+) -> None:
+    """save_ica_to_fif should save epochs (not raw) when pre_ica_raw is Epochs."""
+    ica = MagicMock()
+    ica.exclude = []
+    epochs = MagicMock(spec=mne.BaseEpochs)
+    mock_save_epochs.return_value = tmp_path / "pre_ica_epo.set"
+
+    save_ica_to_fif(ica, _ica_autoclean_dict(tmp_path), epochs)
+
+    mock_save_epochs.assert_called_once_with(epochs, ANY, stage="pre_ica")
+    mock_save_raw.assert_not_called()
+
+
+@patch("autoclean.io.export.manage_database_conditionally")
+@patch("autoclean.io.export.save_raw_to_set")
+@patch("autoclean.io.export.save_epochs_to_set")
+def test_save_ica_to_fif_dispatches_to_save_raw_to_set_for_raw(
+    mock_save_epochs, mock_save_raw, mock_manage_database, tmp_path: Path
+) -> None:
+    """save_ica_to_fif should save raw (not epochs) when pre_ica_raw is Raw."""
+    ica = MagicMock()
+    ica.exclude = []
+    raw = MagicMock(spec=mne.io.BaseRaw)
+    mock_save_raw.return_value = tmp_path / "pre_ica_raw.set"
+
+    save_ica_to_fif(ica, _ica_autoclean_dict(tmp_path), raw)
+
+    mock_save_raw.assert_called_once_with(raw, ANY, stage="pre_ica")
+    mock_save_epochs.assert_not_called()

--- a/tests/unit/mixins/test_ica.py
+++ b/tests/unit/mixins/test_ica.py
@@ -1,6 +1,5 @@
 """Unit tests for IcaMixin."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import mne
@@ -47,6 +46,29 @@ def task(tmp_path):
     t.raw = create_synthetic_raw(
         montage="standard_1020", n_channels=32, duration=20.0, sfreq=250.0
     )
+    return t
+
+
+@pytest.fixture
+def epochs_task(tmp_path):
+    """A task with only epoched data available (no self.raw), matching the
+    `self.import_epochs(); self.run_ica(use_epochs=True)` usage pattern."""
+    settings = {
+        "ICA": {
+            "enabled": True,
+            "value": {"n_components": 5, "method": "fastica"},
+        }
+    }
+    config = {
+        "run_id": "test",
+        "unprocessed_file": tmp_path / "test.fif",
+        "task": "test",
+    }
+    t = _ICATask(config, settings=settings)
+    raw = create_synthetic_raw(
+        montage="standard_1020", n_channels=32, duration=20.0, sfreq=250.0
+    )
+    t.epochs = mne.make_fixed_length_epochs(raw, duration=2.0, preload=True)
     return t
 
 
@@ -108,6 +130,23 @@ class TestRunICA:
         assert result is None
         assert not hasattr(t, "final_ica") or t.final_ica is None  # type: ignore[attr-defined]
 
+    @patch("autoclean.mixins.signal_processing.ica.save_ica_to_fif")
+    @patch("autoclean.mixins.signal_processing.ica.fit_ica")
+    def test_use_epochs_fits_on_self_epochs(self, mock_fit, mock_save_fif, epochs_task):
+        """run_ica(use_epochs=True) should fit on self.epochs when self.raw
+        doesn't exist, matching the `import_epochs(); run_ica(use_epochs=True)`
+        pattern from issue #218."""
+        mock_ica = _make_mock_ica()
+        mock_fit.return_value = mock_ica
+        with patch.object(epochs_task, "_update_metadata"):
+            epochs_task.run_ica(use_epochs=True)
+
+        assert epochs_task.final_ica is mock_ica
+        # run_ica fits on a .copy() of the data, so check type/identity of source
+        fit_call_kwargs = mock_fit.call_args[1]
+        assert isinstance(fit_call_kwargs["raw"], mne.BaseEpochs)
+        assert epochs_task._ica_used_epochs is True
+
 
 # ---------------------------------------------------------------------------
 # apply_ica_component_rejection
@@ -119,6 +158,23 @@ class TestApplyICAComponentRejection:
         """Calling rejection before run_ica should raise RuntimeError."""
         with pytest.raises(RuntimeError, match="final_ica"):
             task.apply_ica_component_rejection()
+
+    def test_manual_override_updates_self_epochs_when_no_raw(self, epochs_task):
+        """When ICA was fit on epochs (no self.raw), manual rejection should
+        default to and modify self.epochs instead of trying self.raw."""
+        mock_ica = _make_mock_ica()
+        mock_ica.apply = MagicMock()
+        epochs_task.final_ica = mock_ica
+        epochs_task._ica_used_epochs = True
+
+        with (
+            patch.object(epochs_task, "_update_metadata"),
+            patch.object(epochs_task, "_auto_export_if_enabled"),
+        ):
+            epochs_task.apply_ica_component_rejection(manual_rejected_components=[0, 2])
+
+        assert epochs_task.final_ica.exclude == [0, 2]
+        mock_ica.apply.assert_called_once_with(epochs_task.epochs)
 
     def test_manual_override_sets_exclude_list(self, task):
         """Manual component list bypasses auto-detection and sets exclude directly."""
@@ -219,6 +275,55 @@ class TestGetIcaReportData:
 
         assert result is task.raw
 
+    def test_returns_none_when_ica_fit_on_epochs(self, epochs_task):
+        """ICA reports are raw-only. When ICA was fit on epochs, this should
+        return None (triggering a graceful skip) rather than silently
+        returning a stale/incompatible self.raw."""
+        epochs_task._ica_used_epochs = True
+
+        result = epochs_task._get_ica_report_data()
+
+        assert result is None
+
+    def test_ignores_stale_raw_when_ica_fit_on_epochs(self, epochs_task):
+        """Even if self.raw happens to exist (e.g. left over from an earlier
+        step), report data must not silently return it when ICA was actually
+        fit on epochs - that data wasn't what ICA ran on."""
+        epochs_task.raw = create_synthetic_raw(
+            montage="standard_1020", n_channels=32, duration=5.0, sfreq=250.0
+        )
+        epochs_task._ica_used_epochs = True
+
+        result = epochs_task._get_ica_report_data()
+
+        assert result is None
+
+
+class TestPlotIcaFull:
+    def test_returns_none_instead_of_crashing_when_report_data_missing(
+        self, epochs_task
+    ):
+        """plot_ica_full should skip gracefully (not raise) when ICA was fit
+        on epochs, since this plot is raw-only."""
+        epochs_task.final_ica = _make_mock_ica()
+        epochs_task._ica_used_epochs = True
+
+        result = epochs_task.plot_ica_full()
+
+        assert result is None
+
+
+class TestPlotIcaComponentsEpochsGuard:
+    def test_skips_gracefully_when_ica_fit_on_epochs(self, epochs_task):
+        """_plot_ica_components should skip gracefully (not crash) when ICA
+        was fit on epochs, consistent with reports being raw-only."""
+        epochs_task.final_ica = _make_mock_ica()
+        epochs_task._ica_used_epochs = True
+
+        result = epochs_task._plot_ica_components()
+
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # classify_ica_components
@@ -264,6 +369,27 @@ class TestClassifyICAComponents:
 
         assert result is mock_flags
         assert task.ica_flags is mock_flags
+
+    @patch("autoclean.mixins.signal_processing.ica.classify_ica_components")
+    def test_classifies_epochs_when_raw_unavailable(self, mock_classify, epochs_task):
+        """When ICA was fit on epochs (no self.raw), classification should
+        receive self.epochs instead of crashing on a missing self.raw."""
+        mock_flags = pd.DataFrame({"label": ["brain", "eye blink"]})
+        mock_classify.return_value = mock_flags
+        epochs_task.final_ica = _make_mock_ica()
+        epochs_task._ica_used_epochs = True
+
+        with (
+            patch.object(epochs_task, "_update_metadata"),
+            patch.object(epochs_task, "_auto_export_if_enabled"),
+            patch.object(epochs_task, "apply_ica_component_rejection"),
+        ):
+            result = epochs_task.classify_ica_components(method="iclabel", reject=False)
+
+        assert result is mock_flags
+        mock_classify.assert_called_once_with(
+            epochs_task.epochs, epochs_task.final_ica, method="iclabel"
+        )
 
     @patch("autoclean.mixins.signal_processing.ica.classify_ica_components")
     def test_classify_components_uses_iclabel_threshold(self, mock_classify, task):


### PR DESCRIPTION
## Summary
  - Extend `fit_ica`, `classify_ica_components`, and `apply_ica_rejection` to accept `mne.BaseEpochs` in addition to `mne.io.BaseRaw`
  - Add `IcaMixin._get_ica_fit_data()`, tracking whether ICA was fit on `self.raw` or `self.epochs` (via a new `_ica_used_epochs` flag set by `run_ica(use_epochs=...)`), and use it consistently in
  classification/rejection instead of hardcoding `self.raw`
  - Update `save_ica_to_fif()` to save epochs vs raw based on data type
  - Fix ICA report generation (`viz/ica.py`) to cleanly skip (rather than crash or silently plot stale/wrong data) when ICA was fit on epochs
  - Bump the pre-commit `black` hook to 25.9.0 to match the version already pinned in `pyproject.toml` (the old pinned rev predated Python 3.13 support and broke the hook for every contributor)

  Fixes #218
  - Bump the pre-commit `black` hook to 25.9.0 to match the version already pinned in `pyproject.toml` (the old pinned rev predated                                                                                                                          Python                                                                                                                         3.13                                                                                                                           support                                                                                                                        and                                                                                                                            broke                                                                                                                          the                                                                                                                            hook                                                                                                                           for                                                                                                                            every                                                                                                                          contributor)

  Fixes #218

  - Extend `fit_ica`, `classify_ica_components`, and `apply_ica_rejection` to accept `mne.BaseEpochs` in addition to
  `mne.io.BaseRaw`
  - Add `IcaMixin._get_ica_fit_data()`, tracking whether ICA was fit on `self.raw` or `self.epochs` (via a new
  `_ica_used_epochs` flag set by `run_ica(use_epochs=...)`), and use it consistently in classification/rejection instead of
  hardcoding `self.raw`
  - Update `save_ica_to_fif()` to save epochs vs raw based on data type
  - Fix ICA report generation (`viz/ica.py`) to cleanly skip (rather than crash or silently plot stale/wrong data) when ICA was
  fit on epochs
  - Bump the pre-commit `black` hook to 25.9.0 to match the version already pinned in `pyproject.toml` (the old pinned rev
  predated Python 3.13 support and broke the hook for every contributor)

  Fixes #218

  ## Test plan
  - [x] `uv run pytest tests/functions/test_ica.py tests/unit/mixins/test_ica.py
  tests/unit/test_apply_ica_component_rejection_manual_override.py tests/integration/test_ica_prerejection_report.py
  tests/unit/io/test_export_fallbacks.py` — 60 passed
  - [x] `ruff check` clean on all touched files
  - [x] Independent code review + QA pass performed on the diff