### PR TITLE
fix: preserve condition codes on epoch export and BIDS conversion

### DIFF
--- a/src/autoclean/io/export.py
+++ b/src/autoclean/io/export.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import mne
-import numpy as np
 import scipy.io as sio
 from eeglabio.epochs import export_set
 
@@ -14,6 +13,7 @@ from eeglabio.epochs import export_set
 from mne.export._eeglab import _get_als_coords_from_chs
 
 from autoclean.utils.database import manage_database_conditionally
+from autoclean.utils.epoch_events import extract_epoch_events
 from autoclean.utils.logging import message
 
 __all__ = [
@@ -373,187 +373,20 @@ def save_epochs_to_set(
     # Only save to stage directory - final files will be copied separately
     paths = [stage_path]
 
-    # Handle epoch metadata for event preservation
-    if epochs.metadata is None:
-        message("warning", "No additional event metadata found for epochs")
+    # Extract event codes for EEGLAB export. Prefers the richer per-epoch
+    # additional_events metadata when it validly covers every epoch, but always
+    # falls back to epochs.events/epochs.event_id (the authoritative source of
+    # truth) rather than risk losing or renumbering condition codes.
+    try:
+        events_in_epochs, event_id_rebuilt, epoch_indices_array, event_source = (
+            extract_epoch_events(epochs)
+        )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        message("error", f"Failed to extract epoch events: {str(e)}")
         events_in_epochs = None
         event_id_rebuilt = None
-    else:
-        try:
-            # Check for metadata-events alignment
-            if len(epochs.metadata) != len(epochs.events):
-                message(
-                    "warning",
-                    "Mismatch in metadata vs events: "
-                    f"{len(epochs.metadata)} vs {len(epochs.events)} — truncating to align.",
-                )
-
-            # Extract events from metadata if available
-            if (
-                "additional_events"
-                in epochs.metadata.columns
-                # and not epochs.metadata["additional_events"].empty # This check might be too simple if NaNs are present
-            ):
-                # Calculate timing parameters for event reconstruction
-                sfreq = epochs.info["sfreq"]
-                # offset = int(round(-epochs.tmin * sfreq))  # Samples from epoch start to time 0. Will recalculate sample pos directly.
-                n_samples = len(epochs.times)  # Total samples per epoch
-
-                # Build event dictionary from all unique event labels
-                all_labels = set()
-                # Iterate over potentially NaN-containing 'additional_events' Series safely
-                for additional_event_list_for_epoch in epochs.metadata[
-                    "additional_events"
-                ].dropna():
-                    if isinstance(additional_event_list_for_epoch, list):
-                        for event_tuple in additional_event_list_for_epoch:
-                            # Ensure the event_tuple is a tuple/list and has at least one element (the label)
-                            if (
-                                isinstance(event_tuple, (list, tuple))
-                                and len(event_tuple) >= 1
-                            ):
-                                label = event_tuple[0]  # Get the label
-                                all_labels.add(str(label))  # Ensure label is a string
-                            else:
-                                message(
-                                    "debug",
-                                    f"Skipping malformed event tuple: {event_tuple} in additional_events.",
-                                )
-                    # else: it's not a list after dropna(), so it was NaN or another non-list type.
-
-                # Preserve original event codes instead of creating sequential ones
-                event_id_rebuilt = {}
-                if hasattr(epochs, "event_id") and epochs.event_id:
-                    # Use original event codes from epochs object
-                    for label in all_labels:
-                        # Find matching event code from original event_id
-                        for orig_label, orig_code in epochs.event_id.items():
-                            if str(orig_label) == str(label):
-                                event_id_rebuilt[label] = orig_code
-                                break
-                        else:
-                            # Fallback: if no match found, use sequential numbering
-                            event_id_rebuilt[label] = len(event_id_rebuilt) + 1
-                else:
-                    # Fallback: if no original event_id available, use sequential numbering
-                    event_id_rebuilt = {
-                        label: idx + 1
-                        for idx, label in enumerate(sorted(list(all_labels)))
-                    }
-                # Reconstruct events array with global sample positions
-                events_in_epochs = []
-                epoch_indices_array = []  # Track which epoch each event belongs to
-                used_samples = set()  # Track used samples to prevent collisions
-
-                # Iterate through metadata rows, but ensure we don't go beyond the actual number of events
-                # This directly addresses the "82 vs 77" mismatch.
-                for i, meta_row_tuple in enumerate(
-                    epochs.metadata.head(len(epochs.events)).itertuples(
-                        index=False, name="Row"
-                    )
-                ):
-                    current_additional_events_for_epoch = getattr(
-                        meta_row_tuple, "additional_events", None
-                    )
-                    if isinstance(current_additional_events_for_epoch, list):
-                        for label, rel_time in current_additional_events_for_epoch:
-                            try:
-                                # rel_time is time from epoch's t=0 (trigger).
-                                # epochs.tmin is the start of the epoch data window relative to t=0.
-                                # Sample index for rel_time within the epoch's data array (0 to n_samples-1) is:
-                                event_sample_within_epoch_data = int(
-                                    round((float(rel_time) - epochs.tmin) * sfreq)
-                                )
-
-                                # Check bounds: sample must be within the current epoch's data segment [0, n_samples-1]
-                                if not (
-                                    0 <= event_sample_within_epoch_data < n_samples
-                                ):
-                                    message(
-                                        "warning",
-                                        f"Epoch {i}, event '{label}': rel_time {rel_time}s -> sample {event_sample_within_epoch_data} is outside epoch data window [0, {n_samples-1}]. Skipping.",
-                                    )
-                                    continue
-
-                                # global_sample is for concatenated data, as expected by eeglabio.export_set
-                                # It's the start of the i-th epoch's data block + the sample within that block.
-                                global_sample = (
-                                    i * n_samples
-                                ) + event_sample_within_epoch_data
-
-                                # Prevent sample collisions by incrementing if needed
-                                while global_sample in used_samples:
-                                    global_sample += 1
-                                used_samples.add(global_sample)
-
-                                str_label = str(
-                                    label
-                                )  # Ensure label is string for dict lookup
-                                if str_label not in event_id_rebuilt:
-                                    message(
-                                        "warning",
-                                        f"Label '{str_label}' (from epoch {i}, rel_time {rel_time}) not found in rebuilt event_id. Available: {list(event_id_rebuilt.keys())}. Skipping this event.",
-                                    )
-                                    continue
-                                code = event_id_rebuilt[str_label]
-                                events_in_epochs.append(
-                                    [global_sample, 0, code]
-                                )  # Assuming duration 0 for point events
-                                epoch_indices_array.append(
-                                    i
-                                )  # Explicit mapping: this event belongs to epoch i
-                            except ValueError:
-                                message(
-                                    "warning",
-                                    f"Epoch {i}, event '{label}': Could not convert rel_time '{rel_time}' to float. Skipping this event.",
-                                )
-                                continue
-                            except (
-                                Exception
-                            ) as e_inner:  # pylint: disable=broad-exception-caught
-                                message(
-                                    "error",
-                                    f"Unexpected error processing event '{label}' in epoch {i} (rel_time: {rel_time}): {e_inner}",
-                                )
-                                continue
-                    # else: current_additional_events_for_epoch is not a list (e.g., NaN), so skip for this epoch.
-
-                if events_in_epochs:  # Only convert to numpy array if list is not empty
-                    events_in_epochs = np.array(events_in_epochs, dtype=int)
-                    epoch_indices_array = np.array(epoch_indices_array, dtype=int)
-
-                    # Check if all epochs are covered
-                    unique_epoch_indices = np.unique(epoch_indices_array)
-                    n_epochs = len(epochs)
-
-                    if len(unique_epoch_indices) < n_epochs:
-                        missing_epochs = sorted(
-                            set(range(n_epochs)) - set(unique_epoch_indices)
-                        )
-                        message(
-                            "warning",
-                            f"Event export: {len(unique_epoch_indices)}/{n_epochs} epochs have events",
-                        )
-                        message(
-                            "warning",
-                            (
-                                f"Missing epoch indices: {missing_epochs[:10]}..."
-                                if len(missing_epochs) > 10
-                                else f"Missing epoch indices: {missing_epochs}"
-                            ),
-                        )
-                else:  # If list is empty, set to None or an empty array as eeglabio expects
-                    events_in_epochs = None  # Or np.empty((0,3), dtype=int) depending on eeglabio's preference for empty
-                    epoch_indices_array = None
-
-            else:
-                message(
-                    "warning",
-                    "No 'additional_events' column found in epochs.metadata or it is empty.",
-                )
-                events_in_epochs = None
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            message("error", f"Failed to rebuild events_in_epochs: {str(e)}")
+        epoch_indices_array = None
+        event_source = "primary"
 
     # Save to all target paths
     epochs.info["description"] = autoclean_dict["run_id"]
@@ -595,7 +428,11 @@ def save_epochs_to_set(
 
             try:
                 # Use specialized export for preserving complex event structures
-                if events_in_epochs is not None and len(events_in_epochs) > 0:
+                if (
+                    event_source == "metadata"
+                    and events_in_epochs is not None
+                    and len(events_in_epochs) > 0
+                ):
                     ## Channel locations fix 10/19/2025
                     drop_chs = ["epoc", "STI 014"]
                     ch_names = [ch for ch in epochs.ch_names if ch not in drop_chs]

--- a/src/autoclean/mixins/utils/bids.py
+++ b/src/autoclean/mixins/utils/bids.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Tuple
 import mne
 
 from autoclean.utils.bids import step_convert_to_bids
+from autoclean.utils.epoch_events import extract_epoch_events
 from autoclean.utils.logging import message
 
 
@@ -106,7 +107,9 @@ class BIDSMixin:
 
         The BIDS conversion functions expect mne.io.Raw objects, but we have epoched data.
         This method creates a synthetic Raw object that contains the concatenated epoch
-        data and mimics the required attributes for BIDS conversion.
+        data and mimics the required attributes for BIDS conversion. Condition labels
+        (epochs.event_id) are preserved as annotations on the mock Raw so downstream
+        BIDS conversion doesn't lose the event structure.
 
         Args:
             epochs: The epochs data to convert
@@ -143,7 +146,31 @@ class BIDSMixin:
 
         # Copy any annotations if they exist
         if hasattr(epochs, "annotations") and epochs.annotations:
-            mock_raw.set_annotations(epochs.annotations)
+            mock_raw.set_annotations(epochs.annotations.copy())
+
+        # Preserve condition codes as annotations so BIDS conversion doesn't
+        # lose the event structure needed later for export or reporting.
+        try:
+            events, event_id, _epoch_indices, _source = extract_epoch_events(epochs)
+            code_to_label = {code: label for label, code in event_id.items()}
+            sfreq = epochs.info["sfreq"]
+            existing = mock_raw.annotations
+            event_annotations = mne.Annotations(
+                onset=events[:, 0] / sfreq,
+                duration=[0.0] * len(events),
+                description=[
+                    code_to_label.get(code, str(code)) for code in events[:, 2]
+                ],
+                # Match the mock raw's own orig_time (often the real
+                # recording's meas_date) -- mismatched orig_time raises on +.
+                orig_time=existing.orig_time,
+            )
+            mock_raw.set_annotations(existing + event_annotations)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            message(
+                "warning",
+                f"Failed to preserve epoch condition codes as annotations: {e}",
+            )
 
         message(
             "success",

--- a/src/autoclean/utils/epoch_events.py
+++ b/src/autoclean/utils/epoch_events.py
@@ -92,8 +92,14 @@ def _rebuild_from_metadata(
         if not isinstance(entry, list):
             continue
         for event_tuple in entry:
-            if isinstance(event_tuple, (list, tuple)) and len(event_tuple) >= 1:
-                all_labels.add(str(event_tuple[0]))
+            if not isinstance(event_tuple, (list, tuple)) or len(event_tuple) != 2:
+                message(
+                    "warning",
+                    "Malformed additional_events entry encountered; falling back "
+                    "to epochs.events/epochs.event_id.",
+                )
+                return None
+            all_labels.add(str(event_tuple[0]))
 
     event_id_rebuilt: Dict[str, int] = {}
     for label in all_labels:
@@ -122,7 +128,8 @@ def _rebuild_from_metadata(
     for i, entry in enumerate(metadata["additional_events"].head(n_rows)):
         if not isinstance(entry, list):
             continue
-        for label, rel_time in entry:
+        for event_tuple in entry:
+            label, rel_time = event_tuple
             try:
                 sample_in_epoch = int(round((float(rel_time) - epochs.tmin) * sfreq))
             except (TypeError, ValueError):

--- a/src/autoclean/utils/epoch_events.py
+++ b/src/autoclean/utils/epoch_events.py
@@ -20,7 +20,9 @@ from autoclean.utils.logging import message
 __all__ = ["extract_epoch_events"]
 
 
-def _primary_events(epochs: mne.BaseEpochs) -> Tuple[np.ndarray, Dict[str, int], np.ndarray]:
+def _primary_events(
+    epochs: mne.BaseEpochs,
+) -> Tuple[np.ndarray, Dict[str, int], np.ndarray]:
     """Build one event per epoch directly from epochs.events / epochs.event_id."""
     n_epochs = len(epochs)
     event_id = dict(epochs.event_id) if epochs.event_id else {}
@@ -96,7 +98,11 @@ def _rebuild_from_metadata(
     event_id_rebuilt: Dict[str, int] = {}
     for label in all_labels:
         match = next(
-            (code for orig_label, code in epochs.event_id.items() if str(orig_label) == label),
+            (
+                code
+                for orig_label, code in epochs.event_id.items()
+                if str(orig_label) == label
+            ),
             None,
         )
         if match is None:

--- a/src/autoclean/utils/epoch_events.py
+++ b/src/autoclean/utils/epoch_events.py
@@ -1,0 +1,229 @@
+"""Centralized epoch event extraction shared by EEGLAB export and BIDS mock-raw conversion.
+
+``epochs.events`` / ``epochs.event_id`` is the authoritative source of truth for
+condition codes on any :class:`mne.BaseEpochs` object — it always covers every
+epoch exactly once. Some pipeline steps additionally attach a richer per-epoch
+``additional_events`` metadata column (see
+``autoclean.mixins.signal_processing.eventid_epochs``) that can carry more than
+one intra-epoch event. That column is only trustworthy when every epoch is
+covered and every label maps back onto ``epochs.event_id``; otherwise we fall
+back to the primary source rather than inventing new codes.
+"""
+
+from typing import Dict, Optional, Tuple
+
+import mne
+import numpy as np
+
+from autoclean.utils.logging import message
+
+__all__ = ["extract_epoch_events"]
+
+
+def _primary_events(epochs: mne.BaseEpochs) -> Tuple[np.ndarray, Dict[str, int], np.ndarray]:
+    """Build one event per epoch directly from epochs.events / epochs.event_id."""
+    n_epochs = len(epochs)
+    event_id = dict(epochs.event_id) if epochs.event_id else {}
+
+    if n_epochs == 0:
+        return np.empty((0, 3), dtype=int), event_id, np.empty(0, dtype=int)
+
+    n_samples = len(epochs.times)
+    trigger_offset = int(round(-epochs.tmin * epochs.info["sfreq"]))
+
+    # Only valid when the epoch window actually contains t=0 (where the
+    # trigger sits). For windows that don't (e.g. tmin > 0 or tmax < 0),
+    # clamp into range and warn rather than silently placing the "trigger"
+    # inside a neighboring epoch's data block.
+    if not (0 <= trigger_offset < n_samples):
+        message(
+            "warning",
+            f"Epoch window [{epochs.tmin}, {epochs.tmax}] does not contain t=0; "
+            "condition-code placement within each epoch's block is approximate.",
+        )
+        trigger_offset = max(0, min(trigger_offset, n_samples - 1))
+
+    events = np.array(
+        [
+            [i * n_samples + trigger_offset, 0, int(code)]
+            for i, code in enumerate(epochs.events[:, 2])
+        ],
+        dtype=int,
+    )
+    epoch_indices = np.arange(n_epochs, dtype=int)
+    return events, event_id, epoch_indices
+
+
+def _rebuild_from_metadata(
+    epochs: mne.BaseEpochs,
+) -> Optional[Tuple[np.ndarray, Dict[str, int], np.ndarray]]:
+    """Attempt to rebuild a per-epoch event list from the additional_events metadata column.
+
+    Returns None if the metadata cannot be trusted to preserve the original
+    condition codes (missing labels, unparsable timings, etc.) so the caller
+    can fall back to the primary epochs.events/event_id source.
+    """
+    metadata = epochs.metadata
+    sfreq = epochs.info["sfreq"]
+    n_samples = len(epochs.times)
+
+    if len(metadata) != len(epochs.events):
+        message(
+            "warning",
+            "additional_events metadata length "
+            f"({len(metadata)}) does not match epochs.events length "
+            f"({len(epochs.events)}); truncating to align.",
+        )
+
+    if not epochs.event_id:
+        message(
+            "warning",
+            "epochs.event_id is empty; cannot validate additional_events labels "
+            "against original condition codes.",
+        )
+        return None
+
+    # Collect every label referenced in the metadata and confirm each one maps
+    # back to an existing code in epochs.event_id. We never invent new codes.
+    all_labels = set()
+    for entry in metadata["additional_events"].dropna():
+        if not isinstance(entry, list):
+            continue
+        for event_tuple in entry:
+            if isinstance(event_tuple, (list, tuple)) and len(event_tuple) >= 1:
+                all_labels.add(str(event_tuple[0]))
+
+    event_id_rebuilt: Dict[str, int] = {}
+    for label in all_labels:
+        match = next(
+            (code for orig_label, code in epochs.event_id.items() if str(orig_label) == label),
+            None,
+        )
+        if match is None:
+            message(
+                "warning",
+                f"Label '{label}' found in additional_events metadata has no matching "
+                "code in epochs.event_id; cannot trust metadata reconstruction.",
+            )
+            return None
+        event_id_rebuilt[label] = match
+
+    events = []
+    epoch_indices = []
+    used_samples = set()
+    n_rows = min(len(metadata), len(epochs.events))
+
+    for i, entry in enumerate(metadata["additional_events"].head(n_rows)):
+        if not isinstance(entry, list):
+            continue
+        for label, rel_time in entry:
+            try:
+                sample_in_epoch = int(round((float(rel_time) - epochs.tmin) * sfreq))
+            except (TypeError, ValueError):
+                message(
+                    "warning",
+                    f"Epoch {i}, event '{label}': could not convert rel_time "
+                    f"'{rel_time}' to float. Skipping this event.",
+                )
+                continue
+
+            if not (0 <= sample_in_epoch < n_samples):
+                message(
+                    "warning",
+                    f"Epoch {i}, event '{label}': sample {sample_in_epoch} is outside "
+                    f"epoch data window [0, {n_samples - 1}]. Skipping.",
+                )
+                continue
+
+            # Collisions are nudged forward one sample at a time, but never
+            # past this epoch's own block — drifting into the next epoch's
+            # samples would silently mismatch the epoch_indices mapping.
+            epoch_start = i * n_samples
+            epoch_end = epoch_start + n_samples - 1
+            global_sample = epoch_start + sample_in_epoch
+            while global_sample in used_samples and global_sample < epoch_end:
+                global_sample += 1
+            if global_sample in used_samples:
+                message(
+                    "warning",
+                    f"Epoch {i}, event '{label}': too many colliding events in "
+                    "this epoch's window; dropping overflow event rather than "
+                    "let it drift into a neighboring epoch's data block.",
+                )
+                continue
+            used_samples.add(global_sample)
+
+            events.append([global_sample, 0, event_id_rebuilt[str(label)]])
+            epoch_indices.append(i)
+
+    if not events:
+        return None
+
+    return (
+        np.array(events, dtype=int),
+        event_id_rebuilt,
+        np.array(epoch_indices, dtype=int),
+    )
+
+
+def extract_epoch_events(
+    epochs: mne.BaseEpochs,
+) -> Tuple[np.ndarray, Dict[str, int], np.ndarray, str]:
+    """Extract a per-epoch event list, preferring metadata but never losing condition codes.
+
+    Parameters
+    ----------
+    epochs : mne.BaseEpochs
+        The epochs object to extract events from.
+
+    Returns
+    -------
+    events : np.ndarray, shape (n_events, 3)
+        Events expressed as global sample positions in the concatenated
+        (n_epochs * n_times) timeline, in the same [sample, 0, code] format
+        as MNE event arrays.
+    event_id : dict
+        Mapping of condition label -> code.
+    epoch_indices : np.ndarray
+        0-based epoch index that each row in `events` belongs to.
+    source : str
+        ``"metadata"`` when the richer additional_events reconstruction was
+        used, ``"primary"`` when this fell back to epochs.events/event_id
+        directly (also the value whenever no additional_events metadata is
+        present at all).
+
+    Notes
+    -----
+    ``epochs.metadata["additional_events"]`` is only used when it is present
+    and reconstructs at least one event for every epoch with labels that all
+    resolve to codes already present in ``epochs.event_id``. Otherwise this
+    falls back to ``epochs.events``/``epochs.event_id`` — which always covers
+    every epoch exactly once — and logs a warning explaining why.
+    """
+    n_epochs = len(epochs)
+    primary_events, primary_event_id, primary_epoch_indices = _primary_events(epochs)
+
+    if epochs.metadata is None or "additional_events" not in epochs.metadata.columns:
+        return primary_events, primary_event_id, primary_epoch_indices, "primary"
+
+    rebuilt = _rebuild_from_metadata(epochs)
+    if rebuilt is None:
+        message(
+            "warning",
+            "additional_events metadata unusable; falling back to epochs.events/"
+            "epochs.event_id to preserve original condition codes.",
+        )
+        return primary_events, primary_event_id, primary_epoch_indices, "primary"
+
+    events, event_id, epoch_indices = rebuilt
+    n_covered = len(np.unique(epoch_indices))
+    if n_covered < n_epochs:
+        message(
+            "warning",
+            f"additional_events metadata only covers {n_covered}/{n_epochs} epochs; "
+            "falling back to epochs.events/epochs.event_id to preserve original "
+            "condition codes.",
+        )
+        return primary_events, primary_event_id, primary_epoch_indices, "primary"
+
+    return events, event_id, epoch_indices, "metadata"

--- a/tests/unit/io/test_export_epoch_events.py
+++ b/tests/unit/io/test_export_epoch_events.py
@@ -1,0 +1,101 @@
+"""Round-trip tests: pre-epoched condition codes must survive EEGLAB export.
+
+Covers the bug where a synthetic (or pre-epoched) EpochsArray with multiple
+event IDs could lose its condition structure on export if
+epochs.metadata["additional_events"] was missing, empty, or misaligned.
+"""
+
+from collections import Counter
+from pathlib import Path
+from unittest.mock import patch
+
+import mne
+import numpy as np
+
+from autoclean.io.export import save_epochs_to_set
+
+
+def _make_epochs(n_epochs=8, n_channels=4, n_times=50, sfreq=100.0):
+    event_id = {"FREQ": 1, "RARE": 2}
+    codes = [1, 2]
+    data = np.random.randn(n_epochs, n_channels, n_times).astype("float64") * 1e-6
+    ch_names = [f"Ch{i}" for i in range(n_channels)]
+    info = mne.create_info(ch_names, sfreq, "eeg")
+    events = np.array(
+        [[i * n_times, 0, codes[i % len(codes)]] for i in range(n_epochs)]
+    )
+    return mne.EpochsArray(
+        data, info, events=events, tmin=-0.1, event_id=event_id, verbose=False
+    )
+
+
+def _autoclean_dict(tmp_path: Path) -> dict:
+    return {
+        "run_id": "run-001",
+        "unprocessed_file": str(tmp_path / "sample.set"),
+        "stage_dir": tmp_path / "stage",
+        "move_flagged_files": True,
+    }
+
+
+@patch("autoclean.io.export.manage_database_conditionally")
+def test_export_reopen_preserves_event_labels_and_codes(
+    mock_manage_database, tmp_path: Path
+) -> None:
+    """No additional_events metadata: epochs.event_id must survive export/reopen."""
+    epochs = _make_epochs()
+
+    result = save_epochs_to_set(
+        epochs, _autoclean_dict(tmp_path), stage="post_import"
+    )
+    reopened = mne.io.read_epochs_eeglab(str(result), verbose=False)
+
+    assert reopened.event_id == {"FREQ": 1, "RARE": 2}
+    assert Counter(reopened.events[:, 2].tolist()) == Counter(
+        epochs.events[:, 2].tolist()
+    )
+
+
+@patch("autoclean.io.export.manage_database_conditionally")
+def test_export_reopen_preserves_counts_per_condition(
+    mock_manage_database, tmp_path: Path
+) -> None:
+    epochs = _make_epochs(n_epochs=12)
+
+    result = save_epochs_to_set(
+        epochs, _autoclean_dict(tmp_path), stage="post_import"
+    )
+    reopened = mne.io.read_epochs_eeglab(str(result), verbose=False)
+
+    for label, code in epochs.event_id.items():
+        orig_count = int((epochs.events[:, 2] == code).sum())
+        new_count = int((reopened.events[:, 2] == reopened.event_id[label]).sum())
+        assert new_count == orig_count
+
+
+@patch("autoclean.io.export.manage_database_conditionally")
+def test_export_with_valid_metadata_still_preserves_codes(
+    mock_manage_database, tmp_path: Path
+) -> None:
+    """additional_events metadata covering every epoch should also round-trip cleanly."""
+    import pandas as pd
+
+    epochs = _make_epochs(n_epochs=6)
+    labels = ["FREQ", "RARE"]
+    epochs.metadata = pd.DataFrame(
+        {
+            "additional_events": [
+                [(labels[i % 2], 0.0)] for i in range(len(epochs))
+            ]
+        }
+    )
+
+    result = save_epochs_to_set(
+        epochs, _autoclean_dict(tmp_path), stage="post_import"
+    )
+    reopened = mne.io.read_epochs_eeglab(str(result), verbose=False)
+
+    assert reopened.event_id == {"FREQ": 1, "RARE": 2}
+    assert Counter(reopened.events[:, 2].tolist()) == Counter(
+        epochs.events[:, 2].tolist()
+    )

--- a/tests/unit/io/test_export_epoch_events.py
+++ b/tests/unit/io/test_export_epoch_events.py
@@ -45,9 +45,7 @@ def test_export_reopen_preserves_event_labels_and_codes(
     """No additional_events metadata: epochs.event_id must survive export/reopen."""
     epochs = _make_epochs()
 
-    result = save_epochs_to_set(
-        epochs, _autoclean_dict(tmp_path), stage="post_import"
-    )
+    result = save_epochs_to_set(epochs, _autoclean_dict(tmp_path), stage="post_import")
     reopened = mne.io.read_epochs_eeglab(str(result), verbose=False)
 
     assert reopened.event_id == {"FREQ": 1, "RARE": 2}
@@ -62,9 +60,7 @@ def test_export_reopen_preserves_counts_per_condition(
 ) -> None:
     epochs = _make_epochs(n_epochs=12)
 
-    result = save_epochs_to_set(
-        epochs, _autoclean_dict(tmp_path), stage="post_import"
-    )
+    result = save_epochs_to_set(epochs, _autoclean_dict(tmp_path), stage="post_import")
     reopened = mne.io.read_epochs_eeglab(str(result), verbose=False)
 
     for label, code in epochs.event_id.items():
@@ -83,16 +79,10 @@ def test_export_with_valid_metadata_still_preserves_codes(
     epochs = _make_epochs(n_epochs=6)
     labels = ["FREQ", "RARE"]
     epochs.metadata = pd.DataFrame(
-        {
-            "additional_events": [
-                [(labels[i % 2], 0.0)] for i in range(len(epochs))
-            ]
-        }
+        {"additional_events": [[(labels[i % 2], 0.0)] for i in range(len(epochs))]}
     )
 
-    result = save_epochs_to_set(
-        epochs, _autoclean_dict(tmp_path), stage="post_import"
-    )
+    result = save_epochs_to_set(epochs, _autoclean_dict(tmp_path), stage="post_import")
     reopened = mne.io.read_epochs_eeglab(str(result), verbose=False)
 
     assert reopened.event_id == {"FREQ": 1, "RARE": 2}

--- a/tests/unit/mixins/test_bids.py
+++ b/tests/unit/mixins/test_bids.py
@@ -16,9 +16,7 @@ except ImportError:
     TASK_AVAILABLE = False
 
 
-pytestmark = pytest.mark.skipif(
-    not TASK_AVAILABLE, reason="Task module not available"
-)
+pytestmark = pytest.mark.skipif(not TASK_AVAILABLE, reason="Task module not available")
 
 
 class _BIDSTask(Task):
@@ -136,10 +134,13 @@ def _create_mock_raw(task_with_epochs):
     """Helper: call create_mock_raw_from_epochs, patching filename validation."""
     epochs = task_with_epochs.epochs
     # MNE validates that filenames exist; patch the setter to avoid filesystem checks
-    with patch("mne.io.base.BaseRaw.filenames", new_callable=lambda: property(
-        fget=lambda self: getattr(self, "_filenames", []),
-        fset=lambda self, v: setattr(self, "_filenames", v),
-    )):
+    with patch(
+        "mne.io.base.BaseRaw.filenames",
+        new_callable=lambda: property(
+            fget=lambda self: getattr(self, "_filenames", []),
+            fset=lambda self, v: setattr(self, "_filenames", v),
+        ),
+    ):
         return task_with_epochs.create_mock_raw_from_epochs(epochs)
 
 
@@ -171,6 +172,7 @@ class TestCreateBIDSPath:
     def _make_mock_bids_path(self, tmp_path):
         """Return a minimal mock BIDSPath-like object."""
         from unittest.mock import MagicMock
+
         bids_path = MagicMock()
         bids_path.basename = "sub-test_task-test_eeg.fif"
         bids_path.subject = "test"
@@ -191,8 +193,10 @@ class TestCreateBIDSPath:
         mock_bids_path, mock_derivatives = self._make_mock_bids_path(tmp_path)
 
         with (
-            patch("autoclean.mixins.utils.bids.step_convert_to_bids",
-                  return_value=(mock_bids_path, mock_derivatives)),
+            patch(
+                "autoclean.mixins.utils.bids.step_convert_to_bids",
+                return_value=(mock_bids_path, mock_derivatives),
+            ),
             patch.object(t, "_update_metadata"),
         ):
             t.create_bids_path()
@@ -205,8 +209,10 @@ class TestCreateBIDSPath:
         mock_bids_path, mock_derivatives = self._make_mock_bids_path(tmp_path)
 
         with (
-            patch("autoclean.mixins.utils.bids.step_convert_to_bids",
-                  return_value=(mock_bids_path, mock_derivatives)),
+            patch(
+                "autoclean.mixins.utils.bids.step_convert_to_bids",
+                return_value=(mock_bids_path, mock_derivatives),
+            ),
             patch.object(t, "_update_metadata"),
         ):
             t.create_bids_path()
@@ -231,8 +237,10 @@ class TestCreateBIDSPath:
         mock_bids_path, mock_derivatives = self._make_mock_bids_path(tmp_path)
 
         with (
-            patch("autoclean.mixins.utils.bids.step_convert_to_bids",
-                  return_value=(mock_bids_path, mock_derivatives)) as mock_convert,
+            patch(
+                "autoclean.mixins.utils.bids.step_convert_to_bids",
+                return_value=(mock_bids_path, mock_derivatives),
+            ) as mock_convert,
             patch.object(t, "_update_metadata"),
         ):
             t.create_bids_path()
@@ -245,8 +253,10 @@ class TestCreateBIDSPath:
         t = self._make_task_with_bids_config(tmp_path)
 
         with (
-            patch("autoclean.mixins.utils.bids.step_convert_to_bids",
-                  side_effect=ValueError("BIDS conversion failed")),
+            patch(
+                "autoclean.mixins.utils.bids.step_convert_to_bids",
+                side_effect=ValueError("BIDS conversion failed"),
+            ),
             patch.object(t, "_update_metadata"),
         ):
             with pytest.raises(ValueError, match="BIDS conversion failed"):
@@ -270,8 +280,10 @@ class TestCreateBIDSPath:
         mock_bids_path, mock_derivatives = self._make_mock_bids_path(tmp_path)
 
         with (
-            patch("autoclean.mixins.utils.bids.step_convert_to_bids",
-                  return_value=(mock_bids_path, mock_derivatives)) as mock_convert,
+            patch(
+                "autoclean.mixins.utils.bids.step_convert_to_bids",
+                return_value=(mock_bids_path, mock_derivatives),
+            ) as mock_convert,
             patch.object(t, "_update_metadata"),
         ):
             t.create_bids_path()
@@ -319,9 +331,7 @@ class TestCreateMockRawFromEpochs:
         expected_data = epoch_data.transpose(1, 0, 2).reshape(n_channels, -1)
 
         result = _create_mock_raw(task_with_epochs)
-        np.testing.assert_array_almost_equal(
-            result.get_data(), expected_data
-        )
+        np.testing.assert_array_almost_equal(result.get_data(), expected_data)
 
     def test_preserves_condition_labels_as_annotations(
         self, task_with_two_condition_epochs
@@ -332,9 +342,7 @@ class TestCreateMockRawFromEpochs:
         descriptions = set(result.annotations.description)
         assert descriptions == {"FREQ", "RARE"}
 
-    def test_annotation_count_matches_epoch_count(
-        self, task_with_two_condition_epochs
-    ):
+    def test_annotation_count_matches_epoch_count(self, task_with_two_condition_epochs):
         epochs = task_with_two_condition_epochs.epochs
         result = _create_mock_raw(task_with_two_condition_epochs)
 

--- a/tests/unit/mixins/test_bids.py
+++ b/tests/unit/mixins/test_bids.py
@@ -1,6 +1,5 @@
 """Unit tests for BIDSMixin."""
 
-from pathlib import Path
 from unittest.mock import patch
 
 import mne
@@ -60,6 +59,71 @@ def task_with_epochs(tmp_path):
     t.epochs = mne.Epochs(
         raw, events, tmin=0, tmax=2.0, baseline=None, preload=True, verbose=False
     )
+    return t
+
+
+@pytest.fixture
+def task_with_two_condition_epochs(tmp_path):
+    """Epochs with two distinct event IDs, as in a pre-epoched ERP dataset."""
+    config = {
+        "run_id": "test",
+        "unprocessed_file": tmp_path / "test.fif",
+        "task": "test",
+    }
+    t = _BIDSTask(config)
+    raw = create_synthetic_raw(
+        montage="standard_1020", n_channels=8, duration=30.0, sfreq=250.0
+    )
+    fixed_events = mne.make_fixed_length_events(raw, duration=2.0)
+    fixed_events[::2, 2] = 1
+    fixed_events[1::2, 2] = 2
+    event_id = {"FREQ": 1, "RARE": 2}
+    t.epochs = mne.Epochs(
+        raw,
+        fixed_events,
+        event_id=event_id,
+        tmin=0,
+        tmax=2.0,
+        baseline=None,
+        preload=True,
+        verbose=False,
+    )
+    return t
+
+
+@pytest.fixture
+def task_with_real_meas_date_epochs(tmp_path):
+    """Epochs derived from a Raw with a real meas_date set, as with real recordings.
+
+    epochs.annotations.orig_time is non-None in this case, which previously
+    crashed condition-label annotation building in create_mock_raw_from_epochs
+    (mne.Annotations concatenation requires matching orig_time).
+    """
+    config = {
+        "run_id": "test",
+        "unprocessed_file": tmp_path / "test.fif",
+        "task": "test",
+    }
+    t = _BIDSTask(config)
+    raw = create_synthetic_raw(
+        montage="standard_1020", n_channels=8, duration=30.0, sfreq=250.0
+    )
+    raw.set_meas_date(1_600_000_000)
+    fixed_events = mne.make_fixed_length_events(raw, duration=2.0)
+    fixed_events[::2, 2] = 1
+    fixed_events[1::2, 2] = 2
+    event_id = {"FREQ": 1, "RARE": 2}
+    t.epochs = mne.Epochs(
+        raw,
+        fixed_events,
+        event_id=event_id,
+        tmin=0,
+        tmax=2.0,
+        baseline=None,
+        preload=True,
+        verbose=False,
+    )
+    assert t.epochs.annotations.orig_time is not None
     return t
 
 
@@ -258,3 +322,50 @@ class TestCreateMockRawFromEpochs:
         np.testing.assert_array_almost_equal(
             result.get_data(), expected_data
         )
+
+    def test_preserves_condition_labels_as_annotations(
+        self, task_with_two_condition_epochs
+    ):
+        """Condition structure must survive the epochs -> mock raw conversion."""
+        result = _create_mock_raw(task_with_two_condition_epochs)
+
+        descriptions = set(result.annotations.description)
+        assert descriptions == {"FREQ", "RARE"}
+
+    def test_annotation_count_matches_epoch_count(
+        self, task_with_two_condition_epochs
+    ):
+        epochs = task_with_two_condition_epochs.epochs
+        result = _create_mock_raw(task_with_two_condition_epochs)
+
+        assert len(result.annotations) == len(epochs)
+
+    def test_annotation_counts_per_condition_match_event_id(
+        self, task_with_two_condition_epochs
+    ):
+        epochs = task_with_two_condition_epochs.epochs
+        result = _create_mock_raw(task_with_two_condition_epochs)
+
+        from collections import Counter
+
+        orig_counts = Counter(epochs.events[:, 2].tolist())
+        code_to_label = {code: label for label, code in epochs.event_id.items()}
+        expected = Counter(
+            {code_to_label[code]: count for code, count in orig_counts.items()}
+        )
+        actual = Counter(result.annotations.description.tolist())
+        assert actual == expected
+
+    def test_does_not_raise_when_epochs_have_a_real_orig_time(
+        self, task_with_real_meas_date_epochs
+    ):
+        """Regression test: mne.Annotations concatenation requires matching
+        orig_time. Real recordings carry a non-None orig_time on
+        epochs.annotations (from the source Raw's meas_date), which must not
+        crash condition-label annotation building."""
+        result = _create_mock_raw(task_with_real_meas_date_epochs)
+
+        epochs = task_with_real_meas_date_epochs.epochs
+        descriptions = set(result.annotations.description)
+        assert descriptions == {"FREQ", "RARE"}
+        assert len(result.annotations) == len(epochs)

--- a/tests/unit/utils/test_epoch_events.py
+++ b/tests/unit/utils/test_epoch_events.py
@@ -127,6 +127,24 @@ class TestMetadataSource:
         # Original condition codes must not be silently replaced/renumbered.
         assert event_id == {"FREQ": 1, "RARE": 2}
 
+    def test_falls_back_to_primary_when_metadata_entry_malformed(self):
+        epochs = _make_epochs(n_epochs=4)
+        epochs.metadata = pd.DataFrame(
+            {
+                "additional_events": [
+                    [("FREQ", 0.0)],
+                    [("RARE",)],
+                    [("FREQ", 0.0)],
+                    [("RARE", 0.0)],
+                ]
+            }
+        )
+
+        _events, event_id, _epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "primary"
+        assert event_id == {"FREQ": 1, "RARE": 2}
+
     def test_never_invents_codes_outside_original_event_id(self):
         epochs = _make_epochs(n_epochs=4)
         epochs.metadata = pd.DataFrame(

--- a/tests/unit/utils/test_epoch_events.py
+++ b/tests/unit/utils/test_epoch_events.py
@@ -1,0 +1,193 @@
+"""Tests for the centralized epoch event extraction helper."""
+
+from typing import Dict
+
+import mne
+import numpy as np
+import pandas as pd
+
+from autoclean.utils.epoch_events import extract_epoch_events
+
+
+def _make_epochs(
+    n_epochs: int = 6,
+    n_channels: int = 3,
+    n_times: int = 50,
+    sfreq: float = 100.0,
+    tmin: float = -0.1,
+    event_id: Dict[str, int] = None,
+) -> mne.EpochsArray:
+    event_id = event_id or {"FREQ": 1, "RARE": 2}
+    codes = list(event_id.values())
+    data = np.random.randn(n_epochs, n_channels, n_times).astype("float64") * 1e-6
+    ch_names = [f"Ch{i}" for i in range(n_channels)]
+    info = mne.create_info(ch_names, sfreq, "eeg")
+    events = np.array(
+        [[i * n_times, 0, codes[i % len(codes)]] for i in range(n_epochs)]
+    )
+    return mne.EpochsArray(
+        data, info, events=events, tmin=tmin, event_id=event_id, verbose=False
+    )
+
+
+class TestPrimarySource:
+    def test_used_when_metadata_is_none(self):
+        epochs = _make_epochs()
+        events, event_id, epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "primary"
+        assert event_id == {"FREQ": 1, "RARE": 2}
+        assert list(events[:, 2]) == list(epochs.events[:, 2])
+        assert list(epoch_indices) == list(range(len(epochs)))
+
+    def test_used_when_additional_events_column_absent(self):
+        epochs = _make_epochs()
+        epochs.metadata = pd.DataFrame({"other_col": [1] * len(epochs)})
+
+        _events, event_id, _epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "primary"
+        assert event_id == {"FREQ": 1, "RARE": 2}
+
+    def test_covers_every_epoch_exactly_once(self):
+        epochs = _make_epochs(n_epochs=8)
+        events, _event_id, epoch_indices, _source = extract_epoch_events(epochs)
+
+        assert len(events) == len(epochs)
+        assert sorted(epoch_indices.tolist()) == list(range(len(epochs)))
+
+    def test_condition_counts_match_original(self):
+        epochs = _make_epochs(n_epochs=10)
+        events, _event_id, _epoch_indices, _source = extract_epoch_events(epochs)
+
+        orig_counts = {
+            code: int((epochs.events[:, 2] == code).sum())
+            for code in epochs.event_id.values()
+        }
+        new_counts = {
+            code: int((events[:, 2] == code).sum()) for code in epochs.event_id.values()
+        }
+        assert new_counts == orig_counts
+
+
+class TestMetadataSource:
+    def test_used_when_metadata_valid_and_covers_every_epoch(self):
+        epochs = _make_epochs(n_epochs=4)
+        epochs.metadata = pd.DataFrame(
+            {
+                "additional_events": [
+                    [("FREQ", 0.0)],
+                    [("RARE", 0.0)],
+                    [("FREQ", 0.0)],
+                    [("RARE", 0.0)],
+                ]
+            }
+        )
+
+        _events, event_id, epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "metadata"
+        assert event_id == {"FREQ": 1, "RARE": 2}
+        assert sorted(np.unique(epoch_indices).tolist()) == list(range(4))
+
+    def test_falls_back_to_primary_when_metadata_missing_an_epoch(self):
+        epochs = _make_epochs(n_epochs=4)
+        epochs.metadata = pd.DataFrame(
+            {
+                "additional_events": [
+                    [("FREQ", 0.0)],
+                    None,
+                    [("FREQ", 0.0)],
+                    [("RARE", 0.0)],
+                ]
+            }
+        )
+
+        _events, event_id, _epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "primary"
+        assert event_id == {"FREQ": 1, "RARE": 2}
+
+    def test_falls_back_to_primary_when_label_unknown_to_event_id(self):
+        epochs = _make_epochs(n_epochs=4)
+        epochs.metadata = pd.DataFrame(
+            {
+                "additional_events": [
+                    [("BOGUS", 0.0)],
+                    [("RARE", 0.0)],
+                    [("FREQ", 0.0)],
+                    [("RARE", 0.0)],
+                ]
+            }
+        )
+
+        _events, event_id, _epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "primary"
+        # Original condition codes must not be silently replaced/renumbered.
+        assert event_id == {"FREQ": 1, "RARE": 2}
+
+    def test_never_invents_codes_outside_original_event_id(self):
+        epochs = _make_epochs(n_epochs=4)
+        epochs.metadata = pd.DataFrame(
+            {
+                "additional_events": [
+                    [("FREQ", 0.0)],
+                    [("RARE", 0.0)],
+                    [("FREQ", 0.0)],
+                    [("RARE", 0.0)],
+                ]
+            }
+        )
+
+        _events, event_id, _epoch_indices, _source = extract_epoch_events(epochs)
+
+        assert set(event_id.values()).issubset(set(epochs.event_id.values()))
+
+    def test_colliding_events_do_not_drift_into_next_epochs_block(self):
+        """Many same-instant additional_events in one epoch must not spill over
+        into the sample range owned by the next epoch."""
+        n_times = 10
+        epochs = _make_epochs(n_epochs=3, n_times=n_times)
+        # 15 events all at rel_time=0.0 for epoch 0 -- more than n_times slots.
+        epochs.metadata = pd.DataFrame(
+            {
+                "additional_events": [
+                    [("FREQ", 0.0)] * 15,
+                    [("RARE", 0.0)],
+                    [("FREQ", 0.0)],
+                ]
+            }
+        )
+
+        events, _event_id, epoch_indices, _source = extract_epoch_events(epochs)
+
+        epoch0_samples = events[epoch_indices == 0][:, 0]
+        assert epoch0_samples.max() < n_times  # never crosses into epoch 1's block
+
+
+class TestPrimarySourceEdgeCases:
+    def test_handles_zero_epochs_without_crashing(self):
+        epochs = _make_epochs(n_epochs=2)
+        epochs.drop(list(range(len(epochs))))
+
+        events, event_id, epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "primary"
+        assert events.shape == (0, 3)
+        assert epoch_indices.shape == (0,)
+        assert event_id == {"FREQ": 1, "RARE": 2}
+
+    def test_handles_epoch_window_that_excludes_t_zero(self):
+        """tmin > 0 (e.g. response-locked, post-stimulus-only epochs) must not
+        place a "trigger" sample inside a neighboring epoch's data block."""
+        n_times = 50
+        epochs = _make_epochs(n_epochs=4, n_times=n_times, tmin=0.2)
+
+        events, _event_id, _epoch_indices, source = extract_epoch_events(epochs)
+
+        assert source == "primary"
+        # Every event's sample offset within its own epoch block must stay
+        # inside [0, n_times), never landing in an adjacent epoch's block.
+        offsets_within_epoch = events[:, 0] % n_times
+        assert np.all((offsets_within_epoch >= 0) & (offsets_within_epoch < n_times))


### PR DESCRIPTION
## Summary
- Centralizes epoch event extraction into a shared helper (`autoclean.utils.epoch_events.extract_epoch_events`) used by both EEGLAB `.set` export and epoch-to-mock-raw BIDS conversion.
- Prefers the richer `additional_events` metadata reconstruction when it validly covers every epoch and every label maps to an existing code in `epochs.event_id`.
- Falls back to `epochs.events`/`epochs.event_id` — the authoritative source of truth — whenever that metadata is missing, incomplete, or references unknown labels, instead of silently inventing/renumbering condition codes.
- `create_mock_raw_from_epochs` (BIDS path) now stamps condition-label annotations onto the mock Raw object so BIDS conversion no longer loses event structure.

Fixes #217.

## Test plan
- [x] `tests/unit/utils/test_epoch_events.py` — new unit coverage of primary vs. metadata source selection, including edge cases (unknown label, missing epoch coverage, zero epochs, epoch windows that exclude t=0, colliding same-instant events).
- [x] `tests/unit/io/test_export_epoch_events.py` — synthetic `EpochsArray` with `event_id={"FREQ": 1, "RARE": 2}`, exported and reopened via `mne.io.read_epochs_eeglab`, asserting labels/codes/counts survive.
- [x] `tests/unit/mixins/test_bids.py` — new fixtures covering two-condition epochs and epochs with a real `meas_date`/`orig_time` (regression test for an annotation-concatenation crash found during review).
- [x] Full `tests/unit/io`, `tests/unit/mixins`, `tests/unit/utils` suites pass; `ruff check` clean.