### PR TITLE
fix: resolve pre-existing black/isort/ruff violations

### DIFF
--- a/scripts/check_code_quality.py
+++ b/scripts/check_code_quality.py
@@ -14,6 +14,10 @@ import sys
 from pathlib import Path
 from typing import List, Tuple
 
+if sys.stdout.encoding is not None and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 
 class CodeQualityChecker:
     """Run code quality checks locally using uv tool."""
@@ -45,7 +49,13 @@ class CodeQualityChecker:
 
         try:
             result = subprocess.run(
-                cmd, capture_output=True, text=True, check=False, cwd=Path.cwd()
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+                cwd=Path.cwd(),
             )
 
             success = result.returncode == 0
@@ -70,12 +80,19 @@ class CodeQualityChecker:
                 print(f"   ❌ {error_msg}")
             return False, error_msg
 
+    # Pinned to match the versions installed in .github/workflows/ci.yml so
+    # local results agree with CI instead of drifting to whatever "latest" is
+    # cached by `uv tool run`.
+    BLACK_VERSION = "black==25.9.0"
+    ISORT_VERSION = "isort==6.0.1"
+    RUFF_VERSION = "ruff==0.15.20"
+
     def check_black(self) -> Tuple[bool, str]:
         """Check code formatting with Black."""
         if self.use_uv:
-            cmd = ["uv", "tool", "run", "black", "--check", "--diff", str(self.src_dir)]
+            cmd = ["uv", "tool", "run", self.BLACK_VERSION, "--check", "--diff", str(self.src_dir)]
             if self.fix:
-                cmd = ["uv", "tool", "run", "black", str(self.src_dir)]
+                cmd = ["uv", "tool", "run", self.BLACK_VERSION, str(self.src_dir)]
         else:
             cmd = ["black", "--check", "--diff", str(self.src_dir)]
             if self.fix:
@@ -86,9 +103,9 @@ class CodeQualityChecker:
     def check_isort(self) -> Tuple[bool, str]:
         """Check import sorting with isort."""
         if self.use_uv:
-            cmd = ["uv", "tool", "run", "isort", "--check-only", "--diff", str(self.src_dir)]
+            cmd = ["uv", "tool", "run", self.ISORT_VERSION, "--check-only", "--diff", str(self.src_dir)]
             if self.fix:
-                cmd = ["uv", "tool", "run", "isort", str(self.src_dir)]
+                cmd = ["uv", "tool", "run", self.ISORT_VERSION, str(self.src_dir)]
         else:
             cmd = ["isort", "--check-only", "--diff", str(self.src_dir)]
             if self.fix:
@@ -99,9 +116,9 @@ class CodeQualityChecker:
     def check_ruff(self) -> Tuple[bool, str]:
         """Check code with Ruff linter."""
         if self.use_uv:
-            cmd = ["uv", "tool", "run", "ruff", "check", str(self.src_dir)]
+            cmd = ["uv", "tool", "run", self.RUFF_VERSION, "check", str(self.src_dir)]
             if self.fix:
-                cmd = ["uv", "tool", "run", "ruff", "check", "--fix", str(self.src_dir)]
+                cmd = ["uv", "tool", "run", self.RUFF_VERSION, "check", "--fix", str(self.src_dir)]
         else:
             cmd = ["ruff", "check", str(self.src_dir)]
             if self.fix:

--- a/scripts/check_code_quality.py
+++ b/scripts/check_code_quality.py
@@ -22,19 +22,25 @@ if sys.stdout.encoding is not None and sys.stdout.encoding.lower() != "utf-8":
 class CodeQualityChecker:
     """Run code quality checks locally using uv tool."""
 
-    def __init__(self, src_dir: Path = None, fix: bool = False, verbose: bool = True, use_uv: bool = None):
+    def __init__(
+        self,
+        src_dir: Path = None,
+        fix: bool = False,
+        verbose: bool = True,
+        use_uv: bool = None,
+    ):
         """Initialize code quality checker."""
         self.src_dir = src_dir or Path("src/autoclean")
         self.fix = fix
         self.verbose = verbose
         self.results = []
-        
+
         # Auto-detect uv if not specified
         if use_uv is None:
-            self.use_uv = shutil.which('uv') is not None
+            self.use_uv = shutil.which("uv") is not None
         else:
             self.use_uv = use_uv
-            
+
         if self.verbose and self.use_uv:
             print("📦 Using uv tool for isolated command execution")
 
@@ -90,7 +96,15 @@ class CodeQualityChecker:
     def check_black(self) -> Tuple[bool, str]:
         """Check code formatting with Black."""
         if self.use_uv:
-            cmd = ["uv", "tool", "run", self.BLACK_VERSION, "--check", "--diff", str(self.src_dir)]
+            cmd = [
+                "uv",
+                "tool",
+                "run",
+                self.BLACK_VERSION,
+                "--check",
+                "--diff",
+                str(self.src_dir),
+            ]
             if self.fix:
                 cmd = ["uv", "tool", "run", self.BLACK_VERSION, str(self.src_dir)]
         else:
@@ -103,7 +117,15 @@ class CodeQualityChecker:
     def check_isort(self) -> Tuple[bool, str]:
         """Check import sorting with isort."""
         if self.use_uv:
-            cmd = ["uv", "tool", "run", self.ISORT_VERSION, "--check-only", "--diff", str(self.src_dir)]
+            cmd = [
+                "uv",
+                "tool",
+                "run",
+                self.ISORT_VERSION,
+                "--check-only",
+                "--diff",
+                str(self.src_dir),
+            ]
             if self.fix:
                 cmd = ["uv", "tool", "run", self.ISORT_VERSION, str(self.src_dir)]
         else:
@@ -118,7 +140,15 @@ class CodeQualityChecker:
         if self.use_uv:
             cmd = ["uv", "tool", "run", self.RUFF_VERSION, "check", str(self.src_dir)]
             if self.fix:
-                cmd = ["uv", "tool", "run", self.RUFF_VERSION, "check", "--fix", str(self.src_dir)]
+                cmd = [
+                    "uv",
+                    "tool",
+                    "run",
+                    self.RUFF_VERSION,
+                    "check",
+                    "--fix",
+                    str(self.src_dir),
+                ]
         else:
             cmd = ["ruff", "check", str(self.src_dir)]
             if self.fix:
@@ -129,7 +159,14 @@ class CodeQualityChecker:
     def check_mypy(self) -> Tuple[bool, str]:
         """Check types with mypy."""
         if self.use_uv:
-            cmd = ["uv", "tool", "run", "mypy", str(self.src_dir), "--ignore-missing-imports"]
+            cmd = [
+                "uv",
+                "tool",
+                "run",
+                "mypy",
+                str(self.src_dir),
+                "--ignore-missing-imports",
+            ]
         else:
             cmd = ["mypy", str(self.src_dir), "--ignore-missing-imports"]
 
@@ -149,7 +186,9 @@ class CodeQualityChecker:
             print("=" * 50)
             print(f"Source directory: {self.src_dir}")
             print(f"Fix mode: {'ON' if self.fix else 'OFF'}")
-            print(f"Tool execution: {'uv tool run' if self.use_uv else 'direct command'}")
+            print(
+                f"Tool execution: {'uv tool run' if self.use_uv else 'direct command'}"
+            )
 
         all_passed = True
 
@@ -217,7 +256,9 @@ Examples:
     )
     parser.add_argument("--quiet", action="store_true", help="Reduce output verbosity")
     parser.add_argument(
-        "--no-uv", action="store_true", help="Use direct commands instead of 'uv tool run'"
+        "--no-uv",
+        action="store_true",
+        help="Use direct commands instead of 'uv tool run'",
     )
     parser.add_argument(
         "--check",
@@ -235,10 +276,7 @@ Examples:
 
     # Initialize checker
     checker = CodeQualityChecker(
-        src_dir=args.src, 
-        fix=args.fix, 
-        verbose=not args.quiet,
-        use_uv=not args.no_uv
+        src_dir=args.src, fix=args.fix, verbose=not args.quiet, use_uv=not args.no_uv
     )
 
     # Run checks

--- a/src/autoclean/api/events.py
+++ b/src/autoclean/api/events.py
@@ -83,11 +83,13 @@ async def websocket_events(websocket: WebSocket) -> None:
 
     try:
         # Send initial connection event
-        await websocket.send_json({
-            "type": "connected",
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "data": {"message": "Connected to event stream"},
-        })
+        await websocket.send_json(
+            {
+                "type": "connected",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "data": {"message": "Connected to event stream"},
+            }
+        )
 
         # Keep connection alive and handle incoming messages
         while True:
@@ -105,10 +107,12 @@ async def websocket_events(websocket: WebSocket) -> None:
             except asyncio.TimeoutError:
                 # Send keepalive ping
                 try:
-                    await websocket.send_json({
-                        "type": "ping",
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                    })
+                    await websocket.send_json(
+                        {
+                            "type": "ping",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                        }
+                    )
                 except Exception:
                     break
 
@@ -119,6 +123,7 @@ async def websocket_events(websocket: WebSocket) -> None:
 
 
 # Convenience functions for broadcasting events
+
 
 async def emit_queue_update(
     action: str,

--- a/src/autoclean/api/models.py
+++ b/src/autoclean/api/models.py
@@ -66,10 +66,18 @@ class QueueEntry(BaseModel):
     path: str = Field(description="Full file path")
     status: QueueStatus = Field(description="Entry status")
     route_id: Optional[str] = Field(default=None, description="Assigned route ID")
-    ingestion_root: Optional[str] = Field(default=None, description="Ingestion root path")
-    added_at: Optional[str] = Field(default=None, description="ISO timestamp when added")
-    processed_at: Optional[str] = Field(default=None, description="ISO timestamp when processed")
-    failed_at: Optional[str] = Field(default=None, description="ISO timestamp when failed")
+    ingestion_root: Optional[str] = Field(
+        default=None, description="Ingestion root path"
+    )
+    added_at: Optional[str] = Field(
+        default=None, description="ISO timestamp when added"
+    )
+    processed_at: Optional[str] = Field(
+        default=None, description="ISO timestamp when processed"
+    )
+    failed_at: Optional[str] = Field(
+        default=None, description="ISO timestamp when failed"
+    )
     last_error: Optional[str] = Field(default=None, description="Last error message")
 
 
@@ -142,7 +150,9 @@ class WorkerInfo(BaseModel):
     name: str = Field(description="Worker name")
     status: WorkerStatus = Field(description="Current status")
     current_job: Optional[str] = Field(default=None, description="Current job ID")
-    queues: list[str] = Field(default_factory=list, description="Queues being processed")
+    queues: list[str] = Field(
+        default_factory=list, description="Queues being processed"
+    )
     pid: Optional[int] = Field(default=None, description="Process ID")
 
 
@@ -288,34 +298,54 @@ class RouteSpecResponse(BaseModel):
     taskfile: str = Field(description="Task file or task name")
     montage: str = Field(description="Montage identifier")
     version: Optional[str] = Field(default=None, description="Optional version tag")
-    ingestion_folders: list[str] = Field(default_factory=list, description="Input roots")
-    ingestion_excludes: list[str] = Field(default_factory=list, description="Excluded subpaths")
+    ingestion_folders: list[str] = Field(
+        default_factory=list, description="Input roots"
+    )
+    ingestion_excludes: list[str] = Field(
+        default_factory=list, description="Excluded subpaths"
+    )
     file_globs: list[str] = Field(default_factory=list, description="File patterns")
     recursive: bool = Field(default=False, description="Whether scanning is recursive")
     sentinel_ext: Optional[str] = Field(default=None, description="Sentinel extension")
-    automation_root: Optional[str] = Field(default=None, description="Automation output root")
-    workspace_name: Optional[str] = Field(default=None, description="Workspace naming template")
-    output_path: Optional[str] = Field(default=None, description="Resolved automation output path")
+    automation_root: Optional[str] = Field(
+        default=None, description="Automation output root"
+    )
+    workspace_name: Optional[str] = Field(
+        default=None, description="Workspace naming template"
+    )
+    output_path: Optional[str] = Field(
+        default=None, description="Resolved automation output path"
+    )
 
 
 class RouteUpsertRequest(BaseModel):
     """Create/update payload for one route spec."""
 
     id: str = Field(description="Route ID")
-    modes: list[str] = Field(default_factory=lambda: ["test"], description="Target modes")
+    modes: list[str] = Field(
+        default_factory=lambda: ["test"], description="Target modes"
+    )
     enabled: bool = Field(default=True, description="Whether the route is enabled")
     archived: bool = Field(default=False, description="Whether the route is archived")
     priority: int = Field(default=0, description="Route priority")
     taskfile: str = Field(description="Task file or task name")
     montage: str = Field(description="Montage identifier")
     version: Optional[str] = Field(default=None, description="Optional version tag")
-    ingestion_folders: list[str] = Field(default_factory=list, description="Input roots")
-    ingestion_excludes: list[str] = Field(default_factory=list, description="Excluded subpaths")
+    ingestion_folders: list[str] = Field(
+        default_factory=list, description="Input roots"
+    )
+    ingestion_excludes: list[str] = Field(
+        default_factory=list, description="Excluded subpaths"
+    )
     file_globs: list[str] = Field(default_factory=list, description="File patterns")
     recursive: bool = Field(default=False, description="Whether scanning is recursive")
     sentinel_ext: Optional[str] = Field(default=None, description="Sentinel extension")
-    automation_root: Optional[str] = Field(default=None, description="Automation output root")
-    workspace_name: Optional[str] = Field(default=None, description="Workspace naming template")
+    automation_root: Optional[str] = Field(
+        default=None, description="Automation output root"
+    )
+    workspace_name: Optional[str] = Field(
+        default=None, description="Workspace naming template"
+    )
 
 
 class RouteActionResponse(BaseModel):
@@ -331,8 +361,12 @@ class SyncResponse(BaseModel):
 
     success: bool = Field(description="Whether sync succeeded")
     message: str = Field(description="Status message")
-    test_path: Optional[str] = Field(default=None, description="Compiled test config path")
-    live_path: Optional[str] = Field(default=None, description="Compiled live config path")
+    test_path: Optional[str] = Field(
+        default=None, description="Compiled test config path"
+    )
+    live_path: Optional[str] = Field(
+        default=None, description="Compiled live config path"
+    )
 
 
 class ServiceStatusResponse(BaseModel):
@@ -341,7 +375,9 @@ class ServiceStatusResponse(BaseModel):
     running: bool = Field(description="Whether the dispatcher is running")
     pid: Optional[int] = Field(default=None, description="Dispatcher PID")
     mode: str = Field(description="Current serve mode")
-    uptime_seconds: Optional[float] = Field(default=None, description="Dispatcher uptime in seconds")
+    uptime_seconds: Optional[float] = Field(
+        default=None, description="Dispatcher uptime in seconds"
+    )
     can_start: bool = Field(
         default=True,
         description="Whether the dispatcher can be started with the current workspace state",

--- a/src/autoclean/api/pdf_extractor.py
+++ b/src/autoclean/api/pdf_extractor.py
@@ -48,7 +48,7 @@ def extract_ica_summary(pdf_path: Path) -> list[dict[str, Any]]:
             if "Component" not in text or "Confidence" not in text:
                 continue
 
-            lines = [l.strip() for l in text.split("\n") if l.strip()]
+            lines = [ln.strip() for ln in text.split("\n") if ln.strip()]
             i = 0
             while i < len(lines):
                 line = lines[i]
@@ -61,12 +61,14 @@ def extract_ica_summary(pdf_path: Path) -> list[dict[str, Any]]:
                         except ValueError:
                             conf = 0.0
                         rejected = lines[i + 3].strip().lower() == "yes"
-                        components.append({
-                            "component": comp,
-                            "type": candidate_type,
-                            "confidence": round(conf, 3),
-                            "rejected": rejected,
-                        })
+                        components.append(
+                            {
+                                "component": comp,
+                                "type": candidate_type,
+                                "confidence": round(conf, 3),
+                                "rejected": rejected,
+                            }
+                        )
                         seen.add(comp)
                         i += 4
                         continue
@@ -141,13 +143,17 @@ def get_ica_structure(pdf_path: Path) -> dict[str, Any]:
                 continue
 
             # Topo grid pages contain "Topographies Overview" or "Topograph...Batch"
-            if "Topographies Overview" in text or ("Topograph" in text and "Batch" in text):
+            if "Topographies Overview" in text or (
+                "Topograph" in text and "Batch" in text
+            ):
                 topo_grid_pages.append(page_idx)
                 continue
 
             # Per-component detail pages contain "IC<N> Topography" or
             # "ICA Component IC<N>"
-            ic_match = re.search(r"(?:ICA Component |^)\s*(IC\d+)\s+(?:Topography|Analysis)", text)
+            ic_match = re.search(
+                r"(?:ICA Component |^)\s*(IC\d+)\s+(?:Topography|Analysis)", text
+            )
             if ic_match:
                 comp_name = ic_match.group(1)
                 detail_page_map[comp_name] = page_idx
@@ -163,7 +169,9 @@ def get_ica_structure(pdf_path: Path) -> dict[str, Any]:
             "summary_pages": summary_pages,
             "topo_grid_page": topo_grid_pages[0] if topo_grid_pages else None,
             "topo_grid_pages": topo_grid_pages,
-            "detail_start_page": min(detail_page_map.values()) if detail_page_map else None,
+            "detail_start_page": (
+                min(detail_page_map.values()) if detail_page_map else None
+            ),
             "n_detail_pages": len(detail_page_map),
             "detail_page_map": detail_page_map,
         }
@@ -200,7 +208,7 @@ def extract_ica_full(pdf_path: Path) -> dict[str, Any]:
                 summary_pages.append(page_idx)
                 # Extract component rows from this page
                 full_text = page.get_text()
-                lines = [l.strip() for l in full_text.split("\n") if l.strip()]
+                lines = [ln.strip() for ln in full_text.split("\n") if ln.strip()]
                 i = 0
                 while i < len(lines):
                     line = lines[i]
@@ -212,12 +220,14 @@ def extract_ica_full(pdf_path: Path) -> dict[str, Any]:
                             except ValueError:
                                 conf = 0.0
                             rejected = lines[i + 3].strip().lower() == "yes"
-                            components.append({
-                                "component": line,
-                                "type": candidate_type,
-                                "confidence": round(conf, 3),
-                                "rejected": rejected,
-                            })
+                            components.append(
+                                {
+                                    "component": line,
+                                    "type": candidate_type,
+                                    "confidence": round(conf, 3),
+                                    "rejected": rejected,
+                                }
+                            )
                             seen.add(line)
                             i += 4
                             continue
@@ -225,12 +235,16 @@ def extract_ica_full(pdf_path: Path) -> dict[str, Any]:
                 continue
 
             # Topo grid pages
-            if "Topographies Overview" in text or ("Topograph" in text and "Batch" in text):
+            if "Topographies Overview" in text or (
+                "Topograph" in text and "Batch" in text
+            ):
                 topo_grid_pages.append(page_idx)
                 continue
 
             # Per-component detail pages
-            ic_match = re.search(r"(?:ICA Component |^)\s*(IC\d+)\s+(?:Topography|Analysis)", text)
+            ic_match = re.search(
+                r"(?:ICA Component |^)\s*(IC\d+)\s+(?:Topography|Analysis)", text
+            )
             if ic_match:
                 detail_page_map[ic_match.group(1)] = page_idx
                 continue
@@ -251,14 +265,18 @@ def extract_ica_full(pdf_path: Path) -> dict[str, Any]:
                 component_page_map[summary_name] = detail_page_map[summary_name]
             # Positional fallback (handles 1-indexed summary vs 0-indexed detail)
             elif i < len(detail_names_sorted):
-                component_page_map[summary_name] = detail_page_map[detail_names_sorted[i]]
+                component_page_map[summary_name] = detail_page_map[
+                    detail_names_sorted[i]
+                ]
 
         structure = {
             "total_pages": n_pages,
             "summary_pages": summary_pages,
             "topo_grid_page": topo_grid_pages[0] if topo_grid_pages else None,
             "topo_grid_pages": topo_grid_pages,
-            "detail_start_page": min(detail_page_map.values()) if detail_page_map else None,
+            "detail_start_page": (
+                min(detail_page_map.values()) if detail_page_map else None
+            ),
             "n_detail_pages": len(detail_page_map),
             "detail_page_map": component_page_map,  # Keyed by SUMMARY names
         }

--- a/src/autoclean/api/routes/config.py
+++ b/src/autoclean/api/routes/config.py
@@ -20,9 +20,7 @@ router = APIRouter()
 def _load_config():
     """Load and parse the serve configuration."""
     from autoclean.utils.ingestion import (
-        ServeConfigError,
         load_serve_config,
-        parse_serve_config,
     )
 
     config_path = api_state.get_config_path(deployed=False)

--- a/src/autoclean/api/routes/event_analyzer.py
+++ b/src/autoclean/api/routes/event_analyzer.py
@@ -38,7 +38,9 @@ def _analyze_file(file_path: Path) -> dict[str, Any]:
         ".edf": lambda p: mne.io.read_raw_edf(str(p), preload=False, verbose=False),
         ".bdf": lambda p: mne.io.read_raw_bdf(str(p), preload=False, verbose=False),
         ".fif": lambda p: mne.io.read_raw_fif(str(p), preload=False, verbose=False),
-        ".vhdr": lambda p: mne.io.read_raw_brainvision(str(p), preload=False, verbose=False),
+        ".vhdr": lambda p: mne.io.read_raw_brainvision(
+            str(p), preload=False, verbose=False
+        ),
     }
     reader = readers.get(ext)
     if reader is None:
@@ -117,15 +119,19 @@ def _analyze_file(file_path: Path) -> dict[str, Any]:
         typed = type_onsets.get(label, [])
         count = len(typed)
         per_isis = [typed[i + 1] - typed[i] for i in range(len(typed) - 1)]
-        type_summary.append({
-            "label": label,
-            "code": code,
-            "count": count,
-            "first_onset": round(typed[0], 3) if typed else None,
-            "last_onset": round(typed[-1], 3) if typed else None,
-            "mean_isi": round(statistics.mean(per_isis), 3) if per_isis else None,
-            "median_isi": round(statistics.median(per_isis), 3) if per_isis else None,
-        })
+        type_summary.append(
+            {
+                "label": label,
+                "code": code,
+                "count": count,
+                "first_onset": round(typed[0], 3) if typed else None,
+                "last_onset": round(typed[-1], 3) if typed else None,
+                "mean_isi": round(statistics.mean(per_isis), 3) if per_isis else None,
+                "median_isi": (
+                    round(statistics.median(per_isis), 3) if per_isis else None
+                ),
+            }
+        )
 
     # Global ISI
     isi_stats = None

--- a/src/autoclean/api/routes/exclude.py
+++ b/src/autoclean/api/routes/exclude.py
@@ -56,7 +56,9 @@ def _resolve_exports_root_for_route(route_id: str | None) -> Path:
             from autoclean.utils.ingestion import build_workspace_name
             from autoclean.utils.serve_routes import load_route_specs
         except Exception as exc:
-            raise HTTPException(status_code=500, detail=f"Could not resolve route exports: {exc}")
+            raise HTTPException(
+                status_code=500, detail=f"Could not resolve route exports: {exc}"
+            )
 
         for spec in load_route_specs(workspace):
             if str(spec.get("id") or "") != route_id:
@@ -64,25 +66,37 @@ def _resolve_exports_root_for_route(route_id: str | None) -> Path:
             taskfile = str(spec.get("taskfile") or "").strip()
             montage = str(spec.get("montage") or "").strip()
             if not taskfile or not montage:
-                raise HTTPException(status_code=400, detail=f"Route '{route_id}' is missing task or montage")
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Route '{route_id}' is missing task or montage",
+                )
             workspace_name = build_workspace_name(
                 spec.get("workspace_name", "taskfile-montage-version"),
                 taskfile=Path(taskfile).name.replace(".py", ""),
                 montage=montage,
                 version=spec.get("version"),
             )
-            automation_root = workspace / str(spec.get("automation_root", "automations"))
+            automation_root = workspace / str(
+                spec.get("automation_root", "automations")
+            )
             route_root = (automation_root / workspace_name).resolve()
             direct_exports = route_root / "exports"
             if direct_exports.exists() and direct_exports.is_dir():
                 return direct_exports
             nested_exports = sorted(
-                [path.resolve() for path in route_root.rglob("exports") if path.is_dir()],
+                [
+                    path.resolve()
+                    for path in route_root.rglob("exports")
+                    if path.is_dir()
+                ],
                 key=lambda path: len(path.parts),
             )
             if nested_exports:
                 return nested_exports[0]
