### PR TITLE
feat(channels): add montage-aware bad-channel detection presets

### DIFF
--- a/src/autoclean/mixins/signal_processing/channels.py
+++ b/src/autoclean/mixins/signal_processing/channels.py
@@ -1,16 +1,25 @@
 """Channel operations mixin for autoclean tasks."""
 
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import mne
 
 from autoclean.functions.artifacts.channels import detect_bad_channels
+from autoclean.utils.bad_channel_presets import (
+    merge_channel_count_bins,
+    resolve_bad_channel_settings,
+)
 from autoclean.utils.logging import message
 from autoclean.utils.metadata_table import (
     load_metadata_table,
     match_recording_row,
     split_channels,
 )
+
+# Sentinel distinguishing "caller did not pass cleaning_method" (use the
+# resolved preset/config value) from an explicit cleaning_method=None
+# (skip interpolation/dropping and leave channels marked as bad).
+_UNSET = object()
 
 
 class ChannelsMixin:
@@ -19,14 +28,18 @@ class ChannelsMixin:
     def clean_bad_channels(
         self,
         data: Union[mne.io.Raw, None] = None,
-        correlation_thresh: float = 0.35,
-        deviation_thresh: float = 2.5,
-        ransac_sample_prop: float = 0.35,
-        ransac_corr_thresh: float = 0.65,
-        ransac_frac_bad: float = 0.25,
-        ransac_channel_wise: bool = False,
+        preset: Optional[str] = None,
+        correlation_thresh: Optional[float] = None,
+        deviation_thresh: Optional[float] = None,
+        ransac_sample_prop: Optional[float] = None,
+        ransac_corr_thresh: Optional[float] = None,
+        ransac_frac_bad: Optional[float] = None,
+        ransac_channel_wise: Optional[bool] = None,
+        ransac_enabled: Optional[bool] = None,
+        max_bad_fraction: Optional[float] = None,
+        channel_count_bins: Optional[Dict[str, Dict[str, Any]]] = None,
         random_state: int = 1337,
-        cleaning_method: Union[str, None] = "interpolate",
+        cleaning_method: Union[str, None] = _UNSET,  # type: ignore[assignment]
         reset_bads: bool = True,
         stage_name: str = "post_bad_channels",
         manual_bad_channels: Union[List[str], None] = None,
@@ -40,23 +53,42 @@ class ChannelsMixin:
         ----------
         data : mne.io.Raw, Optional
             The data object to detect bad channels from. If None, uses self.raw.
+        preset : str, Optional
+            Montage-density preset controlling default thresholds: ``"auto"``
+            (choose by EEG channel count, default), ``"low_density"``,
+            ``"mid_density"``, ``"high_density"``, or ``"legacy"`` (the
+            historical fixed defaults, kept for backward compatibility).
+            Overrides the ``preset`` set in the ``bad_channel_detection``
+            task config, if any.
         correlation_thresh : float, Optional
-            Threshold for correlation-based detection.
+            Threshold for correlation-based detection. Overrides the preset.
         deviation_thresh : float, Optional
-            Threshold for deviation-based detection.
+            Threshold for deviation-based detection. Overrides the preset.
         ransac_sample_prop : float, Optional
-            Proportion of samples to use for RANSAC.
+            Proportion of samples to use for RANSAC. Overrides the preset.
         ransac_corr_thresh : float, Optional
-            Threshold for RANSAC-based detection.
+            Threshold for RANSAC-based detection. Overrides the preset.
         ransac_frac_bad : float, Optional
-            Fraction of bad channels to use for RANSAC.
+            Fraction of bad channels to use for RANSAC. Overrides the preset.
         ransac_channel_wise : bool, Optional
-            Whether to use channel-wise RANSAC.
+            Whether to use channel-wise RANSAC. Overrides the preset.
+        ransac_enabled : bool, Optional
+            Whether RANSAC-based detection runs at all. Low-density presets
+            disable it by default since RANSAC is unstable with limited
+            spatial redundancy. Overrides the preset.
+        max_bad_fraction : float, Optional
+            Fraction of bad channels above which the recording is flagged.
+            Overrides the preset's montage-appropriate default.
+        channel_count_bins : dict, Optional
+            Custom channel-count bins for ``preset="auto"`` (or to override a
+            named density preset's range/thresholds). Merged onto the
+            built-in bins; see :mod:`autoclean.utils.bad_channel_presets`.
         random_state : int, Optional
             Random state for reproducibility.
         cleaning_method : str, Optional
             Method to use for cleaning bad channels.
-            Options are 'interpolate' or 'drop' or None(default).
+            Options are 'interpolate' or 'drop' or None. If not passed,
+            uses the resolved preset/config value (default 'interpolate').
         reset_bads : bool, Optional
             Whether to reset bad channels.
         stage_name : str, Optional
@@ -69,6 +101,14 @@ class ChannelsMixin:
         -------
         result_raw : instance of mne.io.Raw
             The raw data object with bad channels marked or cleaned
+
+        Notes
+        -----
+        Thresholds are resolved in priority order: explicit method
+        arguments > the ``bad_channel_detection`` task config > the
+        selected preset/channel-count bin > historical defaults. The
+        resolved preset, channel-count bin, and thresholds are always
+        recorded in the ``step_clean_bad_channels`` metadata.
 
         See Also
         --------
@@ -115,15 +155,61 @@ class ChannelsMixin:
                 [] if manual_override else self._apply_bad_channel_log(result_raw)
             )
 
+            # Read the bad_channel_detection task config (ignored when the
+            # step is explicitly disabled; detection itself still always
+            # runs -- only the config-driven overrides are skipped).
+            is_config_enabled, bad_channel_step_config = self._check_step_enabled(
+                "bad_channel_detection"
+            )
+            config_value = (
+                (bad_channel_step_config or {}).get("value") or {}
+                if is_config_enabled
+                else {}
+            )
+            config_preset = config_value.get("preset")
+            config_channel_bins = config_value.get("channel_count_bins")
+
+            eeg_channel_count = len(
+                mne.pick_types(result_raw.info, eeg=True, exclude=[])
+            )
+            if eeg_channel_count == 0:
+                eeg_channel_count = result_raw.info["nchan"]
+
+            resolved = resolve_bad_channel_settings(
+                channel_count=eeg_channel_count,
+                preset=preset if preset is not None else (config_preset or "auto"),
+                channel_count_bins=merge_channel_count_bins(
+                    channel_count_bins
+                    if channel_count_bins is not None
+                    else config_channel_bins
+                ),
+                config_overrides=config_value,
+                explicit_overrides={
+                    "correlation_thresh": correlation_thresh,
+                    "deviation_thresh": deviation_thresh,
+                    "ransac_sample_prop": ransac_sample_prop,
+                    "ransac_corr_thresh": ransac_corr_thresh,
+                    "ransac_frac_bad": ransac_frac_bad,
+                    "ransac_channel_wise": ransac_channel_wise,
+                    "ransac_enabled": ransac_enabled,
+                    "max_bad_fraction": max_bad_fraction,
+                },
+            )
+            final_cleaning_method = (
+                cleaning_method if cleaning_method is not _UNSET else resolved.cleaning_method
+            )
+
+            message(
+                "info",
+                f"Bad channel detection preset={resolved.preset!r} "
+                f"density_bin={resolved.density_bin!r} "
+                f"(EEG channels={eeg_channel_count})",
+            )
+
             # Setup options
             options = {
                 "random_state": random_state,
-                "correlation_thresh": correlation_thresh,
-                "deviation_thresh": deviation_thresh,
-                "ransac_sample_prop": ransac_sample_prop,
-                "ransac_corr_thresh": ransac_corr_thresh,
-                "ransac_frac_bad": ransac_frac_bad,
-                "ransac_channel_wise": ransac_channel_wise,
+                **resolved.detector_options(),
             }
 
             if manual_override:
@@ -190,9 +276,9 @@ class ChannelsMixin:
             bads = list(set(result_raw.info["bads"]))
             result_raw.info["bads"] = bads
 
-            if cleaning_method == "interpolate":
+            if final_cleaning_method == "interpolate":
                 result_raw.interpolate_bads(reset_bads=reset_bads)
-            if cleaning_method == "drop":
+            if final_cleaning_method == "drop":
                 result_raw.drop_channels(result_raw.info["bads"])
                 result_raw.info["bads"] = []
 
@@ -204,14 +290,13 @@ class ChannelsMixin:
             else:
                 self.raw.bad_channels = bads
 
-            if (
-                len(self.raw.bad_channels) / result_raw.info["nchan"]
-                > self.BAD_CHANNEL_THRESHOLD
-            ):
+            bad_fraction = len(self.raw.bad_channels) / result_raw.info["nchan"]
+            if bad_fraction > resolved.max_bad_fraction:
                 self.flagged = True
                 warning = (
-                    f"WARNING: {len(self.raw.bad_channels) / result_raw.info['nchan']:.2%} "
-                    "bad channels detected"
+                    f"WARNING: {bad_fraction:.2%} bad channels detected, exceeding the "
+                    f"{resolved.preset!r} preset's max_bad_fraction "
+                    f"({resolved.max_bad_fraction:.0%})"
                 )
                 self.flagged_reasons.append(warning)
                 message("warning", f"Flagging: {warning}")
@@ -258,6 +343,11 @@ class ChannelsMixin:
                     if not manual_override
                     else {"manual_bad_channels": manual_bad_channels}
                 ),
+                "preset": resolved.preset,
+                "density_bin": resolved.density_bin,
+                "eeg_channel_count": eeg_channel_count,
+                "resolved_thresholds": resolved.as_metadata(),
+                "cleaning_method": final_cleaning_method,
                 "channelCount": len(result_raw.ch_names),
                 "durationSec": int(result_raw.n_times) / result_raw.info["sfreq"],
                 "numberSamples": int(result_raw.n_times),

--- a/src/autoclean/mixins/signal_processing/channels.py
+++ b/src/autoclean/mixins/signal_processing/channels.py
@@ -196,7 +196,9 @@ class ChannelsMixin:
                 },
             )
             final_cleaning_method = (
-                cleaning_method if cleaning_method is not _UNSET else resolved.cleaning_method
+                cleaning_method
+                if cleaning_method is not _UNSET
+                else resolved.cleaning_method
             )
 
             message(

--- a/src/autoclean/templates/custom_task_template.jinja
+++ b/src/autoclean/templates/custom_task_template.jinja
@@ -79,6 +79,46 @@ config = {
             "filter_kwargs": None,  # Extra args forwarded to MNE filtering
         },
     },
+    "bad_channel_detection": {
+        "enabled": True,
+        "value": {
+            # "auto" picks thresholds from channel_count_bins below based on
+            # EEG channel count. Other options: "low_density", "mid_density",
+            # "high_density" (force a bin regardless of channel count), or
+            # "legacy" (fixed pre-2025.09 defaults, for reproducibility).
+            "preset": "auto",
+            "cleaning_method": "interpolate",  # 'interpolate', 'drop', or None
+            "channel_count_bins": {
+                "low_density": {
+                    "max_channels": 32,
+                    # Lower = more aggressive. Suggested low-density default: 0.20
+                    "correlation_thresh": 0.20,
+                    # Lower = more aggressive. Suggested low-density default: 4.0
+                    "deviation_thresh": 4.0,
+                    # RANSAC has few neighboring channels to work with below
+                    # ~32 channels and can be unstable; off by default.
+                    "ransac_enabled": False,
+                    # Lower = stricter file flagging. Suggested default: 0.10
+                    "max_bad_fraction": 0.10,
+                },
+                "mid_density": {
+                    "min_channels": 33,
+                    "max_channels": 64,
+                    "correlation_thresh": 0.30,  # Lower = more aggressive
+                    "deviation_thresh": 3.0,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.15,  # Lower = stricter file flagging
+                },
+                "high_density": {
+                    "min_channels": 65,
+                    "correlation_thresh": 0.35,  # Lower = more aggressive
+                    "deviation_thresh": 2.5,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.20,  # Lower = stricter file flagging
+                },
+            },
+        },
+    },
     "reference_step": {
         "enabled": True,
         "value": "average",  # Reference type: 'average', specific channels, or None

--- a/src/autoclean/templates/custom_task_template.py
+++ b/src/autoclean/templates/custom_task_template.py
@@ -79,6 +79,46 @@ config = {
             "filter_kwargs": None,  # Extra args forwarded to MNE filtering
         },
     },
+    "bad_channel_detection": {
+        "enabled": True,
+        "value": {
+            # "auto" picks thresholds from channel_count_bins below based on
+            # EEG channel count. Other options: "low_density", "mid_density",
+            # "high_density" (force a bin regardless of channel count), or
+            # "legacy" (fixed pre-2025.09 defaults, for reproducibility).
+            "preset": "auto",
+            "cleaning_method": "interpolate",  # 'interpolate', 'drop', or None
+            "channel_count_bins": {
+                "low_density": {
+                    "max_channels": 32,
+                    # Lower = more aggressive. Suggested low-density default: 0.20
+                    "correlation_thresh": 0.20,
+                    # Lower = more aggressive. Suggested low-density default: 4.0
+                    "deviation_thresh": 4.0,
+                    # RANSAC has few neighboring channels to work with below
+                    # ~32 channels and can be unstable; off by default.
+                    "ransac_enabled": False,
+                    # Lower = stricter file flagging. Suggested default: 0.10
+                    "max_bad_fraction": 0.10,
+                },
+                "mid_density": {
+                    "min_channels": 33,
+                    "max_channels": 64,
+                    "correlation_thresh": 0.30,  # Lower = more aggressive
+                    "deviation_thresh": 3.0,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.15,  # Lower = stricter file flagging
+                },
+                "high_density": {
+                    "min_channels": 65,
+                    "correlation_thresh": 0.35,  # Lower = more aggressive
+                    "deviation_thresh": 2.5,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.20,  # Lower = stricter file flagging
+                },
+            },
+        },
+    },
     "reference_step": {
         "enabled": True,
         "value": "average",  # Reference type: 'average', specific channels, or None

--- a/src/autoclean/utils/bad_channel_presets.py
+++ b/src/autoclean/utils/bad_channel_presets.py
@@ -1,0 +1,240 @@
+"""Montage/channel-count-aware presets for bad-channel detection.
+
+Correlation and RANSAC-based bad-channel detection rely on spatial
+redundancy between neighboring channels. A threshold tuned for a
+128-channel net can be too aggressive (or numerically unstable) on a
+19-32 channel montage, where losing even a handful of channels is a much
+larger fraction of the total montage. This module resolves a single set
+of detection thresholds from a named preset (or channel-count-based
+"auto" selection) plus any user overrides, so that
+:meth:`~autoclean.mixins.signal_processing.channels.ChannelsMixin.clean_bad_channels`
+can apply montage-appropriate defaults while keeping the historical
+behavior available as an explicit "legacy" opt-in.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
+
+# Historical hardcoded defaults (pre-dating montage-aware presets). These
+# double as the fallback for any threshold not defined by a selected
+# density bin, and as the full threshold set for preset="legacy".
+BASE_DEFAULTS: Dict[str, Any] = {
+    "correlation_thresh": 0.35,
+    "deviation_thresh": 2.5,
+    "ransac_sample_prop": 0.35,
+    "ransac_corr_thresh": 0.65,
+    "ransac_frac_bad": 0.25,
+    "ransac_channel_wise": False,
+    "ransac_enabled": True,
+    "cleaning_method": "interpolate",
+    "max_bad_fraction": 0.15,
+}
+
+LEGACY_PRESET: Dict[str, Any] = dict(BASE_DEFAULTS)
+
+# Suggested channel-count bins for preset="auto". Low-density montages get
+# a more conservative correlation/deviation threshold and RANSAC disabled
+# outright (few neighboring channels make RANSAC's resampling unstable).
+DEFAULT_CHANNEL_COUNT_BINS: Dict[str, Dict[str, Any]] = {
+    "low_density": {
+        "max_channels": 32,
+        # Lower = more aggressive. Suggested low-density default: 0.20
+        "correlation_thresh": 0.20,
+        # Lower = more aggressive. Suggested low-density default: 4.0
+        "deviation_thresh": 4.0,
+        # RANSAC is unstable with limited spatial redundancy; off by default.
+        "ransac_enabled": False,
+        # Lower = stricter file flagging. Suggested low-density default: 0.10
+        "max_bad_fraction": 0.10,
+    },
+    "mid_density": {
+        "min_channels": 33,
+        "max_channels": 64,
+        "correlation_thresh": 0.30,
+        "deviation_thresh": 3.0,
+        # Higher = more aggressive. Suggested mid-density default: 0.65
+        "ransac_corr_thresh": 0.65,
+        "max_bad_fraction": 0.15,
+    },
+    "high_density": {
+        "min_channels": 65,
+        "correlation_thresh": 0.35,
+        "deviation_thresh": 2.5,
+        "ransac_corr_thresh": 0.65,
+        "max_bad_fraction": 0.20,
+    },
+}
+
+DENSITY_PRESET_NAMES = {"low_density", "mid_density", "high_density"}
+VALID_PRESETS = DENSITY_PRESET_NAMES | {"auto", "legacy"}
+
+# Keys resolve_bad_channel_settings will accept from config/explicit overrides.
+_OVERRIDABLE_KEYS = set(BASE_DEFAULTS)
+
+
+@dataclass(frozen=True)
+class ResolvedBadChannelSettings:
+    """Fully resolved bad-channel detection thresholds for one recording."""
+
+    preset: str
+    density_bin: Optional[str]
+    channel_count: int
+    correlation_thresh: float
+    deviation_thresh: float
+    ransac_sample_prop: float
+    ransac_corr_thresh: float
+    ransac_frac_bad: float
+    ransac_channel_wise: bool
+    ransac_enabled: bool
+    cleaning_method: str
+    max_bad_fraction: float
+
+    def detector_options(self) -> Dict[str, Any]:
+        """Options accepted by ``detect_bad_channels`` / ``NoisyChannels``."""
+
+        return {
+            "correlation_thresh": self.correlation_thresh,
+            "deviation_thresh": self.deviation_thresh,
+            "ransac_sample_prop": self.ransac_sample_prop,
+            # A corr_thresh of 0 disables RANSAC in detect_bad_channels().
+            "ransac_corr_thresh": self.ransac_corr_thresh if self.ransac_enabled else 0.0,
+            "ransac_frac_bad": self.ransac_frac_bad,
+            "ransac_channel_wise": self.ransac_channel_wise,
+        }
+
+    def as_metadata(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def merge_channel_count_bins(
+    overrides: Optional[Dict[str, Dict[str, Any]]],
+) -> Dict[str, Dict[str, Any]]:
+    """Merge user-supplied bin overrides onto :data:`DEFAULT_CHANNEL_COUNT_BINS`.
+
+    Bins matching a default name (``low_density``/``mid_density``/
+    ``high_density``) are shallow-merged so a user can override a single
+    field (e.g. ``correlation_thresh``) without repeating the rest.
+    Unrecognized bin names are added as-is, allowing fully custom bins.
+    """
+
+    merged: Dict[str, Dict[str, Any]] = {
+        name: dict(cfg) for name, cfg in DEFAULT_CHANNEL_COUNT_BINS.items()
+    }
+    if not overrides:
+        return merged
+
+    for name, cfg in overrides.items():
+        if name in merged:
+            merged[name].update(cfg or {})
+        else:
+            merged[name] = dict(cfg or {})
+
+    return merged
+
+
+def select_density_bin(channel_count: int, channel_count_bins: Dict[str, Dict[str, Any]]) -> str:
+    """Pick the bin whose [min_channels, max_channels] range contains ``channel_count``.
+
+    Falls back to the closest bin by boundary distance if no bin's range
+    contains the count (e.g. gaps in a custom bin configuration).
+    """
+
+    if not channel_count_bins:
+        raise ValueError("channel_count_bins must contain at least one bin")
+
+    def bounds(cfg: Dict[str, Any]) -> tuple:
+        return cfg.get("min_channels", 0), cfg.get("max_channels", math.inf)
+
+    exact_matches = [
+        name
+        for name, cfg in channel_count_bins.items()
+        if bounds(cfg)[0] <= channel_count <= bounds(cfg)[1]
+    ]
+    if exact_matches:
+        # Prefer the narrowest matching range if bins overlap.
+        return min(
+            exact_matches,
+            key=lambda name: bounds(channel_count_bins[name])[1]
+            - bounds(channel_count_bins[name])[0],
+        )
+
+    def distance(cfg: Dict[str, Any]) -> float:
+        min_ch, max_ch = bounds(cfg)
+        if channel_count < min_ch:
+            return min_ch - channel_count
+        return channel_count - max_ch
+
+    return min(channel_count_bins, key=lambda name: distance(channel_count_bins[name]))
+
+
+def resolve_bad_channel_settings(
+    channel_count: int,
+    preset: str = "auto",
+    channel_count_bins: Optional[Dict[str, Dict[str, Any]]] = None,
+    config_overrides: Optional[Dict[str, Any]] = None,
+    explicit_overrides: Optional[Dict[str, Any]] = None,
+) -> ResolvedBadChannelSettings:
+    """Resolve preset + channel-count-bin + override layers into one threshold set.
+
+    Priority (highest wins): ``explicit_overrides`` (direct method call
+    arguments) > ``config_overrides`` (flat keys under the task's
+    ``bad_channel_detection.value``) > the selected preset/density bin >
+    :data:`BASE_DEFAULTS`.
+    """
+
+    normalized_preset = (preset or "auto").strip().lower()
+    if normalized_preset not in VALID_PRESETS:
+        raise ValueError(
+            f"Unknown bad_channel_detection preset {preset!r}; expected one of "
+            f"{sorted(VALID_PRESETS)}"
+        )
+
+    bins = channel_count_bins if channel_count_bins is not None else DEFAULT_CHANNEL_COUNT_BINS
+
+    resolved: Dict[str, Any] = dict(BASE_DEFAULTS)
+    density_bin: Optional[str] = None
+
+    if normalized_preset == "legacy":
+        resolved.update(LEGACY_PRESET)
+    else:
+        if normalized_preset == "auto":
+            density_bin = select_density_bin(channel_count, bins)
+        else:
+            if normalized_preset not in bins:
+                raise ValueError(
+                    f"Preset {normalized_preset!r} has no matching entry in "
+                    f"channel_count_bins (available: {sorted(bins)})"
+                )
+            density_bin = normalized_preset
+
+        bin_settings = {
+            key: value
+            for key, value in bins[density_bin].items()
+            if key not in ("min_channels", "max_channels")
+        }
+        resolved.update(bin_settings)
+
+    for source in (config_overrides, explicit_overrides):
+        if not source:
+            continue
+        resolved.update(
+            {key: value for key, value in source.items() if key in _OVERRIDABLE_KEYS and value is not None}
+        )
+
+    return ResolvedBadChannelSettings(
+        preset=normalized_preset,
+        density_bin=density_bin,
+        channel_count=channel_count,
+        correlation_thresh=float(resolved["correlation_thresh"]),
+        deviation_thresh=float(resolved["deviation_thresh"]),
+        ransac_sample_prop=float(resolved["ransac_sample_prop"]),
+        ransac_corr_thresh=float(resolved["ransac_corr_thresh"]),
+        ransac_frac_bad=float(resolved["ransac_frac_bad"]),
+        ransac_channel_wise=bool(resolved["ransac_channel_wise"]),
+        ransac_enabled=bool(resolved["ransac_enabled"]),
+        cleaning_method=resolved["cleaning_method"],
+        max_bad_fraction=float(resolved["max_bad_fraction"]),
+    )

--- a/src/autoclean/utils/bad_channel_presets.py
+++ b/src/autoclean/utils/bad_channel_presets.py
@@ -100,7 +100,9 @@ class ResolvedBadChannelSettings:
             "deviation_thresh": self.deviation_thresh,
             "ransac_sample_prop": self.ransac_sample_prop,
             # A corr_thresh of 0 disables RANSAC in detect_bad_channels().
-            "ransac_corr_thresh": self.ransac_corr_thresh if self.ransac_enabled else 0.0,
+            "ransac_corr_thresh": (
+                self.ransac_corr_thresh if self.ransac_enabled else 0.0
+            ),
             "ransac_frac_bad": self.ransac_frac_bad,
             "ransac_channel_wise": self.ransac_channel_wise,
         }
@@ -135,7 +137,9 @@ def merge_channel_count_bins(
     return merged
 
 
-def select_density_bin(channel_count: int, channel_count_bins: Dict[str, Dict[str, Any]]) -> str:
+def select_density_bin(
+    channel_count: int, channel_count_bins: Dict[str, Dict[str, Any]]
+) -> str:
     """Pick the bin whose [min_channels, max_channels] range contains ``channel_count``.
 
     Falls back to the closest bin by boundary distance if no bin's range
@@ -192,7 +196,11 @@ def resolve_bad_channel_settings(
             f"{sorted(VALID_PRESETS)}"
         )
 
-    bins = channel_count_bins if channel_count_bins is not None else DEFAULT_CHANNEL_COUNT_BINS
+    bins = (
+        channel_count_bins
+        if channel_count_bins is not None
+        else DEFAULT_CHANNEL_COUNT_BINS
+    )
 
     resolved: Dict[str, Any] = dict(BASE_DEFAULTS)
     density_bin: Optional[str] = None
@@ -221,7 +229,11 @@ def resolve_bad_channel_settings(
         if not source:
             continue
         resolved.update(
-            {key: value for key, value in source.items() if key in _OVERRIDABLE_KEYS and value is not None}
+            {
+                key: value
+                for key, value in source.items()
+                if key in _OVERRIDABLE_KEYS and value is not None
+            }
         )
 
     return ResolvedBadChannelSettings(

--- a/tests/unit/mixins/test_channels.py
+++ b/tests/unit/mixins/test_channels.py
@@ -1,6 +1,5 @@
 """Unit tests for ChannelsMixin."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import mne
@@ -16,9 +15,7 @@ except ImportError:
     TASK_AVAILABLE = False
 
 
-pytestmark = pytest.mark.skipif(
-    not TASK_AVAILABLE, reason="Task module not available"
-)
+pytestmark = pytest.mark.skipif(not TASK_AVAILABLE, reason="Task module not available")
 
 
 class _ChannelTask(Task):
@@ -54,10 +51,11 @@ class TestDropChannels:
         channels_to_drop = [task.raw.ch_names[0], task.raw.ch_names[1]]
         original_count = len(task.raw.ch_names)
 
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_save_raw_result"
-        ), patch.object(task, "_update_instance_data"), patch.object(
-            task, "_track_channel_removal"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
         ):
             result = task.drop_channels(data=task.raw, channels=channels_to_drop)
 
@@ -71,10 +69,11 @@ class TestDropChannels:
         task.settings = settings
         # Passing channels=[] explicitly: config path is not used; empty list passed
         original_count = len(task.raw.ch_names)
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_save_raw_result"
-        ), patch.object(task, "_update_instance_data"), patch.object(
-            task, "_track_channel_removal"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
         ):
             result = task.drop_channels(data=task.raw, channels=[])
         # MNE silently accepts empty drop list
@@ -86,10 +85,11 @@ class TestDropChannels:
 
     def test_returned_raw_does_not_include_dropped_channels(self, task):
         ch_to_drop = task.raw.ch_names[5]
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_save_raw_result"
-        ), patch.object(task, "_update_instance_data"), patch.object(
-            task, "_track_channel_removal"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
         ):
             result = task.drop_channels(data=task.raw, channels=[ch_to_drop])
         assert ch_to_drop not in result.ch_names
@@ -104,10 +104,11 @@ class TestSetChannelTypes:
     def test_updates_channel_type_in_raw_info(self, task):
         """Mapping a channel to 'eog' should change its type in info."""
         ch_name = task.raw.ch_names[0]
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_save_raw_result"
-        ), patch.object(task, "_update_instance_data"), patch.object(
-            task, "_track_channel_removal"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
         ):
             result = task.set_channel_types(
                 data=task.raw, ch_types_dict={ch_name: "eog"}
@@ -121,10 +122,11 @@ class TestSetChannelTypes:
         ch_to_remove = task.raw.ch_names[0]
         original_count = len(task.raw.ch_names)
 
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_save_raw_result"
-        ), patch.object(task, "_update_instance_data"), patch.object(
-            task, "_track_channel_removal"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
         ):
             result = task.set_channel_types(
                 data=task.raw,
@@ -138,10 +140,11 @@ class TestSetChannelTypes:
     def test_drop_mode_silently_skips_missing_channels(self, task):
         """Channels not present in data should be silently ignored when drop=True."""
         original_count = len(task.raw.ch_names)
-        with patch.object(task, "_update_metadata"), patch.object(
-            task, "_save_raw_result"
-        ), patch.object(task, "_update_instance_data"), patch.object(
-            task, "_track_channel_removal"
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
         ):
             result = task.set_channel_types(
                 data=task.raw,
@@ -309,7 +312,9 @@ class TestCleanBadChannelsPresets:
                 detect_mock,
             ),
         ):
-            task.clean_bad_channels(data=task.raw, preset="legacy", cleaning_method=None)
+            task.clean_bad_channels(
+                data=task.raw, preset="legacy", cleaning_method=None
+            )
 
         call_kwargs = detect_mock.call_args.kwargs
         assert call_kwargs["correlation_thresh"] == 0.35
@@ -414,7 +419,9 @@ class TestCleanBadChannelsPresets:
                     },
                 ),
             ):
-                task.clean_bad_channels(data=task.raw, preset=preset, cleaning_method=None)
+                task.clean_bad_channels(
+                    data=task.raw, preset=preset, cleaning_method=None
+                )
             return task.flagged
 
         assert _run("auto") is True

--- a/tests/unit/mixins/test_channels.py
+++ b/tests/unit/mixins/test_channels.py
@@ -257,6 +257,171 @@ class TestCleanBadChannels:
 
 
 # ---------------------------------------------------------------------------
+# clean_bad_channels (montage-aware presets)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanBadChannelsPresets:
+    """The fixture's synthetic raw has 32 channels -> low_density bin."""
+
+    def test_auto_is_default_and_disables_ransac_for_low_density(self, task):
+        detect_mock = MagicMock(
+            return_value={
+                "correlation": [],
+                "deviation": [],
+                "ransac": [],
+                "combined": [],
+            }
+        )
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
+            patch(
+                "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+                detect_mock,
+            ),
+        ):
+            task.clean_bad_channels(data=task.raw, cleaning_method=None)
+
+        call_kwargs = detect_mock.call_args.kwargs
+        assert call_kwargs["correlation_thresh"] == 0.20
+        assert call_kwargs["deviation_thresh"] == 4.0
+        assert call_kwargs["ransac_corr_thresh"] == 0.0  # RANSAC disabled
+
+    def test_legacy_preset_reproduces_historical_thresholds(self, task):
+        detect_mock = MagicMock(
+            return_value={
+                "correlation": [],
+                "deviation": [],
+                "ransac": [],
+                "combined": [],
+            }
+        )
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
+            patch(
+                "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+                detect_mock,
+            ),
+        ):
+            task.clean_bad_channels(data=task.raw, preset="legacy", cleaning_method=None)
+
+        call_kwargs = detect_mock.call_args.kwargs
+        assert call_kwargs["correlation_thresh"] == 0.35
+        assert call_kwargs["deviation_thresh"] == 2.5
+        assert call_kwargs["ransac_corr_thresh"] == 0.65
+
+    def test_explicit_kwarg_overrides_preset(self, task):
+        detect_mock = MagicMock(
+            return_value={
+                "correlation": [],
+                "deviation": [],
+                "ransac": [],
+                "combined": [],
+            }
+        )
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
+            patch(
+                "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+                detect_mock,
+            ),
+        ):
+            task.clean_bad_channels(
+                data=task.raw, correlation_thresh=0.42, cleaning_method=None
+            )
+
+        assert detect_mock.call_args.kwargs["correlation_thresh"] == 0.42
+
+    def test_config_preset_used_when_no_explicit_kwarg(self, task):
+        task.settings = {
+            "bad_channel_detection": {"enabled": True, "value": {"preset": "legacy"}}
+        }
+        detect_mock = MagicMock(
+            return_value={
+                "correlation": [],
+                "deviation": [],
+                "ransac": [],
+                "combined": [],
+            }
+        )
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
+            patch(
+                "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+                detect_mock,
+            ),
+        ):
+            task.clean_bad_channels(data=task.raw, cleaning_method=None)
+
+        assert detect_mock.call_args.kwargs["correlation_thresh"] == 0.35
+
+    def test_metadata_records_preset_and_density_bin(self, task):
+        with (
+            patch.object(task, "_update_metadata") as mock_meta,
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal"),
+            patch(
+                "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+                return_value={
+                    "correlation": [],
+                    "deviation": [],
+                    "ransac": [],
+                    "combined": [],
+                },
+            ),
+        ):
+            task.clean_bad_channels(data=task.raw, cleaning_method=None)
+
+        metadata = mock_meta.call_args.args[1]
+        assert metadata["preset"] == "auto"
+        assert metadata["density_bin"] == "low_density"
+        assert metadata["eeg_channel_count"] == 32
+        assert "resolved_thresholds" in metadata
+        assert metadata["resolved_thresholds"]["ransac_enabled"] is False
+
+    def test_bad_fraction_warning_uses_preset_max_bad_fraction(self, task):
+        """4/32 = 12.5%: exceeds low_density's 10% cap but not legacy's 15%."""
+        four_bad = task.raw.ch_names[:4]
+
+        def _run(preset):
+            task.flagged = False
+            task.flagged_reasons = []
+            with (
+                patch.object(task, "_update_metadata"),
+                patch.object(task, "_save_raw_result"),
+                patch.object(task, "_update_instance_data"),
+                patch.object(task, "_track_channel_removal"),
+                patch(
+                    "autoclean.mixins.signal_processing.channels.detect_bad_channels",
+                    return_value={
+                        "correlation": list(four_bad),
+                        "deviation": [],
+                        "ransac": [],
+                        "combined": list(four_bad),
+                    },
+                ),
+            ):
+                task.clean_bad_channels(data=task.raw, preset=preset, cleaning_method=None)
+            return task.flagged
+
+        assert _run("auto") is True
+        assert _run("legacy") is False
+
+
+# ---------------------------------------------------------------------------
 # set_channel_types (additional)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/utils/test_bad_channel_presets.py
+++ b/tests/unit/utils/test_bad_channel_presets.py
@@ -140,7 +140,11 @@ class TestResolveBadChannelSettings:
 
     def test_custom_channel_count_bins_are_honored(self):
         custom_bins = {
-            "tiny": {"max_channels": 8, "correlation_thresh": 0.1, "ransac_enabled": False},
+            "tiny": {
+                "max_channels": 8,
+                "correlation_thresh": 0.1,
+                "ransac_enabled": False,
+            },
             "big": {"min_channels": 9, "correlation_thresh": 0.4},
         }
         resolved = resolve_bad_channel_settings(

--- a/tests/unit/utils/test_bad_channel_presets.py
+++ b/tests/unit/utils/test_bad_channel_presets.py
@@ -1,0 +1,169 @@
+"""Unit tests for montage/channel-count-aware bad-channel detection presets."""
+
+import pytest
+
+from autoclean.utils.bad_channel_presets import (
+    BASE_DEFAULTS,
+    DEFAULT_CHANNEL_COUNT_BINS,
+    LEGACY_PRESET,
+    merge_channel_count_bins,
+    resolve_bad_channel_settings,
+    select_density_bin,
+)
+
+
+class TestSelectDensityBin:
+    def test_boundary_channel_counts_map_to_expected_bins(self):
+        assert select_density_bin(19, DEFAULT_CHANNEL_COUNT_BINS) == "low_density"
+        assert select_density_bin(32, DEFAULT_CHANNEL_COUNT_BINS) == "low_density"
+        assert select_density_bin(33, DEFAULT_CHANNEL_COUNT_BINS) == "mid_density"
+        assert select_density_bin(64, DEFAULT_CHANNEL_COUNT_BINS) == "mid_density"
+        assert select_density_bin(65, DEFAULT_CHANNEL_COUNT_BINS) == "high_density"
+        assert select_density_bin(128, DEFAULT_CHANNEL_COUNT_BINS) == "high_density"
+
+    def test_falls_back_to_nearest_bin_on_gap(self):
+        bins = {
+            "low": {"max_channels": 10},
+            "high": {"min_channels": 20},
+        }
+        # 17 is in the gap between the two bins; 20 is closer than 10.
+        assert select_density_bin(17, bins) == "high"
+
+    def test_raises_on_empty_bins(self):
+        with pytest.raises(ValueError):
+            select_density_bin(32, {})
+
+
+class TestMergeChannelCountBins:
+    def test_none_returns_defaults(self):
+        merged = merge_channel_count_bins(None)
+        assert merged == DEFAULT_CHANNEL_COUNT_BINS
+
+    def test_partial_override_preserves_other_fields(self):
+        merged = merge_channel_count_bins({"low_density": {"correlation_thresh": 0.15}})
+        assert merged["low_density"]["correlation_thresh"] == 0.15
+        # Untouched fields still present from the default bin.
+        assert merged["low_density"]["max_channels"] == 32
+        assert merged["low_density"]["ransac_enabled"] is False
+
+    def test_custom_bin_name_is_added(self):
+        merged = merge_channel_count_bins(
+            {"ultra_low": {"max_channels": 16, "correlation_thresh": 0.1}}
+        )
+        assert "ultra_low" in merged
+        assert "low_density" in merged  # defaults untouched
+
+    def test_does_not_mutate_module_defaults(self):
+        merge_channel_count_bins({"low_density": {"correlation_thresh": 0.01}})
+        assert DEFAULT_CHANNEL_COUNT_BINS["low_density"]["correlation_thresh"] == 0.20
+
+
+class TestResolveBadChannelSettings:
+    def test_legacy_preset_matches_historical_defaults(self):
+        resolved = resolve_bad_channel_settings(channel_count=32, preset="legacy")
+        assert resolved.density_bin is None
+        assert resolved.correlation_thresh == LEGACY_PRESET["correlation_thresh"]
+        assert resolved.deviation_thresh == LEGACY_PRESET["deviation_thresh"]
+        assert resolved.ransac_corr_thresh == LEGACY_PRESET["ransac_corr_thresh"]
+        assert resolved.ransac_enabled is True
+        assert resolved.max_bad_fraction == LEGACY_PRESET["max_bad_fraction"]
+
+    def test_auto_high_density_matches_legacy_thresholds(self):
+        """High-density auto resolution should not change existing behavior."""
+        resolved = resolve_bad_channel_settings(channel_count=128, preset="auto")
+        assert resolved.density_bin == "high_density"
+        assert resolved.correlation_thresh == BASE_DEFAULTS["correlation_thresh"]
+        assert resolved.deviation_thresh == BASE_DEFAULTS["deviation_thresh"]
+        assert resolved.ransac_corr_thresh == BASE_DEFAULTS["ransac_corr_thresh"]
+        assert resolved.ransac_enabled is True
+
+    def test_auto_low_density_disables_ransac_and_is_more_conservative(self):
+        resolved = resolve_bad_channel_settings(channel_count=19, preset="auto")
+        assert resolved.density_bin == "low_density"
+        assert resolved.ransac_enabled is False
+        assert resolved.detector_options()["ransac_corr_thresh"] == 0.0
+        assert resolved.correlation_thresh == 0.20
+        assert resolved.deviation_thresh == 4.0
+        assert resolved.max_bad_fraction == 0.10
+
+    def test_auto_mid_density(self):
+        resolved = resolve_bad_channel_settings(channel_count=40, preset="auto")
+        assert resolved.density_bin == "mid_density"
+        assert resolved.correlation_thresh == 0.30
+        assert resolved.deviation_thresh == 3.0
+        assert resolved.max_bad_fraction == 0.15
+        assert resolved.ransac_enabled is True
+
+    def test_explicit_density_preset_ignores_channel_count(self):
+        resolved = resolve_bad_channel_settings(channel_count=128, preset="low_density")
+        assert resolved.density_bin == "low_density"
+        assert resolved.ransac_enabled is False
+
+    def test_unknown_preset_raises(self):
+        with pytest.raises(ValueError):
+            resolve_bad_channel_settings(channel_count=32, preset="not_a_preset")
+
+    def test_config_overrides_apply_over_preset(self):
+        resolved = resolve_bad_channel_settings(
+            channel_count=19,
+            preset="auto",
+            config_overrides={"correlation_thresh": 0.5},
+        )
+        assert resolved.correlation_thresh == 0.5
+        assert resolved.density_bin == "low_density"
+
+    def test_explicit_overrides_win_over_config_overrides(self):
+        resolved = resolve_bad_channel_settings(
+            channel_count=19,
+            preset="auto",
+            config_overrides={"correlation_thresh": 0.5},
+            explicit_overrides={"correlation_thresh": 0.9},
+        )
+        assert resolved.correlation_thresh == 0.9
+
+    def test_none_values_in_overrides_do_not_clobber_resolved_value(self):
+        resolved = resolve_bad_channel_settings(
+            channel_count=19,
+            preset="auto",
+            explicit_overrides={"correlation_thresh": None},
+        )
+        assert resolved.correlation_thresh == 0.20
+
+    def test_ransac_enabled_explicit_override_forces_disable(self):
+        resolved = resolve_bad_channel_settings(
+            channel_count=128,
+            preset="auto",
+            explicit_overrides={"ransac_enabled": False},
+        )
+        assert resolved.ransac_enabled is False
+        assert resolved.detector_options()["ransac_corr_thresh"] == 0.0
+
+    def test_custom_channel_count_bins_are_honored(self):
+        custom_bins = {
+            "tiny": {"max_channels": 8, "correlation_thresh": 0.1, "ransac_enabled": False},
+            "big": {"min_channels": 9, "correlation_thresh": 0.4},
+        }
+        resolved = resolve_bad_channel_settings(
+            channel_count=5, preset="auto", channel_count_bins=custom_bins
+        )
+        assert resolved.density_bin == "tiny"
+        assert resolved.correlation_thresh == 0.1
+
+    def test_detector_options_keys_match_detect_bad_channels_kwargs(self):
+        resolved = resolve_bad_channel_settings(channel_count=64, preset="auto")
+        options = resolved.detector_options()
+        assert set(options) == {
+            "correlation_thresh",
+            "deviation_thresh",
+            "ransac_sample_prop",
+            "ransac_corr_thresh",
+            "ransac_frac_bad",
+            "ransac_channel_wise",
+        }
+
+    def test_as_metadata_is_json_serializable_shape(self):
+        resolved = resolve_bad_channel_settings(channel_count=19, preset="auto")
+        metadata = resolved.as_metadata()
+        assert metadata["preset"] == "auto"
+        assert metadata["density_bin"] == "low_density"
+        assert metadata["channel_count"] == 19


### PR DESCRIPTION
## Summary
- Add a preset system (`auto`/`low_density`/`mid_density`/`high_density`/`legacy`) that resolves bad-channel detection thresholds (correlation, deviation, RANSAC, max bad fraction) from EEG channel count, so low-density montages (<=32ch) get more conservative defaults and RANSAC disabled by default.
- `preset="auto"` is the new default but resolves to numerically identical thresholds as the old hardcoded values for >=65-channel montages, so existing high-density workflows (all shipped built-in tasks use 128/129-channel nets) are unaffected. `preset="legacy"` reproduces the exact historical fixed defaults for reproducibility.
- Resolved preset, density bin, and thresholds are always recorded in `step_clean_bad_channels` metadata, and the bad-channel-fraction flagging warning now uses the preset's `max_bad_fraction` instead of a fixed 15%.
- Threshold resolution priority: explicit `clean_bad_channels()` args > `bad_channel_detection` task config > selected preset/channel-count bin > historical defaults.
- Added a `bad_channel_detection` config block with aggressiveness comments to the custom task template (`.py`/`.jinja`, kept in sync).

Closes #223

## Test plan
- [x] `pytest tests/unit/utils/test_bad_channel_presets.py` — 20 new preset-resolution unit tests
- [x] `pytest tests/unit/mixins/test_channels.py` — existing + 8 new integration tests on `clean_bad_channels` (auto default, legacy reproduction, override precedence, RANSAC disable, metadata, preset-aware flagging)
- [x] `pytest tests/unit/templates/test_custom_task_template.py` — template sync check
- [x] Full `tests/unit` suite run — no regressions (8 pre-existing, unrelated Windows-path failures)