### PR TITLE
deps: bump textual to 6.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     # Machine learning
     "torch==2.2.2",
     # Utilities and data handling
-    "rich==14.1.0",
+    "rich==14.2.0",
     "python-dotenv==1.1.1",
     "defusedxml==0.7.1",
     "pyyaml==6.0.2",
@@ -81,7 +81,7 @@ dependencies = [
     "autocleaneeg-mne-qt-browser-fork==0.8.2",
     # "PySide6>=6.5.0",
     "pyjsonviewer==1.6.0",
-    "textual==6.1.0",
+    "textual==6.5.0",
     "textual-dev==1.7.0",
     "pyvistaqt==0.11.3",
     "qtpy==2.4.3",


### PR DESCRIPTION
## Summary

- Revives the closed Dependabot update from #126 by bumping `textual` from `6.1.0` to `6.5.0`.
- Bumps `rich` from `14.1.0` to `14.2.0`, which is required by `textual==6.5.0` during dependency resolution.

## Validation

- `uv lock --check` with `UV_CACHE_DIR` inside the isolated worktree resolved 232 packages successfully.
- `git diff --check`

## Notes

- `uv.lock` is intentionally ignored by this repository, so the PR only changes `pyproject.toml`.
- Work was done in isolated worktree `worktrees/issue-126-textual` on branch `agent/126-bump-textual-6-5-0`.