-            raise HTTPException(status_code=404, detail=f"No exports directory found for route '{route_id}'")
+            raise HTTPException(
+                status_code=404,
+                detail=f"No exports directory found for route '{route_id}'",
+            )
 
         raise HTTPException(status_code=404, detail=f"Route '{route_id}' not found")
 
@@ -97,7 +111,9 @@ def _resolve_exports_root_for_route(route_id: str | None) -> Path:
     if candidates:
         return candidates[0]
 
-    raise HTTPException(status_code=404, detail="No exports directory found in workspace")
+    raise HTTPException(
+        status_code=404, detail="No exports directory found in workspace"
+    )
 
 
 def _decisions_paths(root: Path) -> tuple[Path, Path]:
@@ -191,7 +207,9 @@ def _save_decisions(root: Path, decisions: dict[str, dict[str, Any]]) -> None:
                     "bad_epoch_events": record.get("bad_epoch_events", ""),
                     "total_epochs": record.get("total_epochs", 0),
                     "epoch_rejection_rate": record.get("epoch_rejection_rate", 0.0),
-                    "manual_bad_channels": ",".join(record.get("manual_bad_channels", [])),
+                    "manual_bad_channels": ",".join(
+                        record.get("manual_bad_channels", [])
+                    ),
                     "manual_rejected_ica": ",".join(
                         str(v) for v in record.get("manual_rejected_ica", [])
                     ),
@@ -232,10 +250,19 @@ def _related_paths(root: Path, file_path: Path) -> dict[str, Optional[Path]]:
     stem = _strip_suffixes(file_path.stem)
     task_root = root.parent
     candidates = {
-        "run_report": task_root / "reports" / "run_reports" / f"{stem}_autoclean_report.pdf",
-        "ica_report": task_root / "reports" / "ica_components" / f"{stem}_ica_components_all.pdf",
+        "run_report": task_root
+        / "reports"
+        / "run_reports"
+        / f"{stem}_autoclean_report.pdf",
+        "ica_report": task_root
+        / "reports"
+        / "ica_components"
+        / f"{stem}_ica_components_all.pdf",
         "psd": task_root / "reports" / "psd_topo" / f"{stem}_psd_topo_figure.png",
-        "metadata": task_root / "reports" / "run_reports" / f"{stem}_autoclean_metadata.json",
+        "metadata": task_root
+        / "reports"
+        / "run_reports"
+        / f"{stem}_autoclean_metadata.json",
         "processing_log": task_root / "exports" / f"{stem}_processing_log.csv",
         "postedit": _postedit_path(task_root, file_path),
     }
@@ -259,7 +286,9 @@ def _parse_metadata(path: Optional[Path]) -> dict[str, Any]:
         if isinstance(removals, list):
             result["channel_removals"] = removals
             result["bad_channels"] = [
-                r.get("channel", "") for r in removals if isinstance(r, dict) and r.get("channel")
+                r.get("channel", "")
+                for r in removals
+                if isinstance(r, dict) and r.get("channel")
             ]
         legacy = metadata.get("step_clean_bad_channels", {}).get("bads", [])
         if not result["bad_channels"] and isinstance(legacy, list):
@@ -271,7 +300,9 @@ def _parse_metadata(path: Optional[Path]) -> dict[str, Any]:
             .get("final_excluded_indices", [])
         )
         if isinstance(rejected, list):
-            result["rejected_ica"] = [int(v) for v in rejected if isinstance(v, (int, float))]
+            result["rejected_ica"] = [
+                int(v) for v in rejected if isinstance(v, (int, float))
+            ]
 
         valid_channels = metadata.get("import_eeg", {}).get("originalChannelNames", [])
         if isinstance(valid_channels, list):
@@ -296,7 +327,9 @@ def _resolve_override_validation_context(
     related: dict[str, Optional[Path]],
     metadata: dict[str, Any],
 ) -> tuple[list[str], int]:
-    valid_channels = [str(v) for v in metadata.get("valid_channels", []) if str(v).strip()]
+    valid_channels = [
+        str(v) for v in metadata.get("valid_channels", []) if str(v).strip()
+    ]
     max_components = int(metadata.get("max_components", 0) or 0)
 
     if not valid_channels:
@@ -341,7 +374,9 @@ def _read_processing_metrics(path: Optional[Path]) -> dict[str, Any]:
     }
 
 
-def _record_for(decisions: dict[str, dict[str, Any]], key: str, relative_path: str) -> dict[str, Any]:
+def _record_for(
+    decisions: dict[str, dict[str, Any]], key: str, relative_path: str
+) -> dict[str, Any]:
     record = decisions.setdefault(key, _default_record(relative_path))
     record["relative_path"] = relative_path
     if "modified_source" not in record:
@@ -386,7 +421,9 @@ def _build_manual_fix_payload(
     task_file_relative = None
     if task_file and task_file.exists():
         task_file_relative = f"status/{task_file.name}"
-        task_file_hash = __import__("hashlib").sha256(task_file.read_bytes()).hexdigest()
+        task_file_hash = (
+            __import__("hashlib").sha256(task_file.read_bytes()).hexdigest()
+        )
 
     ica_file_path = task_root / "ica" / f"{stem}-ica.fif"
     ica_file_relative = f"ica/{stem}-ica.fif" if ica_file_path.exists() else None
@@ -504,7 +541,11 @@ def _validate_override_values(
     manual_rejected_ica: list[int],
 ) -> None:
     valid_channel_set = {str(value).upper() for value in valid_channels}
-    invalid_channels = [channel for channel in manual_bad_channels if channel.upper() not in valid_channel_set]
+    invalid_channels = [
+        channel
+        for channel in manual_bad_channels
+        if channel.upper() not in valid_channel_set
+    ]
     if invalid_channels:
         raise HTTPException(
             status_code=400,
@@ -512,7 +553,11 @@ def _validate_override_values(
         )
 
     if max_components > 0:
-        invalid_ica = [component for component in manual_rejected_ica if component < 0 or component >= max_components]
+        invalid_ica = [
+            component
+            for component in manual_rejected_ica
+            if component < 0 or component >= max_components
+        ]
         if invalid_ica:
             raise HTTPException(
                 status_code=400,
@@ -531,7 +576,9 @@ def _backup_existing_file(path: Path, backups_dir: Path) -> None:
     shutil.copy2(path, backups_dir / path.name)
 
 
-def _backup_and_remove_matching_files(base_dir: Path, patterns: list[str], backups_dir: Path) -> None:
+def _backup_and_remove_matching_files(
+    base_dir: Path, patterns: list[str], backups_dir: Path
+) -> None:
     if not base_dir.exists():
         return
     seen: set[Path] = set()
@@ -544,7 +591,9 @@ def _backup_and_remove_matching_files(base_dir: Path, patterns: list[str], backu
             path.unlink(missing_ok=True)
 
 
-def _replace_existing_reprocess_artifacts(task_root: Path, stem: str, backups_dir: Path) -> None:
+def _replace_existing_reprocess_artifacts(
+    task_root: Path, stem: str, backups_dir: Path
+) -> None:
     _backup_and_remove_matching_files(
         task_root / "exports",
         [f"{stem}*.set", f"{stem}*.fdt", f"{stem}*_processing_log.csv"],
@@ -575,7 +624,11 @@ def _replace_existing_reprocess_artifacts(task_root: Path, stem: str, backups_di
 def _drop_bad_epochs(epochs: mne.BaseEpochs, bad_indices: list[int]) -> None:
     if not bad_indices:
         return
-    selection = epochs.selection.tolist() if hasattr(epochs.selection, "tolist") else list(epochs.selection)
+    selection = (
+        epochs.selection.tolist()
+        if hasattr(epochs.selection, "tolist")
+        else list(epochs.selection)
+    )
     bad_selection_indices: list[int] = []
     for bad_num in bad_indices:
         if bad_num in selection:
@@ -590,7 +643,9 @@ def _calculate_export_hash(file_key: str, record: dict[str, Any]) -> str:
         "bad_epoch_indices": record.get("bad_epoch_indices", ""),
         "total_epochs": record.get("total_epochs", 0),
     }
-    return hashlib.sha256(json.dumps(metadata, sort_keys=True).encode("utf-8")).hexdigest()
+    return hashlib.sha256(
+        json.dumps(metadata, sort_keys=True).encode("utf-8")
+    ).hexdigest()
 
 
 def _preprocessing_log_path(task_root: Path) -> Path:
@@ -608,7 +663,9 @@ def _load_preprocessing_log_rows(task_root: Path) -> list[dict[str, str]]:
         return []
 
 
-def _create_qa_preprocessing_log(task_root: Path, decisions: dict[str, dict[str, Any]]) -> Optional[Path]:
+def _create_qa_preprocessing_log(
+    task_root: Path, decisions: dict[str, dict[str, Any]]
+) -> Optional[Path]:
     rows = _load_preprocessing_log_rows(task_root)
     qa_dir = task_root / "qa"
     if not rows or not qa_dir.exists():
@@ -647,7 +704,9 @@ def _create_qa_preprocessing_log(task_root: Path, decisions: dict[str, dict[str,
                 epoch_badtrials += float(qa.get("manual_bad_epochs", 0) or 0)
                 merged["epoch_badtrials"] = epoch_badtrials
                 if epoch_trials > 0:
-                    merged["epoch_percent"] = (epoch_trials - epoch_badtrials) / epoch_trials
+                    merged["epoch_percent"] = (
+                        epoch_trials - epoch_badtrials
+                    ) / epoch_trials
             except Exception:
                 pass
         merged_rows.append(merged)
@@ -679,7 +738,11 @@ def _export_file_to_qa(
     current_hash = _calculate_export_hash(file_key, record)
     existing_hash = str(record.get("qa_export_hash", ""))
     if existing_hash == current_hash and str(record.get("qa_export_path", "")):
-        return {"exported": False, "skipped": True, "path": record.get("qa_export_path", "")}
+        return {
+            "exported": False,
+            "skipped": True,
+            "path": record.get("qa_export_path", ""),
+        }
 
     epochs = _load_epochs(file_path)
     _drop_bad_epochs(epochs, _manual_bad_epoch_indices(record))
@@ -697,7 +760,9 @@ def _postedit_path(task_root: Path, file_path: Path) -> Path:
     return task_root / "postedit" / f"{stem}_postedit.set"
 
 
-def _sync_postedit_export(task_root: Path, file_path: Path, record: dict[str, Any]) -> Optional[str]:
+def _sync_postedit_export(
+    task_root: Path, file_path: Path, record: dict[str, Any]
+) -> Optional[str]:
     postedit_path = _postedit_path(task_root, file_path)
     bad_indices = _manual_bad_epoch_indices(record)
     if not bad_indices:
@@ -712,13 +777,19 @@ def _sync_postedit_export(task_root: Path, file_path: Path, record: dict[str, An
     return str(postedit_path)
 
 
-def _inject_reprocess_metadata(task_root: Path, stem: str, timestamp: str, payload: dict[str, Any]) -> None:
-    metadata_json_path = task_root / "reports" / "run_reports" / f"{stem}_autoclean_metadata.json"
+def _inject_reprocess_metadata(
+    task_root: Path, stem: str, timestamp: str, payload: dict[str, Any]
+) -> None:
+    metadata_json_path = (
+        task_root / "reports" / "run_reports" / f"{stem}_autoclean_metadata.json"
+    )
     if metadata_json_path.exists():
         metadata = json.loads(metadata_json_path.read_text(encoding="utf-8"))
         metadata["reprocessed"] = True
         metadata["reprocessed_timestamp"] = datetime.now().isoformat()
-        metadata["reprocess_reason"] = f"manual_override_{payload.get('fix_type', 'unknown')}"
+        metadata["reprocess_reason"] = (
+            f"manual_override_{payload.get('fix_type', 'unknown')}"
+        )
         metadata["manual_overrides"] = payload.get("modifications", {})
         metadata["original_backup"] = f"exports/backups/{stem}_{timestamp}/"
         metadata_json_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
@@ -743,7 +814,9 @@ def _inject_reprocess_metadata(task_root: Path, stem: str, timestamp: str, paylo
         writer.writerows(rows)
 
 
-def _save_manual_fix_payload(task_root: Path, stem: str, payload: dict[str, Any]) -> Path:
+def _save_manual_fix_payload(
+    task_root: Path, stem: str, payload: dict[str, Any]
+) -> Path:
     payload_dir = task_root / "qa" / "manual_fixes"
     payload_dir.mkdir(parents=True, exist_ok=True)
     payload_path = payload_dir / f"{stem}_manual_fix.json"
@@ -813,7 +886,9 @@ def _finalize_reprocess_job(job_id: str) -> None:
         payload_path = Path(str(job["payload_path"]))
         if payload_path.exists():
             payload = json.loads(payload_path.read_text(encoding="utf-8"))
-        _inject_reprocess_metadata(task_root, str(job["stem"]), str(job["timestamp"]), payload)
+        _inject_reprocess_metadata(
+            task_root, str(job["stem"]), str(job["timestamp"]), payload
+        )
         try:
             file_path, _relative_path = _resolve_file(root, str(job["file_key"]))
             _sync_postedit_export(task_root, file_path, record)
@@ -822,7 +897,9 @@ def _finalize_reprocess_job(job_id: str) -> None:
         _touch_record(record)
         _save_decisions(root, decisions)
         job["status"] = "completed"
-        job["message"] = "Reprocess completed and outputs copied into the original task folder."
+        job["message"] = (
+            "Reprocess completed and outputs copied into the original task folder."
+        )
     except Exception as exc:
         job["status"] = "failed"
         job["message"] = f"Reprocess completed but finalization failed: {exc}"
@@ -932,13 +1009,17 @@ class OverridesUpdate(BaseModel):
 
 
 @router.get("/root", response_model=ExcludeRootResponse)
-async def get_exclude_root(route_id: str | None = Query(default=None)) -> ExcludeRootResponse:
+async def get_exclude_root(
+    route_id: str | None = Query(default=None),
+) -> ExcludeRootResponse:
     root = _resolve_exports_root_for_route(route_id)
     return ExcludeRootResponse(exports_root=str(root))
 
 
 @router.get("/files", response_model=ExcludeFilesResponse)
-async def list_exclude_files(route_id: str | None = Query(default=None)) -> ExcludeFilesResponse:
+async def list_exclude_files(
+    route_id: str | None = Query(default=None),
+) -> ExcludeFilesResponse:
     root = _resolve_exports_root_for_route(route_id)
     decisions = _load_decisions(root)
     files: list[ExcludeFileSummary] = []
@@ -954,7 +1035,10 @@ async def list_exclude_files(route_id: str | None = Query(default=None)) -> Excl
                 notes_present=bool(record.get("notes")),
                 epochs_reviewed=bool(record.get("epochs_reviewed")),
                 bad_epochs_count=int(record.get("bad_epochs_count", 0) or 0),
-                has_overrides=bool(record.get("manual_bad_channels") or record.get("manual_rejected_ica")),
+                has_overrides=bool(
+                    record.get("manual_bad_channels")
+                    or record.get("manual_rejected_ica")
+                ),
                 status=str(record.get("status", "UNSET")),
             )
         )
@@ -962,7 +1046,9 @@ async def list_exclude_files(route_id: str | None = Query(default=None)) -> Excl
 
 
 @router.get("/files/{file_key:path}/artifacts/{asset_name}")
-async def get_exclude_artifact(file_key: str, asset_name: str, route_id: str | None = Query(default=None)):
+async def get_exclude_artifact(
+    file_key: str, asset_name: str, route_id: str | None = Query(default=None)
+):
     root = _resolve_exports_root_for_route(route_id)
     file_path, _relative_path = _resolve_file(root, file_key)
     related = _related_paths(root, file_path)
@@ -973,7 +1059,9 @@ async def get_exclude_artifact(file_key: str, asset_name: str, route_id: str | N
 
 
 @router.get("/files/{file_key:path}/ica-summary")
-async def get_exclude_ica_summary(file_key: str, route_id: str | None = Query(default=None)) -> dict[str, Any]:
+async def get_exclude_ica_summary(
+    file_key: str, route_id: str | None = Query(default=None)
+) -> dict[str, Any]:
     root = _resolve_exports_root_for_route(route_id)
     file_path, _relative_path = _resolve_file(root, file_key)
     related = _related_paths(root, file_path)
@@ -1009,7 +1097,9 @@ def _render_epoch_topography(
 
     eeg_picks = mne.pick_types(epochs.info, eeg=True, exclude=[])
     if len(eeg_picks) == 0:
-        raise HTTPException(status_code=400, detail="No EEG channels available for topography")
+        raise HTTPException(
+            status_code=400, detail="No EEG channels available for topography"
+        )
 
     sample_index = max(0, min(sample_index, len(epochs.times) - 1))
     epoch_data = epochs.get_data()[epoch_index]
@@ -1066,19 +1156,25 @@ def _render_epoch_topography(
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(status_code=400, detail=f"Could not render topography: {exc}")
+        raise HTTPException(
+            status_code=400, detail=f"Could not render topography: {exc}"
+        )
     finally:
         plt.close(fig)
 
 
 @router.get("/files/{file_key:path}/eeg/manifest", response_model=EpochManifest)
-async def get_eeg_manifest(file_key: str, route_id: str | None = Query(default=None)) -> EpochManifest:
+async def get_eeg_manifest(
+    file_key: str, route_id: str | None = Query(default=None)
+) -> EpochManifest:
     root = _resolve_exports_root_for_route(route_id)
     file_path, relative_path = _resolve_file(root, file_key)
     decisions = _load_decisions(root)
     record = _record_for(decisions, file_key, relative_path)
     epochs = _load_epochs(file_path)
-    existing_bad = [int(v) for v in str(record.get("bad_epoch_indices", "")).split(",") if v.strip()]
+    existing_bad = [
+        int(v) for v in str(record.get("bad_epoch_indices", "")).split(",") if v.strip()
+    ]
     return EpochManifest(
         file_key=file_key,
         relative_path=relative_path,
@@ -1087,7 +1183,9 @@ async def get_eeg_manifest(file_key: str, route_id: str | None = Query(default=N
         n_channels=len(epochs.ch_names),
         n_epochs=len(epochs),
         epoch_length_samples=int(len(epochs.times)),
-        epoch_duration_seconds=float(epochs.times[-1] - epochs.times[0]) if len(epochs.times) > 1 else 0.0,
+        epoch_duration_seconds=(
+            float(epochs.times[-1] - epochs.times[0]) if len(epochs.times) > 1 else 0.0
+        ),
         existing_bad_epoch_indices=existing_bad,
     )
 
@@ -1144,12 +1242,16 @@ async def get_eeg_epochs(
         count=len(payload),
         channel_names=selected_channels,
         sampling_rate=sfreq,
-        epoch_duration_seconds=float(epochs.times[-1] - epochs.times[0]) if len(epochs.times) > 1 else 0.0,
+        epoch_duration_seconds=(
+            float(epochs.times[-1] - epochs.times[0]) if len(epochs.times) > 1 else 0.0
+        ),
         epochs=payload,
     )
 
 
-@router.get("/files/{file_key:path}/eeg/topography", response_model=EpochTopographyResponse)
+@router.get(
+    "/files/{file_key:path}/eeg/topography", response_model=EpochTopographyResponse
+)
 async def get_eeg_topography(
     file_key: str,
     epoch_index: int = Query(..., ge=0),
@@ -1168,13 +1270,19 @@ async def get_eeg_topography(
 
 
 @router.get("/files/{file_key:path}/epoch-review")
-async def get_epoch_review(file_key: str, route_id: str | None = Query(default=None)) -> dict[str, Any]:
+async def get_epoch_review(
+    file_key: str, route_id: str | None = Query(default=None)
+) -> dict[str, Any]:
     root = _resolve_exports_root_for_route(route_id)
     _, relative_path = _resolve_file(root, file_key)
     decisions = _load_decisions(root)
     record = _record_for(decisions, file_key, relative_path)
     return {
-        "bad_epoch_indices": [int(v) for v in str(record.get("bad_epoch_indices", "")).split(",") if v.strip()],
+        "bad_epoch_indices": [
+            int(v)
+            for v in str(record.get("bad_epoch_indices", "")).split(",")
+            if v.strip()
+        ],
         "bad_epochs_count": int(record.get("bad_epochs_count", 0) or 0),
         "total_epochs": int(record.get("total_epochs", 0) or 0),
         "epoch_rejection_rate": float(record.get("epoch_rejection_rate", 0.0) or 0.0),
@@ -1194,7 +1302,9 @@ async def save_epoch_review(
     record = _record_for(decisions, file_key, relative_path)
     epochs = _load_epochs(file_path)
 
-    bad_epochs = sorted(set(int(v) for v in body.bad_epoch_indices if 0 <= int(v) < len(epochs)))
+    bad_epochs = sorted(
+        set(int(v) for v in body.bad_epoch_indices if 0 <= int(v) < len(epochs))
+    )
     epoch_times: list[str] = []
     epoch_events: list[str] = []
     if hasattr(epochs, "events"):
@@ -1211,7 +1321,9 @@ async def save_epoch_review(
     record["bad_epoch_times"] = ",".join(epoch_times)
     record["bad_epoch_events"] = ",".join(epoch_events)
     record["total_epochs"] = total_epochs
-    record["epoch_rejection_rate"] = (len(bad_epochs) / total_epochs * 100.0) if total_epochs else 0.0
+    record["epoch_rejection_rate"] = (
+        (len(bad_epochs) / total_epochs * 100.0) if total_epochs else 0.0
+    )
     _touch_record(record)
     _save_decisions(root, decisions)
     warning: Optional[str] = None
@@ -1231,7 +1343,9 @@ async def save_epoch_review(
 
 
 @router.get("/files/{file_key:path}", response_model=ExcludeFileDetail)
-async def get_exclude_file_detail(file_key: str, route_id: str | None = Query(default=None)) -> ExcludeFileDetail:
+async def get_exclude_file_detail(
+    file_key: str, route_id: str | None = Query(default=None)
+) -> ExcludeFileDetail:
     root = _resolve_exports_root_for_route(route_id)
     file_path, relative_path = _resolve_file(root, file_key)
     decisions = _load_decisions(root)
@@ -1257,12 +1371,20 @@ async def get_exclude_file_detail(file_key: str, route_id: str | None = Query(de
             "epochs_reviewed": bool(record.get("epochs_reviewed")),
             "bad_epochs_count": int(record.get("bad_epochs_count", 0) or 0),
             "bad_epoch_indices": [
-                int(v) for v in str(record.get("bad_epoch_indices", "")).split(",") if v.strip()
+                int(v)
+                for v in str(record.get("bad_epoch_indices", "")).split(",")
+                if v.strip()
             ],
-            "bad_epoch_times": [v for v in str(record.get("bad_epoch_times", "")).split(",") if v],
-            "bad_epoch_events": [v for v in str(record.get("bad_epoch_events", "")).split(",") if v],
+            "bad_epoch_times": [
+                v for v in str(record.get("bad_epoch_times", "")).split(",") if v
+            ],
+            "bad_epoch_events": [
+                v for v in str(record.get("bad_epoch_events", "")).split(",") if v
+            ],
             "total_epochs": int(record.get("total_epochs", 0) or 0),
-            "epoch_rejection_rate": float(record.get("epoch_rejection_rate", 0.0) or 0.0),
+            "epoch_rejection_rate": float(
+                record.get("epoch_rejection_rate", 0.0) or 0.0
+            ),
         },
         qa_export={
             "hash": str(record.get("qa_export_hash", "")),
@@ -1276,32 +1398,58 @@ async def get_exclude_file_detail(file_key: str, route_id: str | None = Query(de
         },
         artifacts={
             "run_report": (
-                f"/api/exclude/files/{file_key}/artifacts/run_report?route_id={route_id}" if related["run_report"] and route_id else
-                f"/api/exclude/files/{file_key}/artifacts/run_report" if related["run_report"] else None
+                f"/api/exclude/files/{file_key}/artifacts/run_report?route_id={route_id}"
+                if related["run_report"] and route_id
+                else (
+                    f"/api/exclude/files/{file_key}/artifacts/run_report"
+                    if related["run_report"]
+                    else None
+                )
             ),
             "ica_report": (
-                f"/api/exclude/files/{file_key}/artifacts/ica_report?route_id={route_id}" if related["ica_report"] and route_id else
-                f"/api/exclude/files/{file_key}/artifacts/ica_report" if related["ica_report"] else None
+                f"/api/exclude/files/{file_key}/artifacts/ica_report?route_id={route_id}"
+                if related["ica_report"] and route_id
+                else (
+                    f"/api/exclude/files/{file_key}/artifacts/ica_report"
+                    if related["ica_report"]
+                    else None
+                )
             ),
             "psd": (
-                f"/api/exclude/files/{file_key}/artifacts/psd?route_id={route_id}" if related["psd"] and route_id else
-                f"/api/exclude/files/{file_key}/artifacts/psd" if related["psd"] else None
+                f"/api/exclude/files/{file_key}/artifacts/psd?route_id={route_id}"
+                if related["psd"] and route_id
+                else (
+                    f"/api/exclude/files/{file_key}/artifacts/psd"
+                    if related["psd"]
+                    else None
+                )
             ),
             "metadata": (
-                f"/api/exclude/files/{file_key}/artifacts/metadata?route_id={route_id}" if related["metadata"] and route_id else
-                f"/api/exclude/files/{file_key}/artifacts/metadata" if related["metadata"] else None
+                f"/api/exclude/files/{file_key}/artifacts/metadata?route_id={route_id}"
+                if related["metadata"] and route_id
+                else (
+                    f"/api/exclude/files/{file_key}/artifacts/metadata"
+                    if related["metadata"]
+                    else None
+                )
             ),
             "postedit": (
-                f"/api/exclude/files/{file_key}/artifacts/postedit?route_id={route_id}" if related["postedit"] and route_id else
-                f"/api/exclude/files/{file_key}/artifacts/postedit" if related["postedit"] else None
+                f"/api/exclude/files/{file_key}/artifacts/postedit?route_id={route_id}"
+                if related["postedit"] and route_id
+                else (
+                    f"/api/exclude/files/{file_key}/artifacts/postedit"
+                    if related["postedit"]
+                    else None
+                )
             ),
         },
     )
 
 
 @router.put("/files/{file_key:path}/notes")
-async def save_notes(file_key: str, body: NotesUpdate, route_id: str | None = Query(default=None)) -> dict[str, Any]:
-    from datetime import datetime
+async def save_notes(
+    file_key: str, body: NotesUpdate, route_id: str | None = Query(default=None)
+) -> dict[str, Any]:
 
     root = _resolve_exports_root_for_route(route_id)
     _, relative_path = _resolve_file(root, file_key)
@@ -1312,12 +1460,17 @@ async def save_notes(file_key: str, body: NotesUpdate, route_id: str | None = Qu
         record["status"] = body.status
     _touch_record(record)
     _save_decisions(root, decisions)
-    return {"saved": True, "last_updated": record["last_updated"], "server_revision": record["revision"]}
+    return {
+        "saved": True,
+        "last_updated": record["last_updated"],
+        "server_revision": record["revision"],
+    }
 
 
 @router.put("/files/{file_key:path}/overrides")
-async def save_overrides(file_key: str, body: OverridesUpdate, route_id: str | None = Query(default=None)) -> dict[str, Any]:
-    from datetime import datetime
+async def save_overrides(
+    file_key: str, body: OverridesUpdate, route_id: str | None = Query(default=None)
+) -> dict[str, Any]:
 
     root = _resolve_exports_root_for_route(route_id)
     file_path, relative_path = _resolve_file(root, file_key)
@@ -1372,24 +1525,34 @@ async def start_reprocess(
     file_path, relative_path = _resolve_file(root, file_key)
     task_root = root.parent
     if "reprocess" in task_root.parts:
-        raise HTTPException(status_code=400, detail="Cannot reprocess from inside a reprocess folder")
+        raise HTTPException(
+            status_code=400, detail="Cannot reprocess from inside a reprocess folder"
+        )
 
     related = _related_paths(root, file_path)
     metadata_path = related.get("metadata")
     if metadata_path is None or not metadata_path.exists():
-        raise HTTPException(status_code=404, detail="Metadata file not found for selected export")
+        raise HTTPException(
+            status_code=404, detail="Metadata file not found for selected export"
+        )
 
     metadata_json = json.loads(metadata_path.read_text())
     raw_file = metadata_json.get("unprocessed_file")
     if not raw_file:
-        raise HTTPException(status_code=400, detail="Original raw file path missing from metadata")
+        raise HTTPException(
+            status_code=400, detail="Original raw file path missing from metadata"
+        )
     raw_path = Path(raw_file)
     if not raw_path.exists():
-        raise HTTPException(status_code=404, detail=f"Original raw file not found: {raw_path}")
+        raise HTTPException(
+            status_code=404, detail=f"Original raw file not found: {raw_path}"
+        )
 
     task_file = _find_task_file(task_root)
     if task_file is None or not task_file.exists():
-        raise HTTPException(status_code=404, detail="Original task file not found in status/")
+        raise HTTPException(
+            status_code=404, detail="Original task file not found in status/"
+        )
 
     metadata = _parse_metadata(metadata_path)
     valid_channels, max_components = _resolve_override_validation_context(
@@ -1440,7 +1603,11 @@ async def start_reprocess(
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     sanitized = stem.replace("-", "_").replace(" ", "_")
     sanitized = "".join(c if c.isalnum() or c == "_" else "_" for c in sanitized)
-    class_name = f"Task_{sanitized}_Reprocess" if sanitized and sanitized[0].isdigit() else f"{sanitized}_Reprocess"
+    class_name = (
+        f"Task_{sanitized}_Reprocess"
+        if sanitized and sanitized[0].isdigit()
+        else f"{sanitized}_Reprocess"
+    )
     task_output_path = task_root / "status" / f"{stem}_Reprocess.py"
     rendered_task = generate_reprocess_task_from_original(
         task_file, payload, class_name, timestamp
@@ -1484,7 +1651,9 @@ async def start_reprocess(
         "relative_path": relative_path,
         "exports_root": str(root),
     }
-    return ReprocessResponse(job_id=job_id, status="running", message=f"Started reprocess for {stem}")
+    return ReprocessResponse(
+        job_id=job_id, status="running", message=f"Started reprocess for {stem}"
+    )
 
 
 @router.get("/reprocess/{job_id}")

--- a/src/autoclean/api/routes/filesystem.py
+++ b/src/autoclean/api/routes/filesystem.py
@@ -121,11 +121,15 @@ async def browse_directory(
             FolderEntry(name=root.name or str(root), path=str(root), is_dir=True)
             for root in _allowed_roots()
         ]
-        unique_entries: dict[str, FolderEntry] = {entry.path: entry for entry in entries}
+        unique_entries: dict[str, FolderEntry] = {
+            entry.path: entry for entry in entries
+        }
         return BrowseResponse(
             path=str(target),
             parent=None,
-            entries=sorted(unique_entries.values(), key=lambda entry: entry.path.lower()),
+            entries=sorted(
+                unique_entries.values(), key=lambda entry: entry.path.lower()
+            ),
         )
 
     # Must be an existing directory
@@ -149,9 +153,7 @@ async def browse_directory(
             # Skip hidden directories (dotfiles)
             if child.name.startswith("."):
                 continue
-            entries.append(
-                FolderEntry(name=child.name, path=str(child), is_dir=True)
-            )
+            entries.append(FolderEntry(name=child.name, path=str(child), is_dir=True))
     except PermissionError:
         raise HTTPException(
             status_code=403,

--- a/src/autoclean/api/routes/montage_browser.py
+++ b/src/autoclean/api/routes/montage_browser.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import matplotlib
+
 if matplotlib.get_backend() != "Agg":
     matplotlib.use("Agg")  # Non-interactive backend — only set if not already Agg
 import matplotlib.pyplot as plt
@@ -54,8 +55,10 @@ def _categorize(name: str) -> str:
 
 def _montage_data_dir() -> Path:
     """Return the path to bundled custom montage files."""
-    import autoclean
     import inspect
+
+    import autoclean
+
     pkg_root = Path(inspect.getfile(autoclean)).parent
     return pkg_root / "data" / "montages"
 
@@ -83,7 +86,12 @@ def _load_montage(name: str) -> Any:
             try:
                 return mne.channels.read_custom_montage(str(candidate))
             except Exception as exc:
-                logger.debug("Could not read custom montage '%s' from %s: %s", name, candidate, exc)
+                logger.debug(
+                    "Could not read custom montage '%s' from %s: %s",
+                    name,
+                    candidate,
+                    exc,
+                )
 
     return None
 
@@ -125,21 +133,43 @@ def _generate_topomap(montage: Any, name: str = "") -> str:
 
         head_radius = 0.095
         theta = np.linspace(0, 2 * np.pi, 100)
-        ax.plot(head_radius * np.cos(theta), head_radius * np.sin(theta),
-                color="#3ecf8e", linewidth=1.5, alpha=0.4)
-        ax.plot([0, 0.01, 0], [head_radius, head_radius + 0.01, head_radius],
-                color="#3ecf8e", linewidth=1.5, alpha=0.4)
+        ax.plot(
+            head_radius * np.cos(theta),
+            head_radius * np.sin(theta),
+            color="#3ecf8e",
+            linewidth=1.5,
+            alpha=0.4,
+        )
+        ax.plot(
+            [0, 0.01, 0],
+            [head_radius, head_radius + 0.01, head_radius],
+            color="#3ecf8e",
+            linewidth=1.5,
+            alpha=0.4,
+        )
         for sign in (-1, 1):
-            ax.plot([sign * head_radius, sign * (head_radius + 0.01), sign * head_radius],
-                    [0.01, 0, -0.01], color="#3ecf8e", linewidth=1.5, alpha=0.3)
+            ax.plot(
+                [sign * head_radius, sign * (head_radius + 0.01), sign * head_radius],
+                [0.01, 0, -0.01],
+                color="#3ecf8e",
+                linewidth=1.5,
+                alpha=0.3,
+            )
 
         ax.scatter(xs_arr, ys_arr, c="#3ecf8e", s=20, alpha=0.8, zorder=5)
 
         if len(names) <= 64:
             for ch_name, x, y in zip(names, xs, ys):
-                ax.annotate(ch_name, (x, y), fontsize=4, color="#a1a1aa",
-                            ha="center", va="bottom", xytext=(0, 2),
-                            textcoords="offset points")
+                ax.annotate(
+                    ch_name,
+                    (x, y),
+                    fontsize=4,
+                    color="#a1a1aa",
+                    ha="center",
+                    va="bottom",
+                    xytext=(0, 2),
+                    textcoords="offset points",
+                )
 
         ax.set_xlim(-0.12, 0.12)
         ax.set_ylim(-0.12, 0.12)
@@ -170,6 +200,7 @@ def _load_montage_yaml() -> dict[str, str]:
     Returns a dict of {name: description}.
     """
     import inspect
+
     import autoclean
 
     pkg_root = Path(inspect.getfile(autoclean)).parent
@@ -180,14 +211,19 @@ def _load_montage_yaml() -> dict[str, str]:
         if candidate.exists():
             try:
                 import yaml  # type: ignore[import-untyped]
+
                 with candidate.open() as fh:
                     data = yaml.safe_load(fh)
                 return data.get("valid_montages", {})
             except Exception as exc:
-                logger.warning("Failed to parse montages.yaml at %s: %s", candidate, exc)
+                logger.warning(
+                    "Failed to parse montages.yaml at %s: %s", candidate, exc
+                )
                 return {}
 
-    logger.warning("configs/montages.yaml not found relative to package root %s", pkg_root)
+    logger.warning(
+        "configs/montages.yaml not found relative to package root %s", pkg_root
+    )
     return {}
 
 
@@ -197,9 +233,10 @@ def _discover_task_montages() -> dict[str, list[str]]:
     Gracefully returns an empty dict if task discovery fails.
     """
     try:
-        from autoclean.utils.task_discovery import safe_discover_tasks
         import importlib.util
         import sys
+
+        from autoclean.utils.task_discovery import safe_discover_tasks
 
         valid_tasks, _invalid, _skipped = safe_discover_tasks()
     except Exception as exc:
@@ -240,6 +277,7 @@ def _discover_task_montages() -> dict[str, list[str]]:
 
 
 # ── Response models ─────────────────────────────────────────────────
+
 
 class MontageInfo(BaseModel):
     """Summary info for the montage list view."""
@@ -282,6 +320,7 @@ class MontageDetail(BaseModel):
 
 
 # ── Endpoints ───────────────────────────────────────────────────────
+
 
 @router.get("", response_model=MontageListResponse)
 async def list_montages() -> MontageListResponse:

--- a/src/autoclean/api/routes/results.py
+++ b/src/autoclean/api/routes/results.py
@@ -142,15 +142,31 @@ def _find_run(run_id: str, workspace: Path) -> tuple[dict[str, Any], Path] | Non
 
 # ── Asset path resolution ────────────────────────────────────────────
 
+
 def _resolve_asset(task_root: Path, stem: str, asset: str) -> Path | None:
     """Return the Path for a named asset, or None if it does not exist."""
     candidates: dict[str, Path] = {
-        "report": task_root / "reports" / "run_reports" / f"{stem}_autoclean_report.pdf",
-        "ica_report": task_root / "reports" / "ica_components" / f"{stem}_ica_components_all.pdf",
+        "report": task_root
+        / "reports"
+        / "run_reports"
+        / f"{stem}_autoclean_report.pdf",
+        "ica_report": task_root
+        / "reports"
+        / "ica_components"
+        / f"{stem}_ica_components_all.pdf",
         "psd": task_root / "reports" / "psd_topo" / f"{stem}_psd_topo_figure.png",
-        "overlay": task_root / "reports" / "raw_vs_cleaned_overlay" / f"{stem}_raw_vs_cleaned_overlay.png",
-        "metadata": task_root / "reports" / "run_reports" / f"{stem}_autoclean_metadata.json",
-        "channels": task_root / "reports" / "run_reports" / f"{stem}_autoclean_report_flagged_channels.tsv",
+        "overlay": task_root
+        / "reports"
+        / "raw_vs_cleaned_overlay"
+        / f"{stem}_raw_vs_cleaned_overlay.png",
+        "metadata": task_root
+        / "reports"
+        / "run_reports"
+        / f"{stem}_autoclean_metadata.json",
+        "channels": task_root
+        / "reports"
+        / "run_reports"
+        / f"{stem}_autoclean_report_flagged_channels.tsv",
     }
     path = candidates.get(asset)
     if path and path.exists():
@@ -159,6 +175,7 @@ def _resolve_asset(task_root: Path, stem: str, asset: str) -> Path | None:
 
 
 # ── Metrics extraction ───────────────────────────────────────────────
+
 
 def _extract_metrics(meta: dict[str, Any]) -> dict[str, Any]:
     """Pull processing metrics out of the pipeline metadata dict defensively."""
@@ -184,7 +201,11 @@ def _extract_metrics(meta: dict[str, Any]) -> dict[str, Any]:
     epoch_step = meta.get("step_create_regular_epochs", {})
     epochs_total: int | None = epoch_step.get("initial_epoch_count")
     epochs_kept_raw: int | None = save_epochs.get("n_epochs")
-    epochs_kept: int | None = epochs_kept_raw if epochs_kept_raw is not None else epoch_step.get("final_epoch_count")
+    epochs_kept: int | None = (
+        epochs_kept_raw
+        if epochs_kept_raw is not None
+        else epoch_step.get("final_epoch_count")
+    )
 
     # ICA
     ica_step = meta.get("step_run_ica", {})
@@ -199,7 +220,9 @@ def _extract_metrics(meta: dict[str, Any]) -> dict[str, Any]:
         ica_method = ica_kwargs.get("method", "")
 
     rejection_step = meta.get("step_apply_ica_component_rejection", {})
-    rejection_ica = rejection_step.get("ica", {}) if isinstance(rejection_step, dict) else {}
+    rejection_ica = (
+        rejection_step.get("ica", {}) if isinstance(rejection_step, dict) else {}
+    )
     ica_removed: list[int] = []
     raw_excluded = rejection_ica.get("final_excluded_indices", [])
     if isinstance(raw_excluded, list):
@@ -287,6 +310,7 @@ def _extract_metrics(meta: dict[str, Any]) -> dict[str, Any]:
 
 # ── Pydantic models ──────────────────────────────────────────────────
 
+
 class RunSummary(BaseModel):
     run_id: str
     created_at: str
@@ -345,6 +369,7 @@ class RunDetail(BaseModel):
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
+
 def _require_workspace() -> Path:
     if not api_state.workspace_dir:
         raise HTTPException(status_code=409, detail="Workspace not configured")
@@ -353,8 +378,8 @@ def _require_workspace() -> Path:
 
 def _route_output_map(workspace: Path) -> dict[str, Path]:
     try:
-        from autoclean.utils.serve_routes import load_route_specs
         from autoclean.utils.ingestion import build_workspace_name
+        from autoclean.utils.serve_routes import load_route_specs
     except Exception:
         return {}
 
@@ -423,11 +448,14 @@ def _get_stem_and_asset(
     stem = _extract_stem(Path(unprocessed).name)
     asset_path = _resolve_asset(task_root, stem, asset)
     if not asset_path:
-        raise HTTPException(status_code=404, detail=f"Asset '{asset}' not available for run '{run_id}'")
+        raise HTTPException(
+            status_code=404, detail=f"Asset '{asset}' not available for run '{run_id}'"
+        )
     return row, task_root, stem, asset_path
 
 
 # ── Endpoints ────────────────────────────────────────────────────────
+
 
 @router.get("", response_model=ResultsListResponse)
 async def list_results(
@@ -437,7 +465,9 @@ async def list_results(
     workspace = _require_workspace()
     all_runs = _find_all_runs(workspace)
     route_outputs = _route_output_map(workspace)
-    summaries = [_row_to_summary(row, task_root, route_outputs) for row, task_root in all_runs]
+    summaries = [
+        _row_to_summary(row, task_root, route_outputs) for row, task_root in all_runs
+    ]
     if route_id:
         summaries = [summary for summary in summaries if summary.route_id == route_id]
     return ResultsListResponse(runs=summaries, total=len(summaries))
@@ -508,7 +538,9 @@ async def get_run_detail(run_id: str) -> RunDetail:
 async def get_report(run_id: str) -> FileResponse:
     """Serve the autoclean PDF report for a run."""
     workspace = _require_workspace()
-    _row, _task_root, _stem, asset_path = _get_stem_and_asset(run_id, workspace, "report")
+    _row, _task_root, _stem, asset_path = _get_stem_and_asset(
+        run_id, workspace, "report"
+    )
     return FileResponse(path=str(asset_path), media_type="application/pdf")
 
 
@@ -516,7 +548,9 @@ async def get_report(run_id: str) -> FileResponse:
 async def get_ica_report(run_id: str) -> FileResponse:
     """Serve the ICA components PDF report for a run."""
     workspace = _require_workspace()
-    _row, _task_root, _stem, asset_path = _get_stem_and_asset(run_id, workspace, "ica_report")
+    _row, _task_root, _stem, asset_path = _get_stem_and_asset(
+        run_id, workspace, "ica_report"
+    )
     return FileResponse(path=str(asset_path), media_type="application/pdf")
 
 
@@ -536,7 +570,9 @@ async def get_psd(run_id: str) -> FileResponse:
 async def get_overlay(run_id: str) -> FileResponse:
     """Serve the raw-vs-cleaned overlay PNG for a run."""
     workspace = _require_workspace()
-    _row, _task_root, _stem, asset_path = _get_stem_and_asset(run_id, workspace, "overlay")
+    _row, _task_root, _stem, asset_path = _get_stem_and_asset(
+        run_id, workspace, "overlay"
+    )
     return FileResponse(
         path=str(asset_path),
         media_type="image/png",
@@ -571,7 +607,9 @@ async def get_metadata(run_id: str) -> JSONResponse:
         except Exception:
             pass
 
-    raise HTTPException(status_code=404, detail=f"Metadata not available for run '{run_id}'")
+    raise HTTPException(
+        status_code=404, detail=f"Metadata not available for run '{run_id}'"
+    )
 
 
 @router.get("/{run_id}/channels")
@@ -605,13 +643,17 @@ async def get_channels(run_id: str) -> JSONResponse:
         rows = [dict(r) for r in reader]
         # Normalise to {channel, reason} shape expected by the frontend
         normalised = [
-            {"channel": r.get("channel", r.get("label", "")),
-             "reason": r.get("label", r.get("reason", ""))}
+            {
+                "channel": r.get("channel", r.get("label", "")),
+                "reason": r.get("label", r.get("reason", "")),
+            }
             for r in rows
         ]
         return JSONResponse(content={"channels": normalised})
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Failed to parse channels file: {exc}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to parse channels file: {exc}"
+        )
 
 
 # ── ICA PDF endpoints ─────────────────────────────────────────────
@@ -643,12 +685,14 @@ async def get_run_events(run_id: str) -> JSONResponse:
                     reader = csv.DictReader(f, delimiter="\t")
                     for ev_row in reader:
                         try:
-                            events_timeline.append({
-                                "onset": float(ev_row.get("onset") or 0),
-                                "duration": float(ev_row.get("duration") or 0),
-                                "trial_type": ev_row.get("trial_type", "unknown"),
-                                "value": ev_row.get("value", ""),
-                            })
+                            events_timeline.append(
+                                {
+                                    "onset": float(ev_row.get("onset") or 0),
+                                    "duration": float(ev_row.get("duration") or 0),
+                                    "trial_type": ev_row.get("trial_type", "unknown"),
+                                    "value": ev_row.get("value", ""),
+                                }
+                            )
                         except (ValueError, TypeError):
                             continue  # skip malformed rows
             except Exception:
@@ -669,14 +713,25 @@ async def get_run_events(run_id: str) -> JSONResponse:
         for label, code in event_dict.items():
             typed_onsets = type_onsets.get(label, type_onsets.get(str(code), []))
             count = len(typed_onsets)
-            per_isis = [typed_onsets[i + 1] - typed_onsets[i] for i in range(len(typed_onsets) - 1)]
-            type_summary.append({
-                "label": label, "code": code, "count": count,
-                "first_onset": round(typed_onsets[0], 3) if typed_onsets else None,
-                "last_onset": round(typed_onsets[-1], 3) if typed_onsets else None,
-                "mean_isi": round(statistics.mean(per_isis), 3) if per_isis else None,
-                "median_isi": round(statistics.median(per_isis), 3) if per_isis else None,
-            })
+            per_isis = [
+                typed_onsets[i + 1] - typed_onsets[i]
+                for i in range(len(typed_onsets) - 1)
+            ]
+            type_summary.append(
+                {
+                    "label": label,
+                    "code": code,
+                    "count": count,
+                    "first_onset": round(typed_onsets[0], 3) if typed_onsets else None,
+                    "last_onset": round(typed_onsets[-1], 3) if typed_onsets else None,
+                    "mean_isi": (
+                        round(statistics.mean(per_isis), 3) if per_isis else None
+                    ),
+                    "median_isi": (
+                        round(statistics.median(per_isis), 3) if per_isis else None
+                    ),
+                }
+            )
 
     # Global ISI, long gaps
     isi_stats: dict[str, Any] | None = None
@@ -685,37 +740,60 @@ async def get_run_events(run_id: str) -> JSONResponse:
         isis = [onsets[i + 1] - onsets[i] for i in range(len(onsets) - 1)]
         if isis:
             isi_stats = {
-                "min": round(min(isis), 3), "max": round(max(isis), 3),
-                "mean": round(statistics.mean(isis), 3), "median": round(statistics.median(isis), 3),
-                "std": round(statistics.stdev(isis), 3) if len(isis) > 1 else 0, "count": len(isis),
+                "min": round(min(isis), 3),
+                "max": round(max(isis), 3),
+                "mean": round(statistics.mean(isis), 3),
+                "median": round(statistics.median(isis), 3),
+                "std": round(statistics.stdev(isis), 3) if len(isis) > 1 else 0,
+                "count": len(isis),
             }
         long_gaps = [
-            {"start": round(onsets[i], 3), "end": round(onsets[i + 1], 3), "duration": round(onsets[i + 1] - onsets[i], 3)}
-            for i in range(len(onsets) - 1) if onsets[i + 1] - onsets[i] > 30.0
+            {
+                "start": round(onsets[i], 3),
+                "end": round(onsets[i + 1], 3),
+                "duration": round(onsets[i + 1] - onsets[i], 3),
+            }
+            for i in range(len(onsets) - 1)
+            if onsets[i + 1] - onsets[i] > 30.0
         ][:10]
 
     # Transitions (uses sorted timeline order)
     transitions_counter: Counter[tuple[str, str]] = Counter()
     for i in range(len(events_timeline) - 1):
-        transitions_counter[(events_timeline[i]["trial_type"], events_timeline[i + 1]["trial_type"])] += 1
-    top_transitions = [{"from": f, "to": t, "count": c} for (f, t), c in transitions_counter.most_common(10)]
+        transitions_counter[
+            (events_timeline[i]["trial_type"], events_timeline[i + 1]["trial_type"])
+        ] += 1
+    top_transitions = [
+        {"from": f, "to": t, "count": c}
+        for (f, t), c in transitions_counter.most_common(10)
+    ]
 
     # Duration and rate
     duration_sec = round(onsets[-1] - onsets[0], 3) if onsets else None
-    events_per_min = round(len(onsets) / (duration_sec / 60.0), 2) if duration_sec and duration_sec > 0 else None
+    events_per_min = (
+        round(len(onsets) / (duration_sec / 60.0), 2)
+        if duration_sec and duration_sec > 0
+        else None
+    )
 
-    return JSONResponse(content={
-        "has_events": has_events,
-        "event_count": event_count,
-        "event_types": type_summary,
-        "unique_type_count": len(unique_types),
-        "isi_stats": isi_stats,
-        "recording_type": "event_related" if has_events and event_count > _MIN_EVENT_RELATED else "resting_state",
-        "long_gaps": long_gaps,
-        "transitions": top_transitions,
-        "duration_sec": duration_sec,
-        "events_per_min": events_per_min,
-    })
+    return JSONResponse(
+        content={
+            "has_events": has_events,
+            "event_count": event_count,
+            "event_types": type_summary,
+            "unique_type_count": len(unique_types),
+            "isi_stats": isi_stats,
+            "recording_type": (
+                "event_related"
+                if has_events and event_count > _MIN_EVENT_RELATED
+                else "resting_state"
+            ),
+            "long_gaps": long_gaps,
+            "transitions": top_transitions,
+            "duration_sec": duration_sec,
+            "events_per_min": events_per_min,
+        }
+    )
 
 
 @router.get("/export/csv")
@@ -730,14 +808,16 @@ async def export_results_csv() -> Response:
     for row, _task_root in all_runs:
         unprocessed = row.get("unprocessed_file") or ""
         filename = Path(unprocessed).name if unprocessed else ""
-        writer.writerow([
-            row.get("run_id", ""),
-            row.get("created_at", ""),
-            row.get("task", ""),
-            filename,
-            row.get("status", ""),
-            "Yes" if row.get("success") else "No",
-        ])
+        writer.writerow(
+            [
+                row.get("run_id", ""),
+                row.get("created_at", ""),
+                row.get("task", ""),
+                filename,
+                row.get("status", ""),
+                "Yes" if row.get("success") else "No",
+            ]
+        )
 
     return Response(
         content=buf.getvalue(),
@@ -758,7 +838,14 @@ async def download_run_artifacts(run_id: str) -> Response:
 
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for asset_name in ("report", "ica_report", "psd", "overlay", "metadata", "channels"):
+        for asset_name in (
+            "report",
+            "ica_report",
+            "psd",
+            "overlay",
+            "metadata",
+            "channels",
+        ):
             asset_path = _resolve_asset(task_root, stem, asset_name)
             if asset_path:
                 zf.write(str(asset_path), asset_path.name)
@@ -817,7 +904,10 @@ async def get_ica_page(
         raise HTTPException(status_code=404, detail="ICA report not found")
 
     try:
-        from autoclean.api.pdf_extractor import get_ica_page_count, render_ica_page  # noqa: PLC0415
+        from autoclean.api.pdf_extractor import (  # noqa: PLC0415
+            get_ica_page_count,
+            render_ica_page,
+        )
 
         total = get_ica_page_count(pdf_path)
     except ImportError:
@@ -839,7 +929,9 @@ async def get_ica_page(
         png_b64 = render_ica_page(pdf_path, page_num, dpi=dpi)
         png_bytes = base64.b64decode(png_b64)
     except Exception as exc:
-        logger.exception("ICA page render failed for run %s page %d: %s", run_id, page_num, exc)
+        logger.exception(
+            "ICA page render failed for run %s page %d: %s", run_id, page_num, exc
+        )
         raise HTTPException(status_code=500, detail=f"Page render failed: {exc}")
 
     return Response(content=png_bytes, media_type="image/png")
@@ -885,13 +977,15 @@ def _decisions_to_csv(decisions: dict[str, Any]) -> str:
     writer = csv.writer(buf)
     writer.writerow(["run_id", "filename", "decision", "notes", "decided_at"])
     for rec in decisions.values():
-        writer.writerow([
-            rec.get("run_id", ""),
-            rec.get("filename", ""),
-            rec.get("decision", ""),
-            rec.get("notes", ""),
-            rec.get("decided_at", ""),
-        ])
+        writer.writerow(
+            [
+                rec.get("run_id", ""),
+                rec.get("filename", ""),
+                rec.get("decision", ""),
+                rec.get("notes", ""),
+                rec.get("decided_at", ""),
+            ]
+        )
     return buf.getvalue()
 
 
@@ -905,9 +999,7 @@ async def get_decisions() -> DecisionsResponse:
     """Return all review decisions for the current workspace."""
     workspace = _require_workspace()
     decisions = _load_decisions(workspace)
-    records = {
-        k: DecisionRecord(**v) for k, v in decisions.items()
-    }
+    records = {k: DecisionRecord(**v) for k, v in decisions.items()}
     return DecisionsResponse(decisions=records, total=len(records))
 
 
@@ -938,7 +1030,9 @@ async def set_decision(run_id: str, body: DecisionInput) -> JSONResponse:
 
     _save_decisions(workspace, decisions)
 
-    return JSONResponse(content={"success": True, "run_id": run_id, "decision": body.decision})
+    return JSONResponse(
+        content={"success": True, "run_id": run_id, "decision": body.decision}
+    )
 
 
 @router.get("/decisions/export/csv")

--- a/src/autoclean/api/routes/serve_routes.py
+++ b/src/autoclean/api/routes/serve_routes.py
@@ -57,6 +57,7 @@ def _serve_task_discovery_context(workspace_dir: Path):
 
 # ── List / Read ──────────────────────────────────────────────────────
 
+
 @router.get("/discovery/tasks", response_model=list[TaskOption])
 async def list_tasks():
     """Return available task files that can be assigned to routes."""
@@ -132,6 +133,7 @@ async def get_route(route_id: str):
 
 # ── Create / Update ─────────────────────────────────────────────────
 
+
 @router.post("", response_model=RouteActionResponse)
 async def upsert_route(body: RouteUpsertRequest):
     """Create or update a route spec."""
@@ -155,6 +157,7 @@ async def upsert_route(body: RouteUpsertRequest):
 
 # ── Delete ───────────────────────────────────────────────────────────
 
+
 @router.delete("/{route_id}", response_model=RouteActionResponse)
 async def delete_route(route_id: str):
     """Delete a route spec (must be archived first)."""
@@ -172,6 +175,7 @@ async def delete_route(route_id: str):
 
 
 # ── Lifecycle actions ────────────────────────────────────────────────
+
 
 @router.post("/{route_id}/promote", response_model=RouteActionResponse)
 async def promote_route(route_id: str):
@@ -265,6 +269,7 @@ async def disable_route(route_id: str):
 
 # ── Sync ─────────────────────────────────────────────────────────────
 
+
 @router.post("/sync", response_model=SyncResponse)
 async def sync_routes():
     """Recompile route spec files into serve-*.yaml configs."""
@@ -272,9 +277,7 @@ async def sync_routes():
     from autoclean.utils.serve_routes import sync_route_registry
 
     try:
-        result = sync_route_registry(
-            api_state.workspace_dir, modes=("test", "live")
-        )
+        result = sync_route_registry(api_state.workspace_dir, modes=("test", "live"))
         synced_modes = list(result.keys()) if isinstance(result, dict) else []
         test_info = result.get("test", {}) if isinstance(result, dict) else {}
         live_info = result.get("live", {}) if isinstance(result, dict) else {}
@@ -294,6 +297,7 @@ async def sync_routes():
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
+
 
 def _compute_output_folder(spec: dict) -> str:
     """Compute the output folder path for a route spec."""

--- a/src/autoclean/api/routes/task_browser.py
+++ b/src/autoclean/api/routes/task_browser.py
@@ -25,6 +25,7 @@ router = APIRouter()
 
 # ── Response model ─────────────────────────────────────────────────
 
+
 class TaskConfig(BaseModel):
     """Flattened, UI-friendly task configuration summary."""
 
@@ -96,7 +97,7 @@ def _parse_pipeline_steps(run_source: str, task_config: dict[str, Any]) -> list[
         Ordered list of human-readable step labels.
     """
     # Filter out comment lines so the regex cannot match commented-out calls.
-    lines = [l for l in run_source.splitlines() if not l.strip().startswith("#")]
+    lines = [ln for ln in run_source.splitlines() if not ln.strip().startswith("#")]
     filtered_source = "\n".join(lines)
 
     # Match self.method_name() calls, ignoring self.attribute = assignments
@@ -113,7 +114,9 @@ def _parse_pipeline_steps(run_source: str, task_config: dict[str, Any]) -> list[
     ica_val = _get_nested(task_config, "ICA", "value") or {}
     ica_method = ica_val.get("method", "")
     ica_extended = ica_val.get("fit_params", {}).get("extended", False)
-    threshold = _get_nested(task_config, "component_rejection", "value", "ic_rejection_threshold")
+    threshold = _get_nested(
+        task_config, "component_rejection", "value", "ic_rejection_threshold"
+    )
     tmin = _get_nested(task_config, "epoch_settings", "value", "tmin")
     tmax = _get_nested(task_config, "epoch_settings", "value", "tmax")
     ref_val = _get_nested(task_config, "reference_step", "value") or ""
@@ -187,6 +190,7 @@ def _is_builtin_source(source_path: str) -> str:
     """Return 'builtin' if the task is from the installed package, else the file path."""
     try:
         import autoclean
+
         pkg_root = Path(inspect.getfile(autoclean)).parent
         if Path(source_path).is_relative_to(pkg_root):
             return "builtin"
@@ -224,8 +228,12 @@ def _build_task_detail(discovered_task: Any) -> Optional[TaskDetail]:
         # Flatten config for UI
         filter_val: dict[str, Any] = _get_nested(raw_config, "filtering", "value") or {}
         ica_val: dict[str, Any] = _get_nested(raw_config, "ICA", "value") or {}
-        epoch_val: dict[str, Any] = _get_nested(raw_config, "epoch_settings", "value") or {}
-        comp_val: dict[str, Any] = _get_nested(raw_config, "component_rejection", "value") or {}
+        epoch_val: dict[str, Any] = (
+            _get_nested(raw_config, "epoch_settings", "value") or {}
+        )
+        comp_val: dict[str, Any] = (
+            _get_nested(raw_config, "component_rejection", "value") or {}
+        )
         event_id: Any = _get_nested(raw_config, "epoch_settings", "event_id")
 
         task_config = TaskConfig(
@@ -276,6 +284,7 @@ def _build_task_detail(discovered_task: Any) -> Optional[TaskDetail]:
 
 
 # ── Endpoints ──────────────────────────────────────────────────────
+
 
 @router.get("", response_model=list[TaskDetail])
 async def list_task_details() -> list[TaskDetail]:

--- a/src/autoclean/api/routes/task_manager.py
+++ b/src/autoclean/api/routes/task_manager.py
@@ -68,10 +68,12 @@ class TaskActionResponse(BaseModel):
 
 # ── Helpers ─────────────────────────────────────────────────────────
 
+
 def _get_workspace_dir() -> Optional[Path]:
     """Return the active Serve workspace tasks directory when available."""
     try:
         from autoclean.utils.user_config import UserConfigManager
+
         mgr = UserConfigManager()
         return mgr.get_serve_tasks_dir() or mgr.tasks_dir
     except Exception as exc:
@@ -89,6 +91,7 @@ def _registry_status() -> RegistryInfo:
     """Return high-level registry sync metadata."""
     try:
         from autoclean.utils.builtins import BuiltinRegistry
+
         reg = BuiltinRegistry()
         status = reg.registry_status()
         tasks = reg.list_tasks()
@@ -102,10 +105,13 @@ def _registry_status() -> RegistryInfo:
         return RegistryInfo()
 
 
-def _build_detail_for(discovered_task: Any) -> tuple[Optional[TaskConfig], list[str], str]:
+def _build_detail_for(
+    discovered_task: Any,
+) -> tuple[Optional[TaskConfig], list[str], str]:
     """Return (config, pipeline, source_code) by delegating to task_browser logic."""
     try:
         from autoclean.api.routes.task_browser import _build_task_detail
+
         detail = _build_task_detail(discovered_task)
         if detail is None:
             return None, [], ""
@@ -115,7 +121,9 @@ def _build_detail_for(discovered_task: Any) -> tuple[Optional[TaskConfig], list[
         return None, [], ""
 
 
-def _sync_status_for_builtin(name: str, workspace_dir: Optional[Path]) -> tuple[str, Optional[str]]:
+def _sync_status_for_builtin(
+    name: str, workspace_dir: Optional[Path]
+) -> tuple[str, Optional[str]]:
     """Return (sync_status, workspace_path) for a registry task.
 
     Maps BuiltinRegistry status strings onto our frontend vocabulary:
@@ -126,6 +134,7 @@ def _sync_status_for_builtin(name: str, workspace_dir: Optional[Path]) -> tuple[
     """
     try:
         from autoclean.utils.builtins import BuiltinRegistry
+
         reg = BuiltinRegistry()
         info = reg.task_sync_status(name, workspace_dir)
         raw = info.get("status", "not_installed")
@@ -144,6 +153,7 @@ def _sync_status_for_builtin(name: str, workspace_dir: Optional[Path]) -> tuple[
 
 # ── GET /api/task-manager ────────────────────────────────────────────
 
+
 @router.get("", response_model=TaskManagerResponse)
 async def get_task_manager() -> TaskManagerResponse:
     """Return unified task catalog merging library, builtin, and workspace tasks."""
@@ -155,6 +165,7 @@ async def get_task_manager() -> TaskManagerResponse:
     library_names: set[str] = set()
     try:
         from autoclean.utils.builtins import BuiltinRegistry
+
         reg = BuiltinRegistry()
         for bt in reg.list_tasks():
             library_names.add(bt.name)
@@ -165,13 +176,11 @@ async def get_task_manager() -> TaskManagerResponse:
     discovered_tasks: list[Any] = []
     try:
         from autoclean.utils.task_discovery import safe_discover_tasks
+
         valid_tasks, _invalid, _skipped = safe_discover_tasks()
         discovered_tasks = valid_tasks
     except Exception as exc:
         logger.error("Task discovery failed: %s", exc)
-
-    # Build a name -> discovered_task lookup
-    discovered_by_name: dict[str, Any] = {t.name: t for t in discovered_tasks}
 
     # -- 3. Determine workspace task names (files in workspace tasks dir)
     workspace_task_names: set[str] = set()
@@ -190,9 +199,8 @@ async def get_task_manager() -> TaskManagerResponse:
         source_path = dt.source
 
         # Is this task in the workspace directory?
-        is_workspace = (
-            workspace_dir is not None
-            and str(source_path).startswith(str(workspace_dir))
+        is_workspace = workspace_dir is not None and str(source_path).startswith(
+            str(workspace_dir)
         )
 
         # Determine source label
@@ -220,36 +228,41 @@ async def get_task_manager() -> TaskManagerResponse:
         # Derive category from task_browser helper
         try:
             from autoclean.api.routes.task_browser import _derive_category
+
             category = _derive_category(source_path)
         except Exception:
             category = "custom"
 
-        tasks.append(ManagedTask(
-            name=name,
-            description=dt.description,
-            category=category,
-            source=source_label,
-            sync_status=sync_status,
-            workspace_path=wp,
-            config=config,
-            pipeline=pipeline,
-            source_code=source_code,
-        ))
+        tasks.append(
+            ManagedTask(
+                name=name,
+                description=dt.description,
+                category=category,
+                source=source_label,
+                sync_status=sync_status,
+                workspace_path=wp,
+                config=config,
+                pipeline=pipeline,
+                source_code=source_code,
+            )
+        )
 
     # Pass B: library tasks not yet discovered (i.e., not installed anywhere)
     discovered_names = {t.name for t in discovered_tasks}
     for lib_name in sorted(library_names - discovered_names):
-        tasks.append(ManagedTask(
-            name=lib_name,
-            description="",
-            category="builtin",
-            source="library",
-            sync_status="not_installed",
-            workspace_path=None,
-            config=None,
-            pipeline=[],
-            source_code="",
-        ))
+        tasks.append(
+            ManagedTask(
+                name=lib_name,
+                description="",
+                category="builtin",
+                source="library",
+                sync_status="not_installed",
+                workspace_path=None,
+                config=None,
+                pipeline=[],
+                source_code="",
+            )
+        )
 
     return TaskManagerResponse(
         tasks=tasks,
@@ -259,6 +272,7 @@ async def get_task_manager() -> TaskManagerResponse:
 
 
 # ── POST /api/task-manager/install ──────────────────────────────────
+
 
 @router.post("/install", response_model=TaskActionResponse)
 async def install_task(body: InstallRequest) -> TaskActionResponse:
@@ -271,6 +285,7 @@ async def install_task(body: InstallRequest) -> TaskActionResponse:
 
     try:
         from autoclean.utils.builtins import BuiltinRegistry
+
         reg = BuiltinRegistry()
         dest_path = reg.materialize_task_to(task_name, workspace_dir)
         return TaskActionResponse(
@@ -288,6 +303,7 @@ async def install_task(body: InstallRequest) -> TaskActionResponse:
 
 # ── POST /api/task-manager/create ───────────────────────────────────
 
+
 @router.post("/create", response_model=TaskActionResponse)
 async def create_task(body: CreateRequest) -> TaskActionResponse:
     """Create a new task from the custom task template."""
@@ -300,6 +316,7 @@ async def create_task(body: CreateRequest) -> TaskActionResponse:
     # Validate identifier
     try:
         from autoclean.utils.template_renderer import validate_python_identifier
+
         validate_python_identifier(class_name, label="class_name")
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
@@ -307,17 +324,21 @@ async def create_task(body: CreateRequest) -> TaskActionResponse:
     # Locate template
     try:
         import autoclean
+
         package_dir = Path(autoclean.__file__).parent
     except Exception:
         package_dir = Path(__file__).parent.parent.parent
 
     template_path = package_dir / "templates" / "custom_task_template.jinja"
     if not template_path.exists():
-        raise HTTPException(status_code=500, detail=f"Template not found: {template_path}")
+        raise HTTPException(
+            status_code=500, detail=f"Template not found: {template_path}"
+        )
 
     # Render template
     try:
         from autoclean.utils.template_renderer import render_template
+
         rendered = render_template(template_path, {"class_name": class_name})
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Template render failed: {exc}")
@@ -346,12 +367,14 @@ async def create_task(body: CreateRequest) -> TaskActionResponse:
 
 # ── POST /api/task-manager/refresh-library ──────────────────────────
 
+
 @router.post("/refresh-library", response_model=TaskActionResponse)
 async def refresh_library() -> TaskActionResponse:
     """Refresh the GitHub registry cache."""
 
     try:
         from autoclean.utils.builtins import BuiltinRegistry
+
         reg = BuiltinRegistry()
         message = reg.update_cache(allow_network=True)
         return TaskActionResponse(
@@ -368,6 +391,7 @@ async def refresh_library() -> TaskActionResponse:
 
 # ── POST /api/task-manager/{task_name}/update ───────────────────────
 
+
 @router.post("/{task_name}/update", response_model=TaskActionResponse)
 async def update_task(task_name: str) -> TaskActionResponse:
     """Re-materialize a task from the registry to pick up the latest version."""
@@ -382,6 +406,7 @@ async def update_task(task_name: str) -> TaskActionResponse:
 
     try:
         from autoclean.utils.builtins import BuiltinRegistry
+
         reg = BuiltinRegistry()
         dest_path = reg.materialize_task_to(task_name, workspace_dir)
         return TaskActionResponse(
@@ -398,6 +423,7 @@ async def update_task(task_name: str) -> TaskActionResponse:
 
 
 # ── DELETE /api/task-manager/{task_name} ────────────────────────────
+
 
 @router.delete("/{task_name}", response_model=TaskActionResponse)
 async def remove_task(task_name: str) -> TaskActionResponse:

--- a/src/autoclean/api/routes/tunnel.py
+++ b/src/autoclean/api/routes/tunnel.py
@@ -264,15 +264,20 @@ def _start_tunnel_blocking(port: int, password: str) -> TunnelStartResponse:
             _tunnel_mode = "named"
             _tunnel_url = config.get("url", "")
             cmd = [
-                "cloudflared", "tunnel", "run",
-                "--token", config["token"],
+                "cloudflared",
+                "tunnel",
+                "run",
+                "--token",
+                config["token"],
             ]
         else:
             # Quick tunnel: ephemeral URL
             _tunnel_mode = "quick"
             cmd = [
-                "cloudflared", "tunnel",
-                "--url", f"http://127.0.0.1:{port}",
+                "cloudflared",
+                "tunnel",
+                "--url",
+                f"http://127.0.0.1:{port}",
             ]
 
         try:

--- a/src/autoclean/api/routes/worker.py
+++ b/src/autoclean/api/routes/worker.py
@@ -37,13 +37,15 @@ def _get_rq_workers() -> list[dict[str, Any]]:
         result = []
         for w in workers:
             current_job = w.get_current_job()
-            result.append({
-                "name": w.name,
-                "state": w.state,
-                "current_job_id": current_job.id if current_job else None,
-                "queues": [q.name for q in w.queues],
-                "pid": w.pid,
-            })
+            result.append(
+                {
+                    "name": w.name,
+                    "state": w.state,
+                    "current_job_id": current_job.id if current_job else None,
+                    "queues": [q.name for q in w.queues],
+                    "pid": w.pid,
+                }
+            )
         return result
     except Exception:
         return []
@@ -203,7 +205,11 @@ async def list_jobs(
     try:
         from rq import Queue
         from rq.job import Job
-        from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegistry
+        from rq.registry import (
+            FailedJobRegistry,
+            FinishedJobRegistry,
+            StartedJobRegistry,
+        )
 
         q = Queue(connection=api_state.redis)
         jobs = []

--- a/src/autoclean/api/server.py
+++ b/src/autoclean/api/server.py
@@ -11,11 +11,9 @@ from typing import Any, Optional
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.openapi.utils import get_openapi
 from fastapi.responses import Response
 
-from autoclean.api.state import APIState, api_state
-
+from autoclean.api.state import api_state
 
 # OpenAPI tag metadata for better documentation
 TAGS_METADATA = [
@@ -199,7 +197,9 @@ def _workspace_meta_path(workspace_dir: Path) -> Path:
 def _read_workspace_metadata(workspace_dir: Path) -> dict[str, Any]:
     """Load lightweight Serve metadata for the workspace."""
     try:
-        raw = json.loads(_workspace_meta_path(workspace_dir).read_text(encoding="utf-8"))
+        raw = json.loads(
+            _workspace_meta_path(workspace_dir).read_text(encoding="utf-8")
+        )
     except Exception:
         return {}
     return raw if isinstance(raw, dict) else {}
@@ -255,7 +255,10 @@ def _workspace_checklist(workspace_dir: Path) -> list[dict[str, Any]]:
     for mode in ("test", "live"):
         runtime_dir = paths[f"runtimes_{mode}"]
         venv_dir = runtime_dir / ".venv"
-        python_candidates = [venv_dir / "bin" / "python", venv_dir / "Scripts" / "python.exe"]
+        python_candidates = [
+            venv_dir / "bin" / "python",
+            venv_dir / "Scripts" / "python.exe",
+        ]
         checks.append(
             {
                 "label": f"{mode} runtime ready",
@@ -291,7 +294,11 @@ def _workspace_doctor(workspace_dir: Path) -> dict[str, Any]:
             "Apply the current configuration in Settings or run 'autocleaneeg-pipeline serve deploy --mode <test|live>' after validation."
         )
 
-    summary = "Workspace looks healthy" if not blocking_issues else f"Found {len(blocking_issues)} blocking issue(s)"
+    summary = (
+        "Workspace looks healthy"
+        if not blocking_issues
+        else f"Found {len(blocking_issues)} blocking issue(s)"
+    )
     return {
         "ok": not blocking_issues,
         "summary": summary,
@@ -466,7 +473,22 @@ REST API for managing automated EEG file processing pipelines.
 
     # Import routes here to avoid circular imports
     from autoclean.api import events
-    from autoclean.api.routes import config, event_analyzer, exclude, filesystem, montage_browser, queue, results, serve_routes, service, task_browser, task_manager, tunnel, tutorial, worker
+    from autoclean.api.routes import (
+        config,
+        event_analyzer,
+        exclude,
+        filesystem,
+        montage_browser,
+        queue,
+        results,
+        serve_routes,
+        service,
+        task_browser,
+        task_manager,
+        tunnel,
+        tutorial,
+        worker,
+    )
 
     # Include routers
     app.include_router(queue.router, prefix="/api/queue", tags=["Queue"])
@@ -478,8 +500,12 @@ REST API for managing automated EEG file processing pipelines.
     app.include_router(tutorial.router, prefix="/api/tutorial", tags=["Tutorial"])
     app.include_router(filesystem.router, prefix="/api/filesystem", tags=["Filesystem"])
     app.include_router(task_browser.router, prefix="/api/tasks", tags=["Tasks"])
-    app.include_router(task_manager.router, prefix="/api/task-manager", tags=["Task Manager"])
-    app.include_router(montage_browser.router, prefix="/api/montages", tags=["Montages"])
+    app.include_router(
+        task_manager.router, prefix="/api/task-manager", tags=["Task Manager"]
+    )
+    app.include_router(
+        montage_browser.router, prefix="/api/montages", tags=["Montages"]
+    )
     app.include_router(results.router, prefix="/api/results", tags=["Results"])
     app.include_router(exclude.router, prefix="/api/exclude", tags=["Exclude"])
     app.include_router(event_analyzer.router, prefix="/api/events", tags=["Events"])
@@ -528,6 +554,7 @@ REST API for managing automated EEG file processing pipelines.
                     return await call_next(request)
             except Exception as _auth_exc:
                 import logging as _logging
+
                 _logging.getLogger(__name__).debug(
                     "tunnel_auth_middleware: credential decode error: %s", _auth_exc
                 )
@@ -546,6 +573,7 @@ REST API for managing automated EEG file processing pipelines.
         and returns the new mode.
         """
         from fastapi import HTTPException as _HTTPExc
+
         from autoclean.api.routes.service import get_service_status, stop_service
 
         new_mode = body.get("mode", "").lower()
@@ -553,7 +581,11 @@ REST API for managing automated EEG file processing pipelines.
             raise _HTTPExc(status_code=400, detail="Mode must be 'test' or 'live'")
 
         if new_mode == api_state.mode:
-            return {"success": True, "mode": new_mode, "message": f"Already in {new_mode} mode"}
+            return {
+                "success": True,
+                "mode": new_mode,
+                "message": f"Already in {new_mode} mode",
+            }
 
         # Stop running service before switching
         try:
@@ -593,6 +625,7 @@ REST API for managing automated EEG file processing pipelines.
         # Stop running service before switching workspaces
         try:
             from autoclean.api.routes.service import get_service_status, stop_service
+
             if get_service_status().get("running"):
                 await stop_service()
         except Exception:
@@ -655,7 +688,9 @@ REST API for managing automated EEG file processing pipelines.
             )
 
         # Configure API state in-place — no restart required
-        api_state.configure(workspace_dir, api_state.mode or "test", api_state.redis_url)
+        api_state.configure(
+            workspace_dir, api_state.mode or "test", api_state.redis_url
+        )
 
         # Persist workspace path for future launches
         try:
@@ -693,7 +728,8 @@ REST API for managing automated EEG file processing pipelines.
             "workspace_dir": str(workspace_dir),
             "selected_workspace_path": str(workspace_dir),
             "bootstrap_origin": _workspace_bootstrap_origin(workspace_dir),
-            "bootstrapped_from_autoclean": _workspace_bootstrap_origin(workspace_dir) == "bootstrapped_autoclean",
+            "bootstrapped_from_autoclean": _workspace_bootstrap_origin(workspace_dir)
+            == "bootstrapped_autoclean",
             "workspace_details": {
                 "serve_test_exists": paths["serve_test"].exists(),
                 "serve_live_exists": paths["serve_live"].exists(),
@@ -718,22 +754,36 @@ REST API for managing automated EEG file processing pipelines.
             if not ws.exists():
                 continue
             routes_dir = ws / "routes"
-            has_routes = routes_dir.exists() and any(routes_dir.iterdir()) if routes_dir.exists() else False
-            n_routes = len(list(routes_dir.glob("*.yaml"))) if routes_dir.exists() else 0
+            has_routes = (
+                routes_dir.exists() and any(routes_dir.iterdir())
+                if routes_dir.exists()
+                else False
+            )
+            n_routes = (
+                len(list(routes_dir.glob("*.yaml"))) if routes_dir.exists() else 0
+            )
             has_runtime_test = (ws / "runtimes" / "test" / ".venv").exists()
             has_runtime_live = (ws / "runtimes" / "live" / ".venv").exists()
-            results.append({
-                "path": str(ws),
-                "name": ws.name,
-                "has_routes": has_routes,
-                "n_routes": n_routes,
-                "has_runtime_test": has_runtime_test,
-                "has_runtime_live": has_runtime_live,
-                "is_current": str(ws) == str(api_state.workspace_dir) if api_state.workspace_dir else False,
-            })
+            results.append(
+                {
+                    "path": str(ws),
+                    "name": ws.name,
+                    "has_routes": has_routes,
+                    "n_routes": n_routes,
+                    "has_runtime_test": has_runtime_test,
+                    "has_runtime_live": has_runtime_live,
+                    "is_current": (
+                        str(ws) == str(api_state.workspace_dir)
+                        if api_state.workspace_dir
+                        else False
+                    ),
+                }
+            )
         return {
             "workspaces": results,
-            "current": str(api_state.workspace_dir) if api_state.workspace_dir else None,
+            "current": (
+                str(api_state.workspace_dir) if api_state.workspace_dir else None
+            ),
         }
 
     @app.get("/health")
@@ -851,9 +901,7 @@ REST API for managing automated EEG file processing pipelines.
                         if not r.get("archived", False) and r.get("enabled", True)
                     ]
                 ),
-                "archived": len(
-                    [r for r in routes if r.get("archived", False)]
-                ),
+                "archived": len([r for r in routes if r.get("archived", False)]),
             },
             "queue": queue_stats,
             "config": {
@@ -875,8 +923,8 @@ REST API for managing automated EEG file processing pipelines.
     # Serve built frontend if available
     static_dir = Path(__file__).parent / "static"
     if static_dir.is_dir() and (static_dir / "index.html").exists():
-        from fastapi.staticfiles import StaticFiles
         from fastapi.responses import FileResponse
+        from fastapi.staticfiles import StaticFiles
 
         # SPA catch-all: return index.html for client-side routes only
         _API_PREFIXES = ("api/", "ws/", "health", "docs", "redoc", "openapi.json")
@@ -886,6 +934,7 @@ REST API for managing automated EEG file processing pipelines.
             # Never intercept API or infrastructure paths
             if path.startswith(_API_PREFIXES):
                 from fastapi.responses import JSONResponse
+
                 return JSONResponse({"detail": f"Not found: /{path}"}, status_code=404)
             # Serve actual static files if they exist
             file_path = (static_dir / path).resolve()
@@ -902,6 +951,7 @@ REST API for managing automated EEG file processing pipelines.
         if assets_dir.is_dir():
             app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="assets")
     else:
+
         @app.get("/")
         async def root() -> dict[str, str]:
             """Root endpoint with API info."""
@@ -949,6 +999,7 @@ def run_server(
         reload: Enable auto-reload for development.
     """
     import os
+
     import uvicorn
 
     # Publish the API port so the tunnel route can bind cloudflared to the

--- a/src/autoclean/api/tasks.py
+++ b/src/autoclean/api/tasks.py
@@ -8,9 +8,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-
 MATLAB_PREFLIGHT_TIMEOUT_SECONDS = 120
 MATLAB_STARTUP_TIMEOUT_SECONDS = 60.0
+
 
 def _timestamp() -> str:
     """Get current ISO timestamp."""
@@ -64,7 +64,9 @@ def _build_process_command(
     return cmd
 
 
-def _run_matlab_preflight(cli_path: Path, taskfile: str, workspace: Path) -> dict[str, Any]:
+def _run_matlab_preflight(
+    cli_path: Path, taskfile: str, workspace: Path
+) -> dict[str, Any]:
     """Run MATLAB readiness checks for MATLAB-backed Python task files."""
     from autoclean.utils.ingestion import resolve_taskfile_path
     from autoclean.utils.matlab_runtime import inspect_taskfile_for_matlab
@@ -296,7 +298,6 @@ def run_ingestion_cycle(
         Dict with cycle results.
     """
     from autoclean.utils.ingestion import (
-        IngestionQueue,
         run_ingestion_service,
     )
 

--- a/src/autoclean/blocks/analysis/matlab_fooof/algorithm.py
+++ b/src/autoclean/blocks/analysis/matlab_fooof/algorithm.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-
 DEFAULT_FOOOF_FREQS = (1.0, 55.0)
 DEFAULT_ARTIFACTS_SUBDIR = "matlab/fooof"
 

--- a/src/autoclean/calc/bycycle_analysis.py
+++ b/src/autoclean/calc/bycycle_analysis.py
@@ -168,7 +168,9 @@ def _resolve_pick_indices(
         return [int(pick) for pick in picks_list]
     if all(isinstance(pick, str) for pick in picks_list):
         return list(mne.pick_channels(data.ch_names, include=picks_list, ordered=True))
-    raise TypeError("picks must be None, a channel name, or a sequence of names/indices")
+    raise TypeError(
+        "picks must be None, a channel name, or a sequence of names/indices"
+    )
 
 
 def _extract_channel_signal(

--- a/src/autoclean/functions/__init__.py
+++ b/src/autoclean/functions/__init__.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from importlib import import_module
 
-
 _FUNCTION_EXPORTS = {
     "autoreject_epochs": ("autoclean.functions.advanced", "autoreject_epochs"),
     "call_matlab": ("autoclean.functions.matlab", "call_matlab"),

--- a/src/autoclean/functions/epoching/__init__.py
+++ b/src/autoclean/functions/epoching/__init__.py
@@ -59,6 +59,7 @@ def create_sl_epochs(
             raise ValueError("No events found") from exc
         raise
 
+
 __all__ = [
     "create_regular_epochs",
     "create_eventid_epochs",

--- a/src/autoclean/functions/visualization/_ica_topography_cache.py
+++ b/src/autoclean/functions/visualization/_ica_topography_cache.py
@@ -293,9 +293,7 @@ def apply_cached_topography(
         ):
             origin = origins[idx] if idx < len(origins) else "upper"
             interpolation = (
-                interpolations[idx]
-                if idx < len(interpolations)
-                else "antialiased"
+                interpolations[idx] if idx < len(interpolations) else "antialiased"
             )
             alpha = alphas[idx] if idx < len(alphas) else None
             ax.imshow(

--- a/src/autoclean/mixins/__init__.py
+++ b/src/autoclean/mixins/__init__.py
@@ -359,7 +359,9 @@ for external_path in _EXTERNAL_BLOCK_PATHS:
     # Find all Python files in the blocks directory
     for block_file in external_path.rglob("*.py"):
         # Skip hidden/macOS resource-fork files (._*) and dot directories
-        if any(part.startswith("._") or part.startswith(".") for part in block_file.parts):
+        if any(
+            part.startswith("._") or part.startswith(".") for part in block_file.parts
+        ):
             continue
         # Skip private files and __init__.py
         if block_file.name.startswith("_"):

--- a/src/autoclean/mixins/analysis/matlab_fooof.py
+++ b/src/autoclean/mixins/analysis/matlab_fooof.py
@@ -31,4 +31,3 @@ _BlockMixin = _load_block_mixin()
 
 class MatlabFooofMixin(_BlockMixin):
     """Auto-discovered task mixin proxy for the bundled MATLAB FOOOF block."""
-

--- a/src/autoclean/mixins/analysis/sensor_psd.py
+++ b/src/autoclean/mixins/analysis/sensor_psd.py
@@ -160,9 +160,7 @@ class SensorPSDMixin:
             for band_name, (band_min, band_max) in DEFAULT_SENSOR_PSD_BANDS.items():
                 band_mask = (freqs >= band_min) & (freqs < band_max)
                 band_power = (
-                    float(np.mean(channel_psd[band_mask]))
-                    if np.any(band_mask)
-                    else 0.0
+                    float(np.mean(channel_psd[band_mask])) if np.any(band_mask) else 0.0
                 )
                 band_rows.append(
                     {

--- a/src/autoclean/mixins/signal_processing/manual_epoch_rejection.py
+++ b/src/autoclean/mixins/signal_processing/manual_epoch_rejection.py
@@ -24,7 +24,9 @@ class ManualEpochRejectionMixin:
         """Drop user-selected bad epochs, mapping stored epoch numbers via selection."""
         epochs = self._get_data_object(data, use_epochs=True)
         if not isinstance(epochs, mne.BaseEpochs):
-            raise TypeError("Data must be an MNE Epochs object for manual epoch rejection")
+            raise TypeError(
+                "Data must be an MNE Epochs object for manual epoch rejection"
+            )
 
         requested_indices = sorted(
             {int(idx) for idx in (manual_bad_epoch_indices or []) if int(idx) >= 0}
@@ -41,7 +43,9 @@ class ManualEpochRejectionMixin:
             else list(epochs.selection)
         )
         bad_selection_indices = [
-            selection.index(bad_num) for bad_num in requested_indices if bad_num in selection
+            selection.index(bad_num)
+            for bad_num in requested_indices
+            if bad_num in selection
         ]
         applied_bad_epoch_indices = [selection[idx] for idx in bad_selection_indices]
         skipped_bad_epoch_indices = [

--- a/src/autoclean/mixins/signal_processing/outlier_detection.py
+++ b/src/autoclean/mixins/signal_processing/outlier_detection.py
@@ -19,8 +19,6 @@ from typing import Union
 import mne
 import numpy as np
 
-from autoclean.utils.logging import message
-
 
 class OutlierDetectionMixin:
     """Mixin class providing functionality for outlier detection in epochs.
@@ -89,6 +87,7 @@ class OutlierDetectionMixin:
 
         if not is_enabled:
             from autoclean.utils.logging import message
+
             message("info", "Outlier epoch detection step is disabled in configuration")
             return None
 

--- a/src/autoclean/mixins/utils/matlab.py
+++ b/src/autoclean/mixins/utils/matlab.py
@@ -34,7 +34,9 @@ class MatlabExecutionMixin:
 
         value = step_config.get("value")
         if not isinstance(value, dict):
-            raise ValueError(f"Invalid MATLAB step config for {config_key}: missing value mapping")
+            raise ValueError(
+                f"Invalid MATLAB step config for {config_key}: missing value mapping"
+            )
 
         metadata = {
             "creationDateTime": datetime.now().isoformat(),
@@ -122,7 +124,9 @@ class MatlabExecutionMixin:
             },
         )
 
-    def _update_matlab_metadata(self, operation: str, metadata_dict: dict[str, Any]) -> None:
+    def _update_matlab_metadata(
+        self, operation: str, metadata_dict: dict[str, Any]
+    ) -> None:
         """Update task metadata if the host class supports metadata tracking."""
         if hasattr(self, "_update_metadata"):
             self._update_metadata(operation, metadata_dict)

--- a/src/autoclean/serve_launcher.py
+++ b/src/autoclean/serve_launcher.py
@@ -27,8 +27,13 @@ _PID_FILE = None  # Set at runtime for cleanup
 # ── Shared HTTP helper ────────────────────────────────────────────────
 
 
-def _api_request(port: int, path: str, method: str = "GET",
-                 body: dict | None = None, timeout: int = 20) -> dict[str, Any]:
+def _api_request(
+    port: int,
+    path: str,
+    method: str = "GET",
+    body: dict | None = None,
+    timeout: int = 20,
+) -> dict[str, Any]:
     """Make a JSON request to the local API server."""
     import urllib.request
 
@@ -43,7 +48,9 @@ def _api_request(port: int, path: str, method: str = "GET",
     return json.loads(resp.read())
 
 
-def _wait_for_health(port: int, attempts: int = 30, delay: float = 0.5) -> dict[str, Any] | None:
+def _wait_for_health(
+    port: int, attempts: int = 30, delay: float = 0.5
+) -> dict[str, Any] | None:
     """Wait for the local API to become healthy."""
     import time
 
@@ -70,7 +77,9 @@ def _ensure_operational_service(port: int) -> tuple[bool, list[str]]:
         return False, [f"Could not inspect Serve status: {exc}"]
 
     if not status.get("configured"):
-        messages.append("Workspace not configured yet. Open the UI to choose or create a workspace.")
+        messages.append(
+            "Workspace not configured yet. Open the UI to choose or create a workspace."
+        )
         return False, messages
 
     workspace_dir = status.get("workspace_dir", "unknown workspace")
@@ -84,11 +93,15 @@ def _ensure_operational_service(port: int) -> tuple[bool, list[str]]:
         return True, messages
 
     if routes.get("total", 0) == 0:
-        messages.append("Serve UI started, but no routes exist yet. Add a route before processing can start.")
+        messages.append(
+            "Serve UI started, but no routes exist yet. Add a route before processing can start."
+        )
         return False, messages
 
     if config.get("errors"):
-        messages.append("Serve UI started, but processing was not started because configuration is invalid.")
+        messages.append(
+            "Serve UI started, but processing was not started because configuration is invalid."
+        )
         return False, messages
 
     if config.get("needs_deploy"):
@@ -115,7 +128,9 @@ def _ensure_operational_service(port: int) -> tuple[bool, list[str]]:
             timeout=10,
         )
     except Exception as exc:
-        messages.append(f"Serve UI started, but processing service failed to start: {exc}")
+        messages.append(
+            f"Serve UI started, but processing service failed to start: {exc}"
+        )
         return False, messages
 
     success = bool(result.get("success"))
@@ -124,7 +139,9 @@ def _ensure_operational_service(port: int) -> tuple[bool, list[str]]:
         pending = queue.get("pending", 0)
         processing = queue.get("processing", 0)
         if pending or processing:
-            messages.append(f"Queue currently has {pending} pending and {processing} active file(s).")
+            messages.append(
+                f"Queue currently has {pending} pending and {processing} active file(s)."
+            )
         return True, messages
 
     messages.append(result.get("message", "Processing service did not start."))
@@ -141,24 +158,33 @@ def main() -> None:
         description="AutoCleanEEG Serve",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Commands:\n"
-               "  (none)    Start server in foreground (Ctrl+C to stop)\n"
-               "  up        Start server as background daemon\n"
-               "  down      Stop the running server\n"
-               "  restart   Stop + start as background daemon\n"
-               "  status    Show whether server is running\n"
-               "  share     Manage public tunnel [start|stop|status|setup|clear]\n",
+        "  (none)    Start server in foreground (Ctrl+C to stop)\n"
+        "  up        Start server as background daemon\n"
+        "  down      Stop the running server\n"
+        "  restart   Stop + start as background daemon\n"
+        "  status    Show whether server is running\n"
+        "  share     Manage public tunnel [start|stop|status|setup|clear]\n",
     )
-    parser.add_argument("command", nargs="?", default=None,
-                        choices=["up", "down", "restart", "status", "share"],
-                        help="Server command (omit for foreground start)")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default=None,
+        choices=["up", "down", "restart", "status", "share"],
+        help="Server command (omit for foreground start)",
+    )
     parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--host", type=str, default="0.0.0.0",
-                        help="Bind address (use 127.0.0.1 for localhost only)")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Bind address (use 127.0.0.1 for localhost only)",
+    )
     parser.add_argument("--path", type=str, default=None, help="Workspace path")
     parser.add_argument("--mode", choices=["test", "live"], default="test")
     parser.add_argument("--no-browser", action="store_true")
-    parser.add_argument("--force", action="store_true",
-                        help="Allow starting a second server instance")
+    parser.add_argument(
+        "--force", action="store_true", help="Allow starting a second server instance"
+    )
 
     # Pre-scan for share sub-action before argparse consumes it
     raw_args = sys.argv[1:]
@@ -202,7 +228,7 @@ def _cmd_foreground(args) -> None:
             pid, port, _health = existing
             print(f"AutoCleanEEG Serve is already running (pid {pid}, port {port}).")
             print(f"  Open: http://127.0.0.1:{port}")
-            print(f"  Use --force to start another instance.")
+            print("  Use --force to start another instance.")
             sys.exit(0)
 
     port = _resolve_port(args)
@@ -212,7 +238,9 @@ def _cmd_foreground(args) -> None:
     if workspace:
         print(f"AutoCleanEEG Serve starting with workspace: {workspace}")
     else:
-        print("AutoCleanEEG Serve starting — workspace setup required (will open in browser)")
+        print(
+            "AutoCleanEEG Serve starting — workspace setup required (will open in browser)"
+        )
 
     listen_display = "0.0.0.0 (LAN accessible)" if host == "0.0.0.0" else host
     print(f"Listening on http://{listen_display}:{port}")
@@ -264,12 +292,29 @@ def _cmd_up(args) -> int:
     # Build command
     exe = shutil.which("autocleaneeg-serve")
     if exe:
-        cmd = [exe, "--no-browser", "--port", str(args.port),
-               "--host", args.host, "--mode", args.mode]
+        cmd = [
+            exe,
+            "--no-browser",
+            "--port",
+            str(args.port),
+            "--host",
+            args.host,
+            "--mode",
+            args.mode,
+        ]
     else:
-        cmd = [sys.executable, "-m", "autoclean.serve_launcher",
-               "--no-browser", "--port", str(args.port),
-               "--host", args.host, "--mode", args.mode]
+        cmd = [
+            sys.executable,
+            "-m",
+            "autoclean.serve_launcher",
+            "--no-browser",
+            "--port",
+            str(args.port),
+            "--host",
+            args.host,
+            "--mode",
+            args.mode,
+        ]
 
     if args.path:
         cmd.extend(["--path", args.path])
@@ -326,7 +371,9 @@ def _cmd_up(args) -> int:
         if service_running:
             print("  Operational state: UI + processing service are running.")
         else:
-            print("  Operational state: UI is running; processing still needs attention.")
+            print(
+                "  Operational state: UI is running; processing still needs attention."
+            )
         return 0
 
     _print_startup_failure_diagnostics(
@@ -448,7 +495,9 @@ def _cmd_down(quiet: bool = False) -> int:
         except OSError:
             pass
         if not quiet:
-            print(f"PID {pid} is alive but not an AutoClean server (stale PID file cleaned up).")
+            print(
+                f"PID {pid} is alive but not an AutoClean server (stale PID file cleaned up)."
+            )
         return 1
 
     try:
@@ -459,6 +508,7 @@ def _cmd_down(quiet: bool = False) -> int:
         return 1
 
     import time
+
     for _ in range(20):
         time.sleep(0.5)
         try:
@@ -511,7 +561,9 @@ def _cmd_status(default_port: int) -> int:
     if health:
         mode = health.get("mode", "?")
         version = health.get("pipeline_version", "?")
-        workspace = "configured" if health.get("workspace_configured") else "not configured"
+        workspace = (
+            "configured" if health.get("workspace_configured") else "not configured"
+        )
         print(f"  Mode: {mode}  |  Version: {version}  |  Workspace: {workspace}")
 
     try:
@@ -538,7 +590,11 @@ def _cmd_status(default_port: int) -> int:
     print(
         "  Routes: "
         f"{routes.get('active', 0)} active"
-        + (f", {routes.get('archived', 0)} archived" if routes.get("archived", 0) else "")
+        + (
+            f", {routes.get('archived', 0)} archived"
+            if routes.get("archived", 0)
+            else ""
+        )
     )
     print(
         "  Queue: "
@@ -560,7 +616,9 @@ def _cmd_status(default_port: int) -> int:
         elif config.get("errors"):
             print("  Next: fix configuration errors, then start processing.")
         else:
-            print("  Next: restart with 'autocleaneeg-pipeline serve up' or start processing from the UI.")
+            print(
+                "  Next: restart with 'autocleaneeg-pipeline serve up' or start processing from the UI."
+            )
     return 0
 
 
@@ -572,12 +630,18 @@ def _cmd_share(default_port: int, action: str = "start") -> int:
         return 1
 
     _pid, port, _health = existing
-    api = lambda method, path, body=None: _api_request(port, path, method, body)
+
+    def api(method, path, body=None):
+        return _api_request(port, path, method, body)
 
     if action == "stop":
         try:
             result = api("POST", "/api/tunnel/stop")
-            print("Tunnel stopped." if result.get("success") else result.get("message", "No tunnel is active."))
+            print(
+                "Tunnel stopped."
+                if result.get("success")
+                else result.get("message", "No tunnel is active.")
+            )
         except Exception as e:
             print(f"Error: {e}")
 
@@ -594,7 +658,7 @@ def _cmd_share(default_port: int, action: str = "start") -> int:
             label = "Permanent" if tunnel.get("mode") == "named" else "Temporary"
             print(f"  Tunnel:   Active ({label})")
             print(f"  URL:      {tunnel.get('url')}")
-            print(f"  Username: autoclean")
+            print("  Username: autoclean")
             print(f"  Password: {tunnel.get('password')}")
         else:
             print("  Tunnel:   Not active")
@@ -661,7 +725,7 @@ def _cmd_share(default_port: int, action: str = "start") -> int:
             label = "Permanent" if tunnel.get("mode") == "named" else "Temporary"
             print(f"Tunnel already active ({label}):")
             print(f"  URL:      {tunnel.get('url')}")
-            print(f"  Username: autoclean")
+            print("  Username: autoclean")
             print(f"  Password: {tunnel.get('password')}")
             return 0
 
@@ -672,7 +736,7 @@ def _cmd_share(default_port: int, action: str = "start") -> int:
                 label = "Permanent" if data.get("mode") == "named" else "Temporary"
                 print(f"Tunnel active ({label}):")
                 print(f"  URL:      {data.get('url')}")
-                print(f"  Username: autoclean")
+                print("  Username: autoclean")
                 print(f"  Password: {data.get('password')}")
                 if data.get("mode") != "named":
                     print("\n  This URL is temporary and changes on restart.")
@@ -692,6 +756,7 @@ def _cmd_share(default_port: int, action: str = "start") -> int:
 def _get_lan_addresses() -> list[str]:
     """Return LAN IP addresses (non-loopback IPv4)."""
     import socket
+
     addrs = []
     try:
         for info in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
@@ -733,7 +798,7 @@ def _resolve_port(args) -> int:
             print(f"Port {args.port} in use — using port {port}")
         else:
             print(f"Port {args.port} is in use by another process.")
-            print(f"  Use --force to start on the next available port.")
+            print("  Use --force to start on the next available port.")
             sys.exit(1)
     return port
 
@@ -812,7 +877,10 @@ def _write_pid_file(port: int) -> None:
 
     def _sigterm_handler(signum, frame):
         _cleanup_pid_file()
-        if callable(prev_handler) and prev_handler not in (signal.SIG_DFL, signal.SIG_IGN):
+        if callable(prev_handler) and prev_handler not in (
+            signal.SIG_DFL,
+            signal.SIG_IGN,
+        ):
             prev_handler(signum, frame)
         sys.exit(0)
 

--- a/src/autoclean/tools/autoclean_exclude.py
+++ b/src/autoclean/tools/autoclean_exclude.py
@@ -95,7 +95,10 @@ from qtpy.QtWidgets import (  # noqa: E402
 )
 
 from autoclean.io.export import save_epochs_to_set  # noqa: E402
-from autoclean.utils.database import get_run_record, merge_reprocess_database  # noqa: E402
+from autoclean.utils.database import (  # noqa: E402
+    get_run_record,
+    merge_reprocess_database,
+)
 from autoclean.utils.logging import message  # noqa: E402
 from autoclean.utils.path_resolution import resolve_moved_path  # noqa: E402
 from autoclean.utils.reprocess_overrides import (  # noqa: E402
@@ -827,7 +830,9 @@ class ReviewBase(QWidget):
         if self.current_dir:
             self.status_bar.showMessage(f"Workspace: {self.current_dir}")
         else:
-            self.status_bar.showMessage("Select a folder with EEG files (.set, .raw, .bdf)")
+            self.status_bar.showMessage(
+                "Select a folder with EEG files (.set, .raw, .bdf)"
+            )
 
     def selectDirectory(self) -> None:  # noqa: N802 - public API compatibility
         dir_path = QFileDialog.getExistingDirectory(
@@ -3997,9 +4002,7 @@ class ExclusionFileSelector(ReviewBase):
                 return (folder.lower(), relative.name.lower())
 
             all_set_files = [
-                f
-                for ext in ("*.set", "*.raw", "*.bdf")
-                for f in root_path.rglob(ext)
+                f for ext in ("*.set", "*.raw", "*.bdf") for f in root_path.rglob(ext)
             ]
 
             # Filter backup and reprocess folders if toggle is off
@@ -4131,7 +4134,9 @@ class ExclusionFileSelector(ReviewBase):
             QTimer.singleShot(0, _select_initial)
         else:
             if self.status_bar is not None:
-                self.status_bar.showMessage("Select a folder with EEG files (.set, .raw, .bdf)")
+                self.status_bar.showMessage(
+                    "Select a folder with EEG files (.set, .raw, .bdf)"
+                )
 
     def selectDirectory(self) -> None:  # noqa: N802 - inherited public API
         dir_path = QFileDialog.getExistingDirectory(
@@ -5155,9 +5160,7 @@ class ExclusionFileSelector(ReviewBase):
             bad_ch_count = len(payload["modifications"]["bad_channels"]["modified"])
             ica_count = len(payload["modifications"]["rejected_ica"]["modified"])
             epoch_count = int(
-                payload.get("modifications", {})
-                .get("epoch_review", {})
-                .get("count", 0)
+                payload.get("modifications", {}).get("epoch_review", {}).get("count", 0)
             )
 
             confirm_msg = (

--- a/src/autoclean/tools/autoclean_review.py
+++ b/src/autoclean/tools/autoclean_review.py
@@ -15,9 +15,9 @@ import matplotlib.pyplot as plt
 import mne
 import scipy.io as sio
 from dotenv import load_dotenv
-from PyQt6.QtWidgets import *  # noqa: F403
 from PyQt6.QtCore import QAbstractItemModel, QModelIndex, Qt, pyqtRemoveInputHook
 from PyQt6.QtGui import QColor, QImage, QPalette, QPixmap
+from PyQt6.QtWidgets import *  # noqa: F403
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,

--- a/src/autoclean/tui/legacy_app.py
+++ b/src/autoclean/tui/legacy_app.py
@@ -15,9 +15,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
 from textual.reactive import reactive
-from textual.screen import Screen
 from textual.widgets import (
-    Button,
     Footer,
     Header,
     Label,
@@ -29,10 +27,10 @@ from textual.widgets import (
 from autoclean.tui.screens.activity import ActivityScreen
 from autoclean.tui.screens.config import ConfigScreen
 from autoclean.tui.screens.dashboard import DashboardScreen
-from autoclean.utils.ingestion import ServeConfigError
 from autoclean.tui.screens.queue import QueueScreen
 from autoclean.tui.screens.routes import RoutesScreen
 from autoclean.tui.screens.service import ServiceScreen
+from autoclean.utils.ingestion import ServeConfigError
 
 
 @dataclass
@@ -117,7 +115,9 @@ class StatusBar(Static):
     service_running = reactive(False)
 
     def render(self) -> str:
-        mode_display = "[bold cyan]Draft[/]" if self.mode == "test" else "[bold cyan]Production[/]"
+        mode_display = (
+            "[bold cyan]Draft[/]" if self.mode == "test" else "[bold cyan]Production[/]"
+        )
         if self.service_running:
             status = "[bold green]Running[/]"
         else:
@@ -363,7 +363,9 @@ class AutoCleanTUI(App):
                     processing += 1
                 elif status == "failed":
                     failed += 1
-                    failed_at = str(entry_data.get("failed_at") or entry_data.get("added_at") or "")
+                    failed_at = str(
+                        entry_data.get("failed_at") or entry_data.get("added_at") or ""
+                    )
                     if failed_at >= latest_failed_at:
                         latest_failed_at = failed_at
                         self.state.last_failed_file = Path(path_str).name
@@ -371,7 +373,9 @@ class AutoCleanTUI(App):
                 elif status == "processed":
                     processed += 1
                     processed_at = str(
-                        entry_data.get("processed_at") or entry_data.get("added_at") or ""
+                        entry_data.get("processed_at")
+                        or entry_data.get("added_at")
+                        or ""
                     )
                     if processed_at >= latest_processed_at:
                         latest_processed_at = processed_at
@@ -733,7 +737,10 @@ class AutoCleanTUI(App):
             return False, "At least one ingestion folder is required"
 
         try:
-            from autoclean.utils.serve_routes import sync_route_registry, upsert_route_spec
+            from autoclean.utils.serve_routes import (
+                sync_route_registry,
+                upsert_route_spec,
+            )
 
             modes = ["test", "live"] if mode_scope == "both" else ["test"]
             updates: dict[str, Any] = {
@@ -773,7 +780,9 @@ class AutoCleanTUI(App):
             "taskfile": taskfile.strip(),
             "montage": montage.strip(),
             "folders": [],
-            "mode_scope": "Draft + Production" if mode_scope == "both" else "Draft only",
+            "mode_scope": (
+                "Draft + Production" if mode_scope == "both" else "Draft only"
+            ),
             "matches": [],
             "warnings": [],
         }
@@ -791,7 +800,9 @@ class AutoCleanTUI(App):
                 continue
             patterns = globs or ["*"]
             for pattern in patterns:
-                iterator = resolved.rglob(pattern) if recursive else resolved.glob(pattern)
+                iterator = (
+                    resolved.rglob(pattern) if recursive else resolved.glob(pattern)
+                )
                 for match in iterator:
                     if match.is_file():
                         preview["matches"].append(str(match))
@@ -806,7 +817,9 @@ class AutoCleanTUI(App):
         if not montage.strip():
             preview["warnings"].append("Montage is required.")
         if not preview["matches"]:
-            preview["warnings"].append("No matching files found in the selected folders yet.")
+            preview["warnings"].append(
+                "No matching files found in the selected folders yet."
+            )
         return preview
 
     def set_route_enabled(self, route_id: str, enabled: bool) -> bool:
@@ -816,7 +829,10 @@ class AutoCleanTUI(App):
             return False
 
         try:
-            from autoclean.utils.serve_routes import sync_route_registry, upsert_route_spec
+            from autoclean.utils.serve_routes import (
+                sync_route_registry,
+                upsert_route_spec,
+            )
 
             upsert_route_spec(workspace_dir, route_id, {"enabled": enabled})
             sync_route_registry(workspace_dir)
@@ -855,7 +871,10 @@ class AutoCleanTUI(App):
             return False
 
         try:
-            from autoclean.utils.serve_routes import promote_route_spec, sync_route_registry
+            from autoclean.utils.serve_routes import (
+                promote_route_spec,
+                sync_route_registry,
+            )
 
             promote_route_spec(workspace_dir, route_id)
             sync_route_registry(workspace_dir)
@@ -887,20 +906,36 @@ class AutoCleanTUI(App):
         queue_path = self.get_queue_path()
         uptime = None
         if self.state.service_started_at is not None and self.state.service_running:
-            uptime_seconds = int((datetime.now() - self.state.service_started_at).total_seconds())
+            uptime_seconds = int(
+                (datetime.now() - self.state.service_started_at).total_seconds()
+            )
             minutes, seconds = divmod(uptime_seconds, 60)
             hours, minutes = divmod(minutes, 60)
             uptime = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
         return {
             "lane": self.get_mode_label(),
-            "workspace": str(self.state.workspace_dir) if self.state.workspace_dir else "Not configured",
+            "workspace": (
+                str(self.state.workspace_dir)
+                if self.state.workspace_dir
+                else "Not configured"
+            ),
             "queue_path": str(queue_path) if queue_path else "Unavailable",
             "config_source": self.state.service_last_config_source or config_source,
             "config_path": str(config_path) if config_path else "Unavailable",
-            "log_path": str(self.state.service_log_path) if self.state.service_log_path else "Unavailable",
-            "pid": self.state.service_process.pid if self.state.service_process else None,
+            "log_path": (
+                str(self.state.service_log_path)
+                if self.state.service_log_path
+                else "Unavailable"
+            ),
+            "pid": (
+                self.state.service_process.pid if self.state.service_process else None
+            ),
             "uptime": uptime,
-            "command": " ".join(self.state.service_last_command) if self.state.service_last_command else "Not started yet",
+            "command": (
+                " ".join(self.state.service_last_command)
+                if self.state.service_last_command
+                else "Not started yet"
+            ),
             "completed": self.state.last_completed_file,
             "failed": self.state.last_failed_file,
             "failed_error": self.state.last_failed_error,
@@ -1040,4 +1075,5 @@ Examples:
 
 if __name__ == "__main__":
     import sys
+
     sys.exit(main())

--- a/src/autoclean/tui/screens/activity.py
+++ b/src/autoclean/tui/screens/activity.py
@@ -95,7 +95,9 @@ class ActivityScreen(Screen):
 
             # Log entries
             with VerticalScroll(id="log-scroll", classes="log-container"):
-                yield Static("No activity logged yet", classes="empty-state", id="empty-log")
+                yield Static(
+                    "No activity logged yet", classes="empty-state", id="empty-log"
+                )
 
             # Status
             yield Static("", id="log-status", classes="help-text")
@@ -123,9 +125,7 @@ class ActivityScreen(Screen):
         events = app.state.activity_log
 
         if not events:
-            log_scroll.mount(
-                Static("No activity logged yet", classes="empty-state")
-            )
+            log_scroll.mount(Static("No activity logged yet", classes="empty-state"))
             self._update_status(0, 0)
             return
 

--- a/src/autoclean/tui/screens/dashboard.py
+++ b/src/autoclean/tui/screens/dashboard.py
@@ -87,10 +87,18 @@ class DashboardScreen(Screen):
             yield Static("Lane Overview", classes="section-header")
 
             with Horizontal(classes="stats-container"):
-                yield StatBox(0, "Waiting", "pending", id="stat-pending", classes="stat-box")
-                yield StatBox(0, "Running", "running", id="stat-running", classes="stat-box")
-                yield StatBox(0, "Completed", "ready", id="stat-completed", classes="stat-box")
-                yield StatBox(0, "Needs attention", "failed", id="stat-failed", classes="stat-box")
+                yield StatBox(
+                    0, "Waiting", "pending", id="stat-pending", classes="stat-box"
+                )
+                yield StatBox(
+                    0, "Running", "running", id="stat-running", classes="stat-box"
+                )
+                yield StatBox(
+                    0, "Completed", "ready", id="stat-completed", classes="stat-box"
+                )
+                yield StatBox(
+                    0, "Needs attention", "failed", id="stat-failed", classes="stat-box"
+                )
 
             with Horizontal(classes="service-controls"):
                 yield Button("Start Service", id="btn-start", variant="success")
@@ -100,7 +108,9 @@ class DashboardScreen(Screen):
             yield Static("Recent Activity", classes="section-header")
 
             with Vertical(id="activity-feed", classes="activity-container"):
-                yield Static("No recent activity", classes="empty-state", id="empty-activity")
+                yield Static(
+                    "No recent activity", classes="empty-state", id="empty-activity"
+                )
 
     def on_mount(self) -> None:
         self.set_interval(2.0, self.refresh_data)

--- a/src/autoclean/tui/screens/queue.py
+++ b/src/autoclean/tui/screens/queue.py
@@ -106,7 +106,10 @@ class QueueScreen(Screen):
             return True
         self._confirm_key = token
         self._confirm_started_at = now
-        self.notify(f"Press again within 5 seconds to confirm {action}: {target}", severity="warning")
+        self.notify(
+            f"Press again within 5 seconds to confirm {action}: {target}",
+            severity="warning",
+        )
         return False
 
     def refresh_data(self) -> None:
@@ -270,7 +273,11 @@ class QueueScreen(Screen):
 
             queue = IngestionQueue(queue_path)
             entries = queue.entries()
-            to_remove = [path for path, data in entries.items() if data.get("status") == "processed"]
+            to_remove = [
+                path
+                for path, data in entries.items()
+                if data.get("status") == "processed"
+            ]
             for path in to_remove:
                 del entries[path]
             if to_remove:

--- a/src/autoclean/tui/screens/routes.py
+++ b/src/autoclean/tui/screens/routes.py
@@ -172,7 +172,9 @@ class RouteEditorScreen(Screen):
         app: AutoCleanTUI = self.app  # type: ignore
         ok, error = app.upsert_route_spec(
             route_id=self.query_one("#input-route-id", Input).value,
-            existing_route_id=str(self.route_spec.get("id")) if self.is_edit_mode else None,
+            existing_route_id=(
+                str(self.route_spec.get("id")) if self.is_edit_mode else None
+            ),
             taskfile=self.query_one("#input-taskfile", Input).value,
             montage=self.query_one("#input-montage", Input).value,
             ingestion_folders=self.query_one("#input-folders", Input).value.split(","),
@@ -291,7 +293,9 @@ class RoutesScreen(Screen):
             live_str = "[green]Yes[/]" if "live" in modes else "[dim]-[/]"
             state_str = "[yellow]Archived[/]" if archived else "[green]Active[/]"
             enabled_str = "[green]Yes[/]" if enabled else "[red]No[/]"
-            task_label = Path(str(route.get("taskfile", ""))).name or str(route.get("taskfile", ""))
+            task_label = Path(str(route.get("taskfile", ""))).name or str(
+                route.get("taskfile", "")
+            )
             table.add_row(
                 str(route["id"]),
                 draft_str,
@@ -405,7 +409,9 @@ class RoutesScreen(Screen):
             self.notify("Route not found", severity="error")
             return
         if route.get("archived", False):
-            self.notify("Restore the route before changing enabled state", severity="warning")
+            self.notify(
+                "Restore the route before changing enabled state", severity="warning"
+            )
             return
 
         enabled = not bool(route.get("enabled", True))

--- a/src/autoclean/tui/screens/service.py
+++ b/src/autoclean/tui/screens/service.py
@@ -37,19 +37,39 @@ class ServiceScreen(Screen):
             with Vertical(classes="service-params"):
                 with Horizontal(classes="param-row"):
                     yield Label("Max Cycles:", classes="param-label")
-                    yield Input(value="1000", placeholder="Maximum cycles to run", id="input-max-cycles", classes="param-input")
+                    yield Input(
+                        value="1000",
+                        placeholder="Maximum cycles to run",
+                        id="input-max-cycles",
+                        classes="param-input",
+                    )
 
                 with Horizontal(classes="param-row"):
                     yield Label("Idle Limit:", classes="param-label")
-                    yield Input(value="10", placeholder="Idle cycles before exit", id="input-idle-limit", classes="param-input")
+                    yield Input(
+                        value="10",
+                        placeholder="Idle cycles before exit",
+                        id="input-idle-limit",
+                        classes="param-input",
+                    )
 
                 with Horizontal(classes="param-row"):
                     yield Label("Sleep (sec):", classes="param-label")
-                    yield Input(value="1.0", placeholder="Seconds between cycles", id="input-sleep", classes="param-input")
+                    yield Input(
+                        value="1.0",
+                        placeholder="Seconds between cycles",
+                        id="input-sleep",
+                        classes="param-input",
+                    )
 
                 with Horizontal(classes="param-row"):
                     yield Label("Max Events:", classes="param-label")
-                    yield Input(value="1", placeholder="Max watch events per cycle", id="input-max-events", classes="param-input")
+                    yield Input(
+                        value="1",
+                        placeholder="Max watch events per cycle",
+                        id="input-max-events",
+                        classes="param-input",
+                    )
 
             yield Static("Options", classes="section-header")
 
@@ -57,12 +77,16 @@ class ServiceScreen(Screen):
                 with Horizontal(classes="param-row"):
                     yield Label("Dry Run:", classes="param-label")
                     yield Switch(value=False, id="switch-dry-run")
-                    yield Static("Print commands without executing", classes="help-text")
+                    yield Static(
+                        "Print commands without executing", classes="help-text"
+                    )
 
                 with Horizontal(classes="param-row"):
                     yield Label("Watch Mode:", classes="param-label")
                     yield Switch(value=True, id="switch-watch")
-                    yield Static("Use watchfiles for file monitoring", classes="help-text")
+                    yield Static(
+                        "Use watchfiles for file monitoring", classes="help-text"
+                    )
 
                 with Horizontal(classes="param-row"):
                     yield Label("Require Sentinel:", classes="param-label")
@@ -146,7 +170,8 @@ class ServiceScreen(Screen):
         service_events = [
             e
             for e in app.state.activity_log
-            if e.event_type.startswith("service") or e.event_type in ("error", "complete")
+            if e.event_type.startswith("service")
+            or e.event_type in ("error", "complete")
         ][:5]
 
         if not service_events:
@@ -215,7 +240,9 @@ class ServiceScreen(Screen):
             params["use_watchfiles"] = True
 
         try:
-            params["require_sentinel"] = self.query_one("#switch-sentinel", Switch).value
+            params["require_sentinel"] = self.query_one(
+                "#switch-sentinel", Switch
+            ).value
         except Exception:
             params["require_sentinel"] = True
 

--- a/src/autoclean/tui/v2_app.py
+++ b/src/autoclean/tui/v2_app.py
@@ -25,12 +25,12 @@ from textual.widgets import (
     Select,
     Static,
     Switch,
-    TabPane,
     TabbedContent,
+    TabPane,
 )
 
-from autoclean.utils.ingestion import ServeConfigError
 from autoclean.tui.v2_state import ServeWorkspaceSnapshot, build_workspace_snapshot
+from autoclean.utils.ingestion import ServeConfigError
 
 
 @dataclass
@@ -100,8 +100,16 @@ class TitleBar(Static):
     last_refresh = reactive("Never")
 
     def render(self) -> str:
-        lane = "[bold cyan]Draft[/]" if self.mode == "test" else "[bold magenta]Production[/]"
-        service = "[bold green]running[/]" if self.service_running else "[bold yellow]stopped[/]"
+        lane = (
+            "[bold cyan]Draft[/]"
+            if self.mode == "test"
+            else "[bold magenta]Production[/]"
+        )
+        service = (
+            "[bold green]running[/]"
+            if self.service_running
+            else "[bold yellow]stopped[/]"
+        )
         return (
             "AutoClean Serve"
             f"  •  {lane}"
@@ -172,8 +180,12 @@ class AutoCleanTUI(App):
                     yield Static("", id="home-publish", classes="card")
                     yield Static("", id="home-service", classes="card")
                 with Horizontal(classes="action-row"):
-                    yield Button("Follow next action", id="btn-home-next", variant="primary")
-                    yield Button("Refresh snapshot", id="btn-home-refresh", variant="default")
+                    yield Button(
+                        "Follow next action", id="btn-home-next", variant="primary"
+                    )
+                    yield Button(
+                        "Refresh snapshot", id="btn-home-refresh", variant="default"
+                    )
                 with VerticalScroll(classes="detail-scroll"):
                     yield Static("", id="home-events", classes="detail-block")
             with TabPane("Routes", id="tab-routes"):
@@ -182,7 +194,11 @@ class AutoCleanTUI(App):
                         with Horizontal(classes="filter-row"):
                             yield Label("View")
                             yield Select(
-                                [("Active", "active"), ("Archived", "archived"), ("All", "all")],
+                                [
+                                    ("Active", "active"),
+                                    ("Archived", "archived"),
+                                    ("All", "all"),
+                                ],
                                 value="active",
                                 id="routes-view",
                             )
@@ -191,8 +207,12 @@ class AutoCleanTUI(App):
                             yield Button("New", id="btn-route-new", variant="primary")
                             yield Button("Edit", id="btn-route-edit")
                             yield Button("Enable/Disable", id="btn-route-toggle")
-                            yield Button("Promote", id="btn-route-promote", variant="success")
-                            yield Button("Archive", id="btn-route-archive", variant="warning")
+                            yield Button(
+                                "Promote", id="btn-route-promote", variant="success"
+                            )
+                            yield Button(
+                                "Archive", id="btn-route-archive", variant="warning"
+                            )
                             yield Button("Sync", id="btn-route-sync")
                     with VerticalScroll(classes="pane detail-pane"):
                         yield Static("", id="route-detail", classes="detail-block")
@@ -200,23 +220,35 @@ class AutoCleanTUI(App):
                         with Vertical(id="route-editor", classes="editor-block"):
                             with Horizontal(classes="editor-row"):
                                 yield Label("Route ID", classes="editor-label")
-                                yield Input(placeholder="resting-biosemi64", id="route-id")
+                                yield Input(
+                                    placeholder="resting-biosemi64", id="route-id"
+                                )
                             with Horizontal(classes="editor-row"):
                                 yield Label("Task File", classes="editor-label")
-                                yield Input(placeholder="/path/to/Task.py", id="route-taskfile")
+                                yield Input(
+                                    placeholder="/path/to/Task.py", id="route-taskfile"
+                                )
                             with Horizontal(classes="editor-row"):
                                 yield Label("Montage", classes="editor-label")
                                 yield Input(placeholder="biosemi64", id="route-montage")
                             with Horizontal(classes="editor-row"):
                                 yield Label("Folders", classes="editor-label")
-                                yield Input(placeholder="/data/incoming, /data/incoming2", id="route-folders")
+                                yield Input(
+                                    placeholder="/data/incoming, /data/incoming2",
+                                    id="route-folders",
+                                )
                             with Horizontal(classes="editor-row"):
                                 yield Label("File globs", classes="editor-label")
-                                yield Input(placeholder="*.set, *_rest.set", id="route-globs")
+                                yield Input(
+                                    placeholder="*.set, *_rest.set", id="route-globs"
+                                )
                             with Horizontal(classes="editor-row"):
                                 yield Label("Scope", classes="editor-label")
                                 yield Select(
-                                    [("Draft only", "test"), ("Draft + Production", "both")],
+                                    [
+                                        ("Draft only", "test"),
+                                        ("Draft + Production", "both"),
+                                    ],
                                     value="test",
                                     id="route-scope",
                                 )
@@ -227,7 +259,9 @@ class AutoCleanTUI(App):
                                 yield Switch(value=True, id="route-recursive")
                             with Horizontal(classes="action-row"):
                                 yield Button("Preview", id="btn-route-preview")
-                                yield Button("Save", id="btn-route-save", variant="success")
+                                yield Button(
+                                    "Save", id="btn-route-save", variant="success"
+                                )
                                 yield Button("Reset", id="btn-route-reset")
                             yield Static("", id="route-preview", classes="detail-block")
             with TabPane("Queue", id="tab-queue"):
@@ -247,11 +281,19 @@ class AutoCleanTUI(App):
                                 id="queue-status-filter",
                             )
                             yield Label("Route")
-                            yield Select([("All Routes", "all")], value="all", id="queue-route-filter")
+                            yield Select(
+                                [("All Routes", "all")],
+                                value="all",
+                                id="queue-route-filter",
+                            )
                         yield DataTable(id="queue-table")
                         with Horizontal(classes="action-row"):
-                            yield Button("Retry failed", id="btn-queue-retry", variant="warning")
-                            yield Button("Remove", id="btn-queue-remove", variant="error")
+                            yield Button(
+                                "Retry failed", id="btn-queue-retry", variant="warning"
+                            )
+                            yield Button(
+                                "Remove", id="btn-queue-remove", variant="error"
+                            )
                             yield Button("Clear completed", id="btn-queue-clear")
                             yield Button("Refresh", id="btn-queue-refresh")
                     with VerticalScroll(classes="pane detail-pane"):
@@ -261,11 +303,17 @@ class AutoCleanTUI(App):
                     with VerticalScroll(classes="pane detail-pane"):
                         yield Static("", id="publish-summary", classes="detail-block")
                         with Horizontal(classes="action-row"):
-                            yield Button("Validate", id="btn-publish-validate", variant="primary")
-                            yield Button("Deploy", id="btn-publish-deploy", variant="success")
+                            yield Button(
+                                "Validate", id="btn-publish-validate", variant="primary"
+                            )
+                            yield Button(
+                                "Deploy", id="btn-publish-deploy", variant="success"
+                            )
                             yield Button("Refresh", id="btn-publish-refresh")
                     with VerticalScroll(classes="pane detail-pane"):
-                        yield Static("", id="publish-yaml", classes="detail-block code-block")
+                        yield Static(
+                            "", id="publish-yaml", classes="detail-block code-block"
+                        )
             with TabPane("Service", id="tab-service"):
                 with Horizontal(classes="split"):
                     with Vertical(classes="pane detail-pane"):
@@ -292,11 +340,17 @@ class AutoCleanTUI(App):
                                 yield Label("Sentinel", classes="editor-label")
                                 yield Switch(value=True, id="service-sentinel")
                             with Horizontal(classes="action-row"):
-                                yield Button("Start", id="btn-service-start", variant="success")
-                                yield Button("Stop", id="btn-service-stop", variant="error")
+                                yield Button(
+                                    "Start", id="btn-service-start", variant="success"
+                                )
+                                yield Button(
+                                    "Stop", id="btn-service-stop", variant="error"
+                                )
                                 yield Button("Refresh", id="btn-service-refresh")
                     with VerticalScroll(classes="pane detail-pane"):
-                        yield Static("", id="service-log", classes="detail-block code-block")
+                        yield Static(
+                            "", id="service-log", classes="detail-block code-block"
+                        )
         yield StatusBar(id="status-bar")
 
     def on_mount(self) -> None:
@@ -321,7 +375,9 @@ class AutoCleanTUI(App):
         title_bar = self.query_one("#title-bar", TitleBar)
         title_bar.mode = self.state.mode
         title_bar.service_running = self.state.service_running
-        title_bar.config_source = self.state.service_last_config_source or self.get_service_config_source()[0]
+        title_bar.config_source = (
+            self.state.service_last_config_source or self.get_service_config_source()[0]
+        )
         title_bar.queue_summary = (
             f"Queue: {self.state.failed_count} failed / {self.state.running_count} running / "
             f"{self.state.pending_count} waiting"
@@ -425,7 +481,9 @@ class AutoCleanTUI(App):
 
             raw_config = load_serve_config(config_file)
             parse_serve_config(raw_config, self.state.workspace_dir, strict=True)
-            _, warnings = parse_serve_config(raw_config, self.state.workspace_dir, strict=False)
+            _, warnings = parse_serve_config(
+                raw_config, self.state.workspace_dir, strict=False
+            )
             self.state.config_valid = True
             self.state.config_errors = []
             self.state.config_warnings = list(warnings)
@@ -472,17 +530,25 @@ class AutoCleanTUI(App):
                     self.state.running_count += 1
                 elif status == "processed":
                     self.state.completed_count += 1
-                    processed_at = str(entry_data.get("processed_at") or entry_data.get("added_at") or "")
+                    processed_at = str(
+                        entry_data.get("processed_at")
+                        or entry_data.get("added_at")
+                        or ""
+                    )
                     if processed_at >= latest_processed_at:
                         latest_processed_at = processed_at
                         self.state.last_completed_file = Path(path_str).name
                 elif status == "failed":
                     self.state.failed_count += 1
-                    failed_at = str(entry_data.get("failed_at") or entry_data.get("added_at") or "")
+                    failed_at = str(
+                        entry_data.get("failed_at") or entry_data.get("added_at") or ""
+                    )
                     if failed_at >= latest_failed_at:
                         latest_failed_at = failed_at
                         self.state.last_failed_file = Path(path_str).name
-                        self.state.last_failed_error = str(entry_data.get("last_error") or "")
+                        self.state.last_failed_error = str(
+                            entry_data.get("last_error") or ""
+                        )
         except Exception:
             pass
 
@@ -494,12 +560,16 @@ class AutoCleanTUI(App):
             from watchfiles import watch
 
             paths_to_watch = [self.state.workspace_dir]
-            for changes in watch(*paths_to_watch, recursive=False, stop_event=self._watcher_stop_event):
+            for changes in watch(
+                *paths_to_watch, recursive=False, stop_event=self._watcher_stop_event
+            ):
                 if self._watcher_stop_event.is_set():
                     break
                 for _, path in changes:
                     changed_path = Path(path)
-                    if changed_path.name.startswith("queue-") or changed_path.name.startswith("serve-"):
+                    if changed_path.name.startswith(
+                        "queue-"
+                    ) or changed_path.name.startswith("serve-"):
                         self.call_from_thread(self.refresh_snapshot)
                         break
         except Exception:
@@ -532,7 +602,9 @@ class AutoCleanTUI(App):
             from autoclean.utils.ingestion import load_serve_config, parse_serve_config
 
             raw_config = load_serve_config(config_file)
-            config, _ = parse_serve_config(raw_config, self.state.workspace_dir, strict=False)
+            config, _ = parse_serve_config(
+                raw_config, self.state.workspace_dir, strict=False
+            )
             return config.routes
         except Exception:
             return []
@@ -601,14 +673,19 @@ class AutoCleanTUI(App):
         if not folders:
             return False, "At least one ingestion folder is required"
         try:
-            from autoclean.utils.serve_routes import sync_route_registry, upsert_route_spec
+            from autoclean.utils.serve_routes import (
+                sync_route_registry,
+                upsert_route_spec,
+            )
 
             modes = ["test", "live"] if mode_scope == "both" else ["test"]
             updates: dict[str, Any] = {
                 "modes": modes,
                 "taskfile": str(Path(taskfile).expanduser().resolve()),
                 "montage": montage,
-                "ingestion_folders": [str(Path(item).expanduser().resolve()) for item in folders],
+                "ingestion_folders": [
+                    str(Path(item).expanduser().resolve()) for item in folders
+                ],
                 "enabled": enabled,
                 "recursive": recursive,
             }
@@ -617,7 +694,9 @@ class AutoCleanTUI(App):
             upsert_route_spec(workspace_dir, route_id, updates)
             sync_route_registry(workspace_dir)
             self._load_config()
-            self._add_activity_event("route_saved", f"Saved route {route_id}", route_id=route_id)
+            self._add_activity_event(
+                "route_saved", f"Saved route {route_id}", route_id=route_id
+            )
             return True, ""
         except Exception as exc:
             return False, str(exc)
@@ -638,7 +717,9 @@ class AutoCleanTUI(App):
             "taskfile": taskfile.strip(),
             "montage": montage.strip(),
             "folders": [],
-            "mode_scope": "Draft + Production" if mode_scope == "both" else "Draft only",
+            "mode_scope": (
+                "Draft + Production" if mode_scope == "both" else "Draft only"
+            ),
             "matches": [],
             "warnings": [],
         }
@@ -656,7 +737,9 @@ class AutoCleanTUI(App):
                 continue
             patterns = globs or ["*"]
             for pattern in patterns:
-                iterator = resolved.rglob(pattern) if recursive else resolved.glob(pattern)
+                iterator = (
+                    resolved.rglob(pattern) if recursive else resolved.glob(pattern)
+                )
                 for match in iterator:
                     if match.is_file():
                         preview["matches"].append(str(match))
@@ -671,14 +754,19 @@ class AutoCleanTUI(App):
         if not montage.strip():
             preview["warnings"].append("Montage is required.")
         if not preview["matches"]:
-            preview["warnings"].append("No matching files found in the selected folders yet.")
+            preview["warnings"].append(
+                "No matching files found in the selected folders yet."
+            )
         return preview
 
     def set_route_enabled(self, route_id: str, enabled: bool) -> bool:
         if self.state.workspace_dir is None:
             return False
         try:
-            from autoclean.utils.serve_routes import sync_route_registry, upsert_route_spec
+            from autoclean.utils.serve_routes import (
+                sync_route_registry,
+                upsert_route_spec,
+            )
 
             upsert_route_spec(self.state.workspace_dir, route_id, {"enabled": enabled})
             sync_route_registry(self.state.workspace_dir)
@@ -696,7 +784,11 @@ class AutoCleanTUI(App):
         if self.state.workspace_dir is None:
             return False
         try:
-            from autoclean.utils.serve_routes import archive_route_spec, sync_route_registry, unarchive_route_spec
+            from autoclean.utils.serve_routes import (
+                archive_route_spec,
+                sync_route_registry,
+                unarchive_route_spec,
+            )
 
             if archived:
                 archive_route_spec(self.state.workspace_dir, route_id)
@@ -717,12 +809,17 @@ class AutoCleanTUI(App):
         if self.state.workspace_dir is None:
             return False
         try:
-            from autoclean.utils.serve_routes import promote_route_spec, sync_route_registry
+            from autoclean.utils.serve_routes import (
+                promote_route_spec,
+                sync_route_registry,
+            )
 
             promote_route_spec(self.state.workspace_dir, route_id)
             sync_route_registry(self.state.workspace_dir)
             self._load_config()
-            self._add_activity_event("route_promote", f"Promoted route {route_id}", route_id=route_id)
+            self._add_activity_event(
+                "route_promote", f"Promoted route {route_id}", route_id=route_id
+            )
             return True
         except Exception:
             return False
@@ -744,20 +841,36 @@ class AutoCleanTUI(App):
         queue_path = self.get_queue_path()
         uptime = None
         if self.state.service_started_at is not None and self.state.service_running:
-            uptime_seconds = int((datetime.now() - self.state.service_started_at).total_seconds())
+            uptime_seconds = int(
+                (datetime.now() - self.state.service_started_at).total_seconds()
+            )
             minutes, seconds = divmod(uptime_seconds, 60)
             hours, minutes = divmod(minutes, 60)
             uptime = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
         return {
             "lane": self.get_mode_label(),
-            "workspace": str(self.state.workspace_dir) if self.state.workspace_dir else "Not configured",
+            "workspace": (
+                str(self.state.workspace_dir)
+                if self.state.workspace_dir
+                else "Not configured"
+            ),
             "queue_path": str(queue_path) if queue_path else "Unavailable",
             "config_source": self.state.service_last_config_source or config_source,
             "config_path": str(config_path) if config_path else "Unavailable",
-            "log_path": str(self.state.service_log_path) if self.state.service_log_path else "Unavailable",
-            "pid": self.state.service_process.pid if self.state.service_process else None,
+            "log_path": (
+                str(self.state.service_log_path)
+                if self.state.service_log_path
+                else "Unavailable"
+            ),
+            "pid": (
+                self.state.service_process.pid if self.state.service_process else None
+            ),
             "uptime": uptime,
-            "command": " ".join(self.state.service_last_command) if self.state.service_last_command else "Not started yet",
+            "command": (
+                " ".join(self.state.service_last_command)
+                if self.state.service_last_command
+                else "Not started yet"
+            ),
             "completed": self.state.last_completed_file,
             "failed": self.state.last_failed_file,
             "failed_error": self.state.last_failed_error,
@@ -799,7 +912,9 @@ class AutoCleanTUI(App):
             raw_config = load_serve_config(source)
             parse_serve_config(raw_config, self.state.workspace_dir, strict=True)
         except ServeConfigError as exc:
-            return False, "Cannot deploy invalid configuration: " + "; ".join(exc.errors)
+            return False, "Cannot deploy invalid configuration: " + "; ".join(
+                exc.errors
+            )
         except Exception as exc:
             return False, f"Deploy failed: {exc}"
         try:
@@ -820,8 +935,12 @@ class AutoCleanTUI(App):
         self._load_config()
         self._load_queue()
         config_source, _ = self.get_service_config_source()
-        operator_path = self.get_config_path(deployed=False) or Path("serve-missing.yaml")
-        deployed_path = self.get_config_path(deployed=True) or Path("deploy/serve-missing.yaml")
+        operator_path = self.get_config_path(deployed=False) or Path(
+            "serve-missing.yaml"
+        )
+        deployed_path = self.get_config_path(deployed=True) or Path(
+            "deploy/serve-missing.yaml"
+        )
         self._snapshot = build_workspace_snapshot(
             workspace_dir=self.state.workspace_dir,
             mode=self.state.mode,
@@ -836,7 +955,9 @@ class AutoCleanTUI(App):
             deployed_config_path=deployed_path,
             config_source=config_source,
         )
-        self.state.service_running = bool(self.state.service_process and self.state.service_process.poll() is None)
+        self.state.service_running = bool(
+            self.state.service_process and self.state.service_process.poll() is None
+        )
         self._update_status_bar()
         self._refresh_home_tab()
         self._refresh_routes_tab()
@@ -861,8 +982,12 @@ class AutoCleanTUI(App):
             f"Waiting: {snapshot.queue.pending}\nCompleted: {snapshot.queue.processed}"
         )
         ready = len([route for route in snapshot.routes if route.state == "Ready"])
-        draft_only = len([route for route in snapshot.routes if route.state == "Draft only"])
-        attention = len([route for route in snapshot.routes if route.state == "Attention"])
+        draft_only = len(
+            [route for route in snapshot.routes if route.state == "Draft only"]
+        )
+        attention = len(
+            [route for route in snapshot.routes if route.state == "Attention"]
+        )
         self.query_one("#home-routes", Static).update(
             f"[b]Routes[/b]\nReady: {ready}\nDraft only: {draft_only}\nNeeds attention: {attention}\n"
             f"Total tracked: {len(snapshot.routes)}"
@@ -898,20 +1023,40 @@ class AutoCleanTUI(App):
         for route in routes:
             lane = "Draft + Production" if "live" in route.modes else "Draft only"
             task_name = Path(route.taskfile).name if route.taskfile else "-"
-            table.add_row(route.label, route.state, lane, route.montage or "-", task_name, key=route.route_id)
+            table.add_row(
+                route.label,
+                route.state,
+                lane,
+                route.montage or "-",
+                task_name,
+                key=route.route_id,
+            )
             self._route_row_ids.append(route.route_id)
         if self._selected_route_id not in self._route_row_ids:
-            self._selected_route_id = self._route_row_ids[0] if self._route_row_ids else None
+            self._selected_route_id = (
+                self._route_row_ids[0] if self._route_row_ids else None
+            )
         self._refresh_route_detail()
         if not self._route_editor_existing_id and self._selected_route_id:
-            self._load_route_editor(self.get_route_spec(self._selected_route_id), edit_mode=False)
+            self._load_route_editor(
+                self.get_route_spec(self._selected_route_id), edit_mode=False
+            )
 
     def _refresh_route_detail(self) -> None:
         if self._snapshot is None:
             return
-        route = next((item for item in self._snapshot.routes if item.route_id == self._selected_route_id), None)
+        route = next(
+            (
+                item
+                for item in self._snapshot.routes
+                if item.route_id == self._selected_route_id
+            ),
+            None,
+        )
         if route is None:
-            self.query_one("#route-detail", Static).update("Select a route to inspect it.")
+            self.query_one("#route-detail", Static).update(
+                "Select a route to inspect it."
+            )
             return
         issues = route.issues or [route.summary]
         lanes = ", ".join(route.modes) if route.modes else "test"
@@ -939,7 +1084,15 @@ class AutoCleanTUI(App):
         self.query_one("#route-detail", Static).update("\n".join(detail))
 
     def _refresh_queue_route_filter(self) -> None:
-        routes = [item.route_id for item in self._snapshot.queue_items if item.route_id != "-"] if self._snapshot else []
+        routes = (
+            [
+                item.route_id
+                for item in self._snapshot.queue_items
+                if item.route_id != "-"
+            ]
+            if self._snapshot
+            else []
+        )
         options = [("All Routes", "all")]
         for route_id in sorted(set(routes)):
             options.append((route_id, route_id))
@@ -960,20 +1113,42 @@ class AutoCleanTUI(App):
                 continue
             if route_filter != "all" and item.route_id != route_filter:
                 continue
-            error = item.last_error[:72] + ("..." if len(item.last_error) > 72 else "") if item.last_error else "-"
+            error = (
+                item.last_error[:72] + ("..." if len(item.last_error) > 72 else "")
+                if item.last_error
+                else "-"
+            )
             when = item.updated_at or item.added_at
-            table.add_row(item.file_name, item.status, item.route_id, when[:19] or "-", error, key=item.path)
+            table.add_row(
+                item.file_name,
+                item.status,
+                item.route_id,
+                when[:19] or "-",
+                error,
+                key=item.path,
+            )
             self._queue_row_paths.append(item.path)
         if self._selected_queue_path not in self._queue_row_paths:
-            self._selected_queue_path = self._queue_row_paths[0] if self._queue_row_paths else None
+            self._selected_queue_path = (
+                self._queue_row_paths[0] if self._queue_row_paths else None
+            )
         self._refresh_queue_detail()
 
     def _refresh_queue_detail(self) -> None:
         if self._snapshot is None:
             return
-        item = next((entry for entry in self._snapshot.queue_items if entry.path == self._selected_queue_path), None)
+        item = next(
+            (
+                entry
+                for entry in self._snapshot.queue_items
+                if entry.path == self._selected_queue_path
+            ),
+            None,
+        )
         if item is None:
-            self.query_one("#queue-detail", Static).update("Select a queue item to inspect it.")
+            self.query_one("#queue-detail", Static).update(
+                "Select a queue item to inspect it."
+            )
             return
         lines = [
             f"[b]{item.file_name}[/b]",
@@ -987,7 +1162,12 @@ class AutoCleanTUI(App):
             lines.extend(["", "Last error:", item.last_error])
         else:
             lines.extend(["", "No error text recorded for this item."])
-        lines.extend(["", "Safe actions: retry failed items, remove one item, clear completed items."])
+        lines.extend(
+            [
+                "",
+                "Safe actions: retry failed items, remove one item, clear completed items.",
+            ]
+        )
         self.query_one("#queue-detail", Static).update("\n".join(lines))
 
     def _refresh_publish_tab(self) -> None:
@@ -1004,12 +1184,18 @@ class AutoCleanTUI(App):
             "",
             f"Errors ({len(publish.config_errors)}):",
         ]
-        summary.extend(f"- {error}" for error in publish.config_errors) or summary.append("- None")
+        summary.extend(
+            f"- {error}" for error in publish.config_errors
+        ) or summary.append("- None")
         summary.append("")
         summary.append(f"Warnings ({len(publish.config_warnings)}):")
-        summary.extend(f"- {warning}" for warning in publish.config_warnings) or summary.append("- None")
+        summary.extend(
+            f"- {warning}" for warning in publish.config_warnings
+        ) or summary.append("- None")
         self.query_one("#publish-summary", Static).update("\n".join(summary))
-        self.query_one("#publish-yaml", Static).update(self.get_config_yaml() or "# No operator config present")
+        self.query_one("#publish-yaml", Static).update(
+            self.get_config_yaml() or "# No operator config present"
+        )
 
     def _refresh_service_tab(self) -> None:
         if self._snapshot is None:
@@ -1032,14 +1218,18 @@ class AutoCleanTUI(App):
             summary.extend(["", "Last failure detail:", service.failed_error])
         summary.extend(["", "Command:", service.command])
         self.query_one("#service-summary", Static).update("\n".join(summary))
-        self.query_one("#service-log", Static).update(self.read_service_log_tail() or "No service log yet.")
+        self.query_one("#service-log", Static).update(
+            self.read_service_log_tail() or "No service log yet."
+        )
         self._sync_service_form_from_state()
 
     def _sync_service_form_from_state(self) -> None:
         settings = self.state.service_settings
         self.query_one("#service-max-cycles", Input).value = str(settings.max_cycles)
         self.query_one("#service-idle-limit", Input).value = str(settings.idle_limit)
-        self.query_one("#service-sleep-seconds", Input).value = str(settings.sleep_seconds)
+        self.query_one("#service-sleep-seconds", Input).value = str(
+            settings.sleep_seconds
+        )
         self.query_one("#service-max-events", Input).value = str(settings.max_events)
         self.query_one("#service-dry-run", Switch).value = settings.dry_run
         self.query_one("#service-watchfiles", Switch).value = settings.use_watchfiles
@@ -1050,14 +1240,18 @@ class AutoCleanTUI(App):
             return {
                 "max_cycles": int(self.query_one("#service-max-cycles", Input).value),
                 "idle_limit": int(self.query_one("#service-idle-limit", Input).value),
-                "sleep_seconds": float(self.query_one("#service-sleep-seconds", Input).value),
+                "sleep_seconds": float(
+                    self.query_one("#service-sleep-seconds", Input).value
+                ),
                 "max_events": int(self.query_one("#service-max-events", Input).value),
                 "dry_run": self.query_one("#service-dry-run", Switch).value,
                 "use_watchfiles": self.query_one("#service-watchfiles", Switch).value,
                 "require_sentinel": self.query_one("#service-sentinel", Switch).value,
             }
         except ValueError:
-            self.notify("Service settings must be numeric where expected", severity="error")
+            self.notify(
+                "Service settings must be numeric where expected", severity="error"
+            )
             return None
 
     def _set_active_tab(self, tab_id: str) -> None:
@@ -1099,7 +1293,9 @@ class AutoCleanTUI(App):
 
     def action_route_archive(self) -> None:
         route = self._selected_route_spec()
-        if route and self.set_route_archived(str(route.get("id")), not bool(route.get("archived", False))):
+        if route and self.set_route_archived(
+            str(route.get("id")), not bool(route.get("archived", False))
+        ):
             self.refresh_snapshot()
             self._set_last_action("Route archive state updated")
             self.notify("Route archive state updated")
@@ -1183,7 +1379,9 @@ class AutoCleanTUI(App):
 
     def action_toggle_mode(self) -> None:
         self.state.mode = "live" if self.state.mode == "test" else "test"
-        self._add_activity_event("lane_toggle", f"Switched to {self.get_mode_label()} lane")
+        self._add_activity_event(
+            "lane_toggle", f"Switched to {self.get_mode_label()} lane"
+        )
         self.refresh_snapshot()
         self._set_last_action(f"Switched to {self.get_mode_label()} lane")
         self.notify(f"Switched to {self.get_mode_label()} lane")
@@ -1201,7 +1399,9 @@ class AutoCleanTUI(App):
     @work(exclusive=True, thread=True)
     def _start_service(self) -> None:
         if not self.state.workspace_dir:
-            self.call_from_thread(self.notify, "No workspace configured", severity="error")
+            self.call_from_thread(
+                self.notify, "No workspace configured", severity="error"
+            )
             return
         try:
             from autoclean.utils.ingestion import resolve_runtime_cli
@@ -1221,7 +1421,9 @@ class AutoCleanTUI(App):
             self.state.service_last_config_source = config_source
             self.state.service_last_returncode = None
             with log_path.open("a", encoding="utf-8") as log_handle:
-                log_handle.write(f"\n[{datetime.now().isoformat()}] Starting service: {' '.join(cmd)}\n")
+                log_handle.write(
+                    f"\n[{datetime.now().isoformat()}] Starting service: {' '.join(cmd)}\n"
+                )
                 log_handle.flush()
                 self.state.service_process = subprocess.Popen(
                     cmd,
@@ -1232,8 +1434,14 @@ class AutoCleanTUI(App):
                 self.state.service_running = True
                 self.call_from_thread(self.refresh_snapshot)
                 self.call_from_thread(self._set_last_action, "Service started")
-                self.call_from_thread(self.notify, "Service started", severity="information")
-                self.call_from_thread(self._add_activity_event, "service_start", f"Service started ({log_path.name})")
+                self.call_from_thread(
+                    self.notify, "Service started", severity="information"
+                )
+                self.call_from_thread(
+                    self._add_activity_event,
+                    "service_start",
+                    f"Service started ({log_path.name})",
+                )
                 returncode = self.state.service_process.wait()
             stop_requested = self.state.service_stop_requested
             self.state.service_stop_requested = False
@@ -1244,11 +1452,21 @@ class AutoCleanTUI(App):
             self.call_from_thread(self.refresh_snapshot)
             if stop_requested or returncode == 0:
                 self.call_from_thread(self._set_last_action, "Service stopped")
-                self.call_from_thread(self.notify, "Service stopped", severity="information")
-                self.call_from_thread(self._add_activity_event, "service_stop", "Service stopped")
+                self.call_from_thread(
+                    self.notify, "Service stopped", severity="information"
+                )
+                self.call_from_thread(
+                    self._add_activity_event, "service_stop", "Service stopped"
+                )
             else:
-                self.call_from_thread(self._set_last_action, f"Service exited with code {returncode}")
-                self.call_from_thread(self.notify, f"Service exited with code {returncode}", severity="error")
+                self.call_from_thread(
+                    self._set_last_action, f"Service exited with code {returncode}"
+                )
+                self.call_from_thread(
+                    self.notify,
+                    f"Service exited with code {returncode}",
+                    severity="error",
+                )
                 self.call_from_thread(
                     self._add_activity_event,
                     "service_error",
@@ -1260,7 +1478,9 @@ class AutoCleanTUI(App):
             self.state.service_started_at = None
             self.state.service_process = None
             self.call_from_thread(self.refresh_snapshot)
-            self.call_from_thread(self.notify, f"Failed to start service: {exc}", severity="error")
+            self.call_from_thread(
+                self.notify, f"Failed to start service: {exc}", severity="error"
+            )
 
     def _stop_service(self) -> None:
         if self.state.service_process:
@@ -1270,21 +1490,41 @@ class AutoCleanTUI(App):
             self._set_last_action("Stopping service")
             self.notify("Stopping service...", severity="information")
 
-    def _load_route_editor(self, route_spec: Optional[dict[str, Any]], *, edit_mode: bool) -> None:
+    def _load_route_editor(
+        self, route_spec: Optional[dict[str, Any]], *, edit_mode: bool
+    ) -> None:
         route_spec = route_spec or {}
-        self._route_editor_mode = "edit" if edit_mode and route_spec.get("id") else "create"
-        self._route_editor_existing_id = str(route_spec.get("id")) if edit_mode and route_spec.get("id") else None
+        self._route_editor_mode = (
+            "edit" if edit_mode and route_spec.get("id") else "create"
+        )
+        self._route_editor_existing_id = (
+            str(route_spec.get("id")) if edit_mode and route_spec.get("id") else None
+        )
         route_id_input = self.query_one("#route-id", Input)
         route_id_input.disabled = bool(self._route_editor_existing_id)
         route_id_input.value = str(route_spec.get("id") or "")
-        self.query_one("#route-taskfile", Input).value = str(route_spec.get("taskfile") or "")
-        self.query_one("#route-montage", Input).value = str(route_spec.get("montage") or "")
-        self.query_one("#route-folders", Input).value = ", ".join(route_spec.get("ingestion_folders", []))
-        self.query_one("#route-globs", Input).value = ", ".join(route_spec.get("file_globs", []))
+        self.query_one("#route-taskfile", Input).value = str(
+            route_spec.get("taskfile") or ""
+        )
+        self.query_one("#route-montage", Input).value = str(
+            route_spec.get("montage") or ""
+        )
+        self.query_one("#route-folders", Input).value = ", ".join(
+            route_spec.get("ingestion_folders", [])
+        )
+        self.query_one("#route-globs", Input).value = ", ".join(
+            route_spec.get("file_globs", [])
+        )
         modes = route_spec.get("modes", ["test"])
-        self.query_one("#route-scope", Select).value = "both" if "live" in modes else "test"
-        self.query_one("#route-enabled", Switch).value = bool(route_spec.get("enabled", True))
-        self.query_one("#route-recursive", Switch).value = bool(route_spec.get("recursive", True))
+        self.query_one("#route-scope", Select).value = (
+            "both" if "live" in modes else "test"
+        )
+        self.query_one("#route-enabled", Switch).value = bool(
+            route_spec.get("enabled", True)
+        )
+        self.query_one("#route-recursive", Switch).value = bool(
+            route_spec.get("recursive", True)
+        )
         if route_spec:
             self._refresh_route_preview()
         else:
@@ -1361,7 +1601,9 @@ class AutoCleanTUI(App):
                 existing_route_id=self._route_editor_existing_id,
                 taskfile=self.query_one("#route-taskfile", Input).value,
                 montage=self.query_one("#route-montage", Input).value,
-                ingestion_folders=self.query_one("#route-folders", Input).value.split(","),
+                ingestion_folders=self.query_one("#route-folders", Input).value.split(
+                    ","
+                ),
                 file_globs=self.query_one("#route-globs", Input).value.split(","),
                 mode_scope=str(self.query_one("#route-scope", Select).value),
                 enabled=self.query_one("#route-enabled", Switch).value,
@@ -1375,10 +1617,15 @@ class AutoCleanTUI(App):
                 self.notify(error or "Failed to save route", severity="error")
                 self._refresh_route_preview()
         elif button_id == "btn-route-reset":
-            self._load_route_editor(self._selected_route_spec() if self._route_editor_existing_id else None, edit_mode=bool(self._route_editor_existing_id))
+            self._load_route_editor(
+                self._selected_route_spec() if self._route_editor_existing_id else None,
+                edit_mode=bool(self._route_editor_existing_id),
+            )
         elif button_id == "btn-route-toggle":
             route = self._selected_route_spec()
-            if route and self.set_route_enabled(str(route.get("id")), not bool(route.get("enabled", True))):
+            if route and self.set_route_enabled(
+                str(route.get("id")), not bool(route.get("enabled", True))
+            ):
                 self.refresh_snapshot()
                 self._set_last_action("Route toggled")
                 self.notify("Route updated")
@@ -1390,7 +1637,9 @@ class AutoCleanTUI(App):
                 self.notify("Route promoted to Production")
         elif button_id == "btn-route-archive":
             route = self._selected_route_spec()
-            if route and self.set_route_archived(str(route.get("id")), not bool(route.get("archived", False))):
+            if route and self.set_route_archived(
+                str(route.get("id")), not bool(route.get("archived", False))
+            ):
                 self.refresh_snapshot()
                 self._set_last_action("Route archive state updated")
                 self.notify("Route archive state updated")
@@ -1476,16 +1725,24 @@ class AutoCleanTUI(App):
         if removed is None:
             raise ValueError("Selected queue item was not found")
         file_name = Path(self._selected_queue_path).name
-        self._add_activity_event("queue_remove", f"Removed {file_name}", file_path=Path(self._selected_queue_path))
+        self._add_activity_event(
+            "queue_remove",
+            f"Removed {file_name}",
+            file_path=Path(self._selected_queue_path),
+        )
         return f"Removed {file_name}"
 
     def _clear_processed_entries(self, entries: dict[str, Any]) -> str:
-        to_remove = [path for path, data in entries.items() if data.get("status") == "processed"]
+        to_remove = [
+            path for path, data in entries.items() if data.get("status") == "processed"
+        ]
         for path in to_remove:
             del entries[path]
         if not to_remove:
             return "No completed items to clear"
-        self._add_activity_event("queue_clear", f"Cleared {len(to_remove)} completed item(s)")
+        self._add_activity_event(
+            "queue_clear", f"Cleared {len(to_remove)} completed item(s)"
+        )
         return f"Cleared {len(to_remove)} completed item(s)"
 
     def _follow_recommendation(self) -> None:
@@ -1525,7 +1782,9 @@ class AutoCleanTUI(App):
         elif event.select.id in {"queue-status-filter", "queue-route-filter"}:
             self._refresh_queue_tab()
 
-    def on_tabbed_content_tab_activated(self, event: TabbedContent.TabActivated) -> None:
+    def on_tabbed_content_tab_activated(
+        self, event: TabbedContent.TabActivated
+    ) -> None:
         self._update_status_bar()
 
     def action_quit(self) -> None:

--- a/src/autoclean/tui/v2_state.py
+++ b/src/autoclean/tui/v2_state.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
 
-
 STATUS_ORDER = {"failed": 0, "processing": 1, "pending": 2, "processed": 3}
 
 
@@ -166,7 +165,9 @@ def _build_route_health(route: dict[str, Any], lane: str) -> RouteHealth:
             issues.append("No file globs configured.")
         if lane == "live" and "live" not in modes:
             state = "Draft only"
-            summary = "Route is available in Draft but has not been promoted to Production."
+            summary = (
+                "Route is available in Draft but has not been promoted to Production."
+            )
         elif issues:
             state = "Attention"
             summary = issues[0]
@@ -350,9 +351,15 @@ def build_workspace_snapshot(
         needs_deploy=_config_needs_deploy(operator_config_path, deployed_config_path),
     )
     service = ServiceHealth(
-        lane=str(service_snapshot.get("lane") or ("Draft" if mode == "test" else "Production")),
+        lane=str(
+            service_snapshot.get("lane")
+            or ("Draft" if mode == "test" else "Production")
+        ),
         running=bool(service_snapshot.get("pid") or service_snapshot.get("uptime")),
-        workspace=str(service_snapshot.get("workspace") or (str(workspace_dir) if workspace_dir else "Not configured")),
+        workspace=str(
+            service_snapshot.get("workspace")
+            or (str(workspace_dir) if workspace_dir else "Not configured")
+        ),
         queue_path=str(service_snapshot.get("queue_path") or "Unavailable"),
         config_source=str(service_snapshot.get("config_source") or config_source),
         config_path=str(service_snapshot.get("config_path") or "Unavailable"),

--- a/src/autoclean/utils/ingestion.py
+++ b/src/autoclean/utils/ingestion.py
@@ -417,11 +417,15 @@ def parse_serve_config(
         return config.get(key)
 
     default_file_globs = _normalize_file_globs(
-        defaults_raw.get("file_globs")
-        if "file_globs" in defaults_raw
-        else defaults_raw.get("file_glob")
-        if "file_glob" in defaults_raw
-        else config.get("file_globs", config.get("file_glob")),
+        (
+            defaults_raw.get("file_globs")
+            if "file_globs" in defaults_raw
+            else (
+                defaults_raw.get("file_glob")
+                if "file_glob" in defaults_raw
+                else config.get("file_globs", config.get("file_glob"))
+            )
+        ),
         errors,
         "file_globs",
     )
@@ -489,11 +493,15 @@ def parse_serve_config(
             version_value = str(version_value)
 
         route_file_globs = _normalize_file_globs(
-            route_data.get("file_globs")
-            if "file_globs" in route_data
-            else route_data.get("file_glob")
-            if "file_glob" in route_data
-            else default_file_globs,
+            (
+                route_data.get("file_globs")
+                if "file_globs" in route_data
+                else (
+                    route_data.get("file_glob")
+                    if "file_glob" in route_data
+                    else default_file_globs
+                )
+            ),
             errors,
             f"automations[{idx}].file_globs",
         )
@@ -542,12 +550,16 @@ def parse_serve_config(
         )
         if ingestion_excludes and ingestion_folders:
             for exclude in ingestion_excludes:
-                if not any(_is_relative_to(exclude, root) for root in ingestion_folders):
+                if not any(
+                    _is_relative_to(exclude, root) for root in ingestion_folders
+                ):
                     errors.append(
                         f"{exclude} is not under any ingestion_folders for automations[{idx}]"
                     )
 
-        automation_root_value = route_data.get("automation_root", default_automation_root)
+        automation_root_value = route_data.get(
+            "automation_root", default_automation_root
+        )
         if not automation_root_value:
             if strict:
                 errors.append(f"automations[{idx}].automation_root is required")
@@ -579,11 +591,15 @@ def parse_serve_config(
 
         route_id = route_data.get("id")
         if not route_id:
-            route_id = _normalize_route_id(str(taskfile_value), str(montage_value), version_value)
+            route_id = _normalize_route_id(
+                str(taskfile_value), str(montage_value), version_value
+            )
         route_id = _normalize_workspace_name(str(route_id))
 
         requires_matlab = False
-        taskfile_path = resolve_taskfile_path(str(taskfile_value), workspace_dir, strict=False)
+        taskfile_path = resolve_taskfile_path(
+            str(taskfile_value), workspace_dir, strict=False
+        )
         if taskfile_path is not None:
             try:
                 from autoclean.utils.matlab_runtime import inspect_taskfile_for_matlab
@@ -655,12 +671,15 @@ def parse_serve_config(
     if runtime_path is None:
         runtime_path = workspace_dir
 
-    return ServeConfig(
-        mode=str(mode),
-        runtime_path=runtime_path,
-        routes=routes,
-        legacy=legacy,
-    ), warnings
+    return (
+        ServeConfig(
+            mode=str(mode),
+            runtime_path=runtime_path,
+            routes=routes,
+            legacy=legacy,
+        ),
+        warnings,
+    )
 
 
 def resolve_ingestion_roots(
@@ -1011,7 +1030,9 @@ def _matches_route(route: ServeRoute, file_path: Path) -> Optional[RouteMatch]:
     for root in route.ingestion_folders:
         if not _is_relative_to(file_path, root):
             continue
-        if any(_is_relative_to(file_path, exclude) for exclude in route.ingestion_excludes):
+        if any(
+            _is_relative_to(file_path, exclude) for exclude in route.ingestion_excludes
+        ):
             continue
         rel_path = file_path.relative_to(root)
         if not route.recursive and len(rel_path.parts) > 1:
@@ -1019,14 +1040,21 @@ def _matches_route(route: ServeRoute, file_path: Path) -> Optional[RouteMatch]:
         rel_posix = PurePosixPath(rel_path.as_posix())
         for pattern in route.file_globs:
             patterns = [pattern]
-            if route.recursive and "/" not in pattern and "\\" not in pattern and "**" not in pattern:
+            if (
+                route.recursive
+                and "/" not in pattern
+                and "\\" not in pattern
+                and "**" not in pattern
+            ):
                 patterns.append(f"**/{pattern}")
             for match_pattern in patterns:
                 if rel_posix.match(match_pattern):
                     spec = _glob_specificity(match_pattern)
                     depth = len(root.parts)
-                    if best_spec is None or spec > best_spec or (
-                        spec == best_spec and depth > best_depth
+                    if (
+                        best_spec is None
+                        or spec > best_spec
+                        or (spec == best_spec and depth > best_depth)
                     ):
                         best_spec = spec
                         best_depth = depth
@@ -1047,13 +1075,13 @@ def _select_route_for_file(
     if not matches:
         return None
     max_priority = max(match.route.priority for match in matches)
-    priority_matches = [match for match in matches if match.route.priority == max_priority]
+    priority_matches = [
+        match for match in matches if match.route.priority == max_priority
+    ]
     priority_matches.sort(key=lambda match: match.specificity, reverse=True)
     best = priority_matches[0]
     tied = [
-        match
-        for match in priority_matches
-        if match.specificity == best.specificity
+        match for match in priority_matches if match.specificity == best.specificity
     ]
     if len(tied) > 1:
         tied_ids = ", ".join(match.route.id for match in tied)
@@ -1866,9 +1894,11 @@ class IngestionQueue:
                 QueueEntry(
                     path=Path(path_str),
                     route_id=entry_route,
-                    ingestion_root=Path(ingestion_root)
-                    if isinstance(ingestion_root, str)
-                    else None,
+                    ingestion_root=(
+                        Path(ingestion_root)
+                        if isinstance(ingestion_root, str)
+                        else None
+                    ),
                 )
             )
         return pending

--- a/src/autoclean/utils/matlab_runtime.py
+++ b/src/autoclean/utils/matlab_runtime.py
@@ -103,8 +103,7 @@ def _read_engine_arch_file(matlab_pkg: Any) -> tuple[Optional[str], Optional[str
             return None, None
 
         lines = [
-            line.strip()
-            for line in arch_file.read_text(encoding="utf-8").splitlines()
+            line.strip() for line in arch_file.read_text(encoding="utf-8").splitlines()
         ]
         if len(lines) < 2:
             return None, None
@@ -147,14 +146,18 @@ def inspect_taskfile_for_matlab(taskfile: Path | str) -> MatlabTaskfileInspectio
     if taskfile_path.suffix != ".py":
         return inspection
     if not taskfile_path.exists():
-        inspection.warnings.append(f"Task file not found for MATLAB inspection: {taskfile_path}")
+        inspection.warnings.append(
+            f"Task file not found for MATLAB inspection: {taskfile_path}"
+        )
         return inspection
 
     try:
         source = taskfile_path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(taskfile_path))
     except Exception as exc:
-        inspection.warnings.append(f"Unable to inspect task file for MATLAB usage: {exc}")
+        inspection.warnings.append(
+            f"Unable to inspect task file for MATLAB usage: {exc}"
+        )
         return inspection
 
     matlab_aliases: set[str] = set()
@@ -229,7 +232,9 @@ def inspect_taskfile_for_matlab(taskfile: Path | str) -> MatlabTaskfileInspectio
                 base_name = _node_to_dotted_name(base)
                 if not base_name:
                     continue
-                if base_name in matlab_mixin_names or base_name.endswith(".MatlabExecutionMixin"):
+                if base_name in matlab_mixin_names or base_name.endswith(
+                    ".MatlabExecutionMixin"
+                ):
                     inspection.requires_matlab = True
                     inspection.reasons.append(
                         f"class {node.name} inherits {base_name.split('.')[-1]}"
@@ -239,13 +244,18 @@ def inspect_taskfile_for_matlab(taskfile: Path | str) -> MatlabTaskfileInspectio
             call_name = _node_to_dotted_name(node.func)
             if not call_name:
                 continue
-            if call_name in matlab_call_names or call_name.split(".")[-1] in matlab_call_names:
+            if (
+                call_name in matlab_call_names
+                or call_name.split(".")[-1] in matlab_call_names
+            ):
                 inspection.requires_matlab = True
                 inspection.reasons.append(f"calls {call_name.split('.')[-1]}")
 
     if inspection.requires_matlab:
         inspection.reasons = list(dict.fromkeys(inspection.reasons))
-        inspection.matlab_config_keys = list(dict.fromkeys(inspection.matlab_config_keys))
+        inspection.matlab_config_keys = list(
+            dict.fromkeys(inspection.matlab_config_keys)
+        )
 
     return inspection
 
@@ -468,7 +478,9 @@ def run_matlab_script(
     except MatlabRuntimeError:
         raise
     except Exception as exc:  # pragma: no cover - depends on local MATLAB runtime
-        raise MatlabExecutionError(f"Failed to run MATLAB script '{script}': {exc}") from exc
+        raise MatlabExecutionError(
+            f"Failed to run MATLAB script '{script}': {exc}"
+        ) from exc
     finally:
         if created_engine and not keep_engine:
             shutdown_matlab_engine(local_engine)

--- a/src/autoclean/utils/reprocess_overrides.py
+++ b/src/autoclean/utils/reprocess_overrides.py
@@ -15,7 +15,9 @@ EPOCH_CREATION_METHODS = {
 }
 
 
-def epoch_review_override_from_record(record: Optional[dict[str, Any]]) -> dict[str, Any]:
+def epoch_review_override_from_record(
+    record: Optional[dict[str, Any]],
+) -> dict[str, Any]:
     """Normalize manual epoch-review data from an exclusion decision record."""
     record = record or {}
     return {
@@ -57,9 +59,7 @@ def generate_reprocess_task_from_original(
     file_stem = payload.get("file_stem", "unknown")
     dataset_name = f"{file_stem}_{timestamp}"
 
-    bad_channels = [
-        ch for ch in bad_channels_raw if ch not in EOG_CHANNEL_PATTERNS
-    ]
+    bad_channels = [ch for ch in bad_channels_raw if ch not in EOG_CHANNEL_PATTERNS]
 
     class ConfigModifier(ast.NodeTransformer):
         def visit_Assign(self, node: ast.Assign):  # type: ignore[override]
@@ -85,12 +85,8 @@ def generate_reprocess_task_from_original(
                 f"- Manual ICA component rejection: {rejected_ica}",
             ]
             if manual_bad_epoch_indices:
-                doc_lines.append(
-                    f"- Manual bad epochs: {manual_bad_epoch_indices}"
-                )
-            new_docstring = ast.Expr(
-                value=ast.Constant(value="\n".join(doc_lines))
-            )
+                doc_lines.append(f"- Manual bad epochs: {manual_bad_epoch_indices}")
+            new_docstring = ast.Expr(value=ast.Constant(value="\n".join(doc_lines)))
 
             if (
                 node.body

--- a/src/autoclean/utils/serve_routes.py
+++ b/src/autoclean/utils/serve_routes.py
@@ -212,7 +212,9 @@ def upsert_route_spec(
     return path, cleaned, status
 
 
-def promote_route_spec(workspace_dir: Path, route_id: str) -> tuple[Path, dict[str, Any], str]:
+def promote_route_spec(
+    workspace_dir: Path, route_id: str
+) -> tuple[Path, dict[str, Any], str]:
     """Add live mode to an existing route spec."""
     path = route_spec_path(workspace_dir, route_id)
     if not path.exists():
@@ -237,7 +239,9 @@ def set_route_archived(
     return upsert_route_spec(workspace_dir, route_id, updates)
 
 
-def archive_route_spec(workspace_dir: Path, route_id: str) -> tuple[Path, dict[str, Any], str]:
+def archive_route_spec(
+    workspace_dir: Path, route_id: str
+) -> tuple[Path, dict[str, Any], str]:
     """Archive an existing route spec."""
     return set_route_archived(workspace_dir, route_id, True)
 
@@ -280,7 +284,9 @@ def _route_modes(route: dict[str, Any]) -> list[str]:
     return _normalize_modes(route.get("modes"))
 
 
-def _render_compiled_config(base_config: dict[str, Any], mode: str, routes: Iterable[dict[str, Any]]) -> str:
+def _render_compiled_config(
+    base_config: dict[str, Any], mode: str, routes: Iterable[dict[str, Any]]
+) -> str:
     compiled: dict[str, Any] = {}
     for key, value in base_config.items():
         if key in _LEGACY_TOP_LEVEL_ROUTE_KEYS or key == "automations":


### PR DESCRIPTION
## Summary
- Fixes the `UnicodeEncodeError`/`UnicodeDecodeError` crash in `scripts/check_code_quality.py` that prevented `make check` from ever running the linters on Windows (emoji printed to a cp1252 stdout, and subprocess output decoded with the same locale codec instead of UTF-8).
- Pins the `uv tool run` invocations in that script to the exact versions CI uses (`black==25.9.0`, `isort==6.0.1`, `ruff==0.15.20`) so local results stop drifting from CI.
- Applies `black` and `isort` across `src/autoclean/` and cleans up the remaining `ruff` findings (unused imports/locals, ambiguous single-letter variable names, a lambda assigned to a name rewritten as a `def`).

No behavioral changes — formatting/lint only, plus the tooling fix.

Closes #236

## Test plan
- [x] `python scripts/check_code_quality.py` → all 3 checks pass
- [x] `python -m pytest -k "pdf_extractor or task_browser or task_manager or serve_launcher or outlier"` → 9 passed
- [x] Confirmed CI's changed-file lint step is unaffected (still scoped to diffed files, pinned versions unchanged)