### PR TITLE
feat: detect likely prior eeg preprocessing

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -14,6 +14,7 @@ Start here if you're new to EEG processing or AutoClean:
 
    command_line_basics
    first_time_processing
+   prior_preprocessing_detection
    understanding_results
 
 Command references:

--- a/docs/tutorials/prior_preprocessing_detection.rst
+++ b/docs/tutorials/prior_preprocessing_detection.rst
@@ -18,3 +18,5 @@ review. It does not stop the import or preprocessing run.
 
 Detection is conservative: documented provenance has priority, while signal
 inspection produces confidence labels rather than proof of prior processing.
+When enabled, signal inference reads and processes the full signal and may use
+substantial memory and CPU time for long recordings.

--- a/docs/tutorials/prior_preprocessing_detection.rst
+++ b/docs/tutorials/prior_preprocessing_detection.rst
@@ -20,3 +20,7 @@ Detection is conservative: documented provenance has priority, while signal
 inspection produces confidence labels rather than proof of prior processing.
 When enabled, signal inference reads and processes the full signal and may use
 substantial memory and CPU time for long recordings.
+
+Reference reporting is similarly conservative. An MNE flag indicating that a
+custom reference was applied does not identify the reference label; without a
+documented label, the report truthfully records the reference as unavailable.

--- a/docs/tutorials/prior_preprocessing_detection.rst
+++ b/docs/tutorials/prior_preprocessing_detection.rst
@@ -1,0 +1,20 @@
+Prior Preprocessing Detection
+=============================
+
+AutoClean can inspect imported EEG data and available EEGLAB provenance for
+signs of earlier filtering, referencing, epoching, ICA, and related processing.
+The check is opt-in. Add this top-level configuration alongside your existing
+task settings:
+
+.. code-block:: yaml
+
+   prior_preprocessing_detection:
+     enabled: true
+     strict: false
+
+``enabled`` writes per-file JSON and Markdown reports plus a dataset summary.
+``strict`` labels detected conflicts in ``strict_violations`` for downstream
+review. It does not stop the import or preprocessing run.
+
+Detection is conservative: documented provenance has priority, while signal
+inspection produces confidence labels rather than proof of prior processing.

--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -431,6 +431,10 @@ def _build_task_settings_schema() -> Schema:
             Optional("incremental_cleanup"): {
                 Optional("enabled"): bool,
             },
+            Optional("prior_preprocessing_detection"): {
+                "enabled": bool,
+                Optional("strict"): bool,
+            },
             Optional("dataset_name"): Or(str, None),
             Optional("automation_mode"): Or(bool, str, None),
             # Basic preprocessing
@@ -679,6 +683,10 @@ def export_task_schema_layout() -> dict:
                 "seed": "int|null",
             },
             "move_flagged_files": "bool|null",
+            "prior_preprocessing_detection": {
+                "enabled": "bool",
+                "strict": "bool",
+            },
             "resample_step": _step_value_num_descriptor(),
             "filtering": _filtering_descriptor(),
             "drop_outerlayer": {"enabled": "bool", "value": "list|None"},

--- a/src/autoclean/core/task.py
+++ b/src/autoclean/core/task.py
@@ -134,6 +134,14 @@ class Task(ABC, *DISCOVERED_MIXINS):
                 "incremental_cleanup", self.settings["incremental_cleanup"]
             )
 
+        # Import-time prior-processing detection is configured with the Python
+        # task settings, but import_eeg receives only the runtime config.
+        if self.settings and "prior_preprocessing_detection" in self.settings:
+            config.setdefault(
+                "prior_preprocessing_detection",
+                self.settings["prior_preprocessing_detection"],
+            )
+
         # Configuration must be validated first as other initializations depend on it
         self.config = self.validate_config(config)
 

--- a/src/autoclean/io/eeglab_provenance.py
+++ b/src/autoclean/io/eeglab_provenance.py
@@ -206,17 +206,25 @@ def _mne_provenance_view(eeg_data: Any) -> dict[str, Any]:
         {"labels": name, "type": kind}
         for name, kind in zip(eeg_data.ch_names, eeg_data.get_channel_types())
     ]
-    annotations = getattr(eeg_data, "annotations", None)
-    if annotations is not None:
-        events = [{"type": description} for description in annotations.description]
-    else:
+    epoch_events = getattr(eeg_data, "events", None)
+    if epoch_events is not None and len(epoch_events):
         code_to_name = {
             code: name for name, code in getattr(eeg_data, "event_id", {}).items()
         }
         events = [
-            {"type": code_to_name.get(int(event[2]), str(int(event[2])))}
-            for event in getattr(eeg_data, "events", [])
+            {
+                "type": code_to_name.get(int(event[2]), str(int(event[2]))),
+                "code": str(int(event[2])),
+            }
+            for event in epoch_events
         ]
+    else:
+        annotations = getattr(eeg_data, "annotations", None)
+        events = (
+            [{"type": description} for description in annotations.description]
+            if annotations is not None and len(annotations)
+            else []
+        )
 
     times = eeg_data.times
     is_epochs = hasattr(eeg_data, "events")
@@ -228,7 +236,14 @@ def _mne_provenance_view(eeg_data: Any) -> dict[str, Any]:
         "pnts": len(times),
         "xmin": times[0] if len(times) else UNAVAILABLE,
         "xmax": times[-1] if len(times) else UNAVAILABLE,
-        "ref": "average" if info.get("custom_ref_applied") else UNAVAILABLE,
+        "ref": next(
+            (
+                value
+                for value in (info.get("reference"), info.get("ref"))
+                if isinstance(value, str) and value.strip()
+            ),
+            UNAVAILABLE,
+        ),
         "chanlocs": chanlocs,
         "event": events,
     }

--- a/src/autoclean/io/import_.py
+++ b/src/autoclean/io/import_.py
@@ -463,6 +463,9 @@ def import_eeg(
 
         # Get plugin metadata
         plugin_metadata = plugin.get_metadata()
+        provenance_summary = resolve_prior_preprocessing_provenance(
+            plugin_metadata, autoclean_dict
+        )
 
         # Prepare metadata
         metadata = {
@@ -528,9 +531,6 @@ def import_eeg(
             prior_preprocessing = None
             try:
                 task_config = _resolve_task_settings(autoclean_dict)
-                provenance_summary = resolve_prior_preprocessing_provenance(
-                    metadata["import_eeg"], autoclean_dict
-                )
                 prior_preprocessing = detect_prior_preprocessing(
                     eeg_data,
                     import_metadata=metadata["import_eeg"],

--- a/src/autoclean/io/import_.py
+++ b/src/autoclean/io/import_.py
@@ -524,7 +524,7 @@ def import_eeg(
         prior_config = autoclean_dict.get("prior_preprocessing_detection", {})
         if not isinstance(prior_config, dict):
             prior_config = {"enabled": bool(prior_config)}
-        if prior_config.get("enabled", True):
+        if prior_config.get("enabled", False):
             prior_preprocessing = None
             try:
                 task_config = _resolve_task_settings(autoclean_dict)

--- a/src/autoclean/io/import_.py
+++ b/src/autoclean/io/import_.py
@@ -489,11 +489,8 @@ def import_eeg(
                     f"EEGLAB provenance summary unavailable: {provenance_error}",
                 )
 
-        provenance_metadata = dict(plugin_metadata)
-        if eeglab_provenance is not None:
-            provenance_metadata["eeglab_provenance"] = eeglab_provenance
         provenance_summary = resolve_prior_preprocessing_provenance(
-            provenance_metadata, autoclean_dict
+            plugin_metadata, autoclean_dict, eeglab_provenance
         )
 
         # Prepare metadata

--- a/src/autoclean/io/import_.py
+++ b/src/autoclean/io/import_.py
@@ -20,6 +20,12 @@ import pandas as pd
 
 from autoclean.utils.database import manage_database_conditionally
 from autoclean.utils.logging import message
+from autoclean.utils.prior_preprocessing import (
+    detect_prior_preprocessing,
+    resolve_prior_preprocessing_dir,
+    resolve_prior_preprocessing_provenance,
+    write_prior_preprocessing_artifacts,
+)
 
 # Optional import for HBCD processor
 try:
@@ -515,6 +521,55 @@ def import_eeg(
                 }
             )
 
+        prior_config = autoclean_dict.get("prior_preprocessing_detection", {})
+        if not isinstance(prior_config, dict):
+            prior_config = {"enabled": bool(prior_config)}
+        if prior_config.get("enabled", True):
+            prior_preprocessing = None
+            try:
+                task_config = _resolve_task_settings(autoclean_dict)
+                provenance_summary = resolve_prior_preprocessing_provenance(
+                    metadata["import_eeg"], autoclean_dict
+                )
+                prior_preprocessing = detect_prior_preprocessing(
+                    eeg_data,
+                    import_metadata=metadata["import_eeg"],
+                    provenance_summary=provenance_summary,
+                    task_config=task_config,
+                    strict=bool(prior_config.get("strict", False)),
+                )
+                artifact_paths = write_prior_preprocessing_artifacts(
+                    prior_preprocessing,
+                    resolve_prior_preprocessing_dir(autoclean_dict),
+                    unprocessed_file.stem,
+                )
+                metadata["import_eeg"]["prior_preprocessing"] = {
+                    "available": True,
+                    "schema_version": prior_preprocessing.get("schema_version"),
+                    "artifact_paths": artifact_paths,
+                    "summary_row": prior_preprocessing.get("summary_row", {}),
+                    "warnings": prior_preprocessing.get("warnings", []),
+                    "strict_violations": prior_preprocessing.get(
+                        "strict_violations", []
+                    ),
+                    "findings": prior_preprocessing.get("findings", {}),
+                }
+                for warning in prior_preprocessing.get("warnings", []):
+                    message("warning", f"Prior preprocessing check: {warning}")
+                message(
+                    "info",
+                    f"Prior preprocessing summary written to {artifact_paths['json']}",
+                )
+            except Exception as prior_error:  # pylint: disable=broad-except
+                metadata["import_eeg"]["prior_preprocessing"] = {
+                    "available": False,
+                    "error": str(prior_error),
+                }
+                message(
+                    "warning",
+                    f"Prior preprocessing summary unavailable: {prior_error}",
+                )
+
         # Update database
         manage_database_conditionally(
             operation="update",
@@ -530,6 +585,24 @@ def import_eeg(
     except Exception as e:
         message("error", f"Failed to import EEG data: {str(e)}")
         raise
+
+
+def _resolve_task_settings(autoclean_dict: dict) -> dict:
+    """Return task settings for warning comparisons when available."""
+
+    if isinstance(autoclean_dict.get("settings"), dict):
+        return autoclean_dict["settings"]
+
+    task_name = autoclean_dict.get("task")
+    tasks = autoclean_dict.get("tasks")
+    if isinstance(task_name, str) and isinstance(tasks, dict):
+        task_entry = tasks.get(task_name) or tasks.get(task_name.lower())
+        if isinstance(task_entry, dict) and isinstance(
+            task_entry.get("settings"), dict
+        ):
+            return task_entry["settings"]
+
+    return autoclean_dict
 
 
 # Event processor plugin system

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -875,7 +875,7 @@ def _epoch_window(
 
 
 def _reference(info: Mapping[str, Any]) -> Any:
-    for key in ("reference", "ref", "description"):
+    for key in ("reference", "ref"):
         value = info.get(key, UNAVAILABLE)
         if isinstance(value, str) and value.strip() not in {UNAVAILABLE, UNKNOWN}:
             return value

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -526,25 +526,30 @@ def _infer_from_signal(eeg_data: Any | None) -> dict[str, Any]:
 
     info = getattr(eeg_data, "info", {}) or {}
     ch_names = list(getattr(eeg_data, "ch_names", []) or [])
-    data = _get_data(eeg_data)
+    channel_kinds = _channel_type_list(eeg_data, ch_names)
+    eeg_picks = [index for index, kind in enumerate(channel_kinds) if kind == "eeg"]
+    data = _get_data(eeg_data, picks=eeg_picks if ch_names else None)
     times = np.asarray(getattr(eeg_data, "times", []), dtype=float)
     sfreq = _to_float(info.get("sfreq"))
-    channel_types = _channel_types(eeg_data, ch_names)
+    channel_types = dict(Counter(channel_kinds))
+    eeg_channel_count = (
+        len(eeg_picks) if ch_names else (int(data.shape[-2]) if data is not None else 0)
+    )
     freqs, spectrum = _mean_spectrum(data, sfreq)
     inference: dict[str, Any] = {
         "data_shape": list(data.shape) if data is not None else UNAVAILABLE,
         "eog_ecg_misc_channel_presence": _infer_aux_channels(channel_types, ch_names),
-        "channel_count_suggests_dropping": _infer_channel_count_drop(len(ch_names)),
+        "channel_count_suggests_dropping": _infer_channel_count_drop(eeg_channel_count),
         "baseline_applied": _infer_baseline(data, times),
         "highpass_filter": _infer_highpass(freqs, spectrum),
         "lowpass_filter": _infer_lowpass(freqs, spectrum, sfreq),
         "ica_pruned": _possible("ICA pruning cannot be confirmed from signal alone"),
         "ica_capable": _finding(
-            CONFIDENCE_POSSIBLE if len(ch_names) >= 2 else CONFIDENCE_UNKNOWN,
-            len(ch_names) >= 2,
+            CONFIDENCE_POSSIBLE if eeg_channel_count >= 2 else CONFIDENCE_UNKNOWN,
+            eeg_channel_count >= 2,
             (
-                f"{len(ch_names)} channels available for ICA"
-                if ch_names
+                f"{eeg_channel_count} EEG channels available for ICA"
+                if eeg_channel_count
                 else "channel names unavailable"
             ),
         ),
@@ -824,13 +829,36 @@ def _safe_mean(values: np.ndarray) -> float | None:
     return mean if np.isfinite(mean) else None
 
 
-def _get_data(eeg_data: Any) -> np.ndarray | None:
+def _get_data(eeg_data: Any, picks: Sequence[int] | None = None) -> np.ndarray | None:
     if eeg_data is None or not hasattr(eeg_data, "get_data"):
         return None
+    requested_picks = list(picks) if picks is not None else None
+    if requested_picks == []:
+        return None
     try:
-        data = eeg_data.get_data()
+        data = (
+            eeg_data.get_data(picks=requested_picks)
+            if requested_picks is not None
+            else eeg_data.get_data()
+        )
     except TypeError:
-        data = eeg_data.get_data(copy=False)
+        # Lightweight adapters may not accept ``picks``. Read once and slice
+        # their channel axis locally while retaining compatibility with older
+        # MNE ``copy`` signatures.
+        try:
+            data = eeg_data.get_data(copy=False)
+        except TypeError:
+            try:
+                data = eeg_data.get_data()
+            except Exception:  # pragma: no cover - defensive
+                return None
+        except Exception:  # pragma: no cover - defensive
+            return None
+        if requested_picks is not None:
+            try:
+                data = np.take(data, requested_picks, axis=-2)
+            except Exception:  # pragma: no cover - defensive
+                return None
     except Exception:  # pragma: no cover - defensive for third-party objects
         return None
     return np.asarray(data, dtype=float)
@@ -846,15 +874,19 @@ def _is_epochs_like(eeg_data: Any | None, import_metadata: Mapping[str, Any]) ->
     )
 
 
-def _channel_types(eeg_data: Any | None, ch_names: Sequence[str]) -> dict[str, int]:
+def _channel_type_list(eeg_data: Any | None, ch_names: Sequence[str]) -> list[str]:
     if eeg_data is not None and hasattr(eeg_data, "get_channel_types"):
         try:
-            return dict(
-                Counter(str(kind).lower() for kind in eeg_data.get_channel_types())
-            )
+            kinds = [str(kind).lower() for kind in eeg_data.get_channel_types()]
+            if len(kinds) == len(ch_names):
+                return kinds
         except Exception:  # pragma: no cover - defensive
             pass
-    return dict(Counter(_type_from_name(name) for name in ch_names))
+    return [_type_from_name(name) for name in ch_names]
+
+
+def _channel_types(eeg_data: Any | None, ch_names: Sequence[str]) -> dict[str, int]:
+    return dict(Counter(_channel_type_list(eeg_data, ch_names)))
 
 
 def _type_from_name(name: str) -> str:

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -305,7 +305,9 @@ def resolve_prior_preprocessing_dir(autoclean_dict: Mapping[str, Any]) -> Path:
 
 
 def resolve_prior_preprocessing_provenance(
-    import_metadata: Mapping[str, Any], autoclean_dict: Mapping[str, Any]
+    import_metadata: Mapping[str, Any],
+    autoclean_dict: Mapping[str, Any],
+    extracted_provenance: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any] | None:
     """Return the richest available EEGLAB provenance summary.
 
@@ -319,10 +321,27 @@ def resolve_prior_preprocessing_provenance(
         return direct
 
     from_import = import_metadata.get("eeglab_provenance")
-    if isinstance(from_import, Mapping):
-        return from_import
+    candidates = [
+        candidate
+        for candidate in (from_import, extracted_provenance)
+        if isinstance(candidate, Mapping)
+    ]
+    if candidates:
+        # max() is stable, so equally rich summaries prefer plugin metadata.
+        return max(candidates, key=_provenance_richness)
 
     return None
+
+
+def _provenance_richness(provenance: Mapping[str, Any]) -> tuple[int, int]:
+    """Rank full documented summaries above compact summary-row metadata."""
+
+    documented = provenance.get("documented_provenance")
+    summary_row = provenance.get("summary_row")
+    return (
+        2 if isinstance(documented, Mapping) and documented else 0,
+        1 if isinstance(summary_row, Mapping) and summary_row else 0,
+    )
 
 
 def build_prior_preprocessing_warnings(

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -8,6 +8,7 @@ hard failures, unless callers opt into strict validation handling.
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -421,9 +422,17 @@ def _merge_findings(
     text = " ".join(
         str(documented.get(key, "")) for key in ("history", "comments", "etc_keys")
     ).lower()
+    directional_filters = {
+        "highpass_filter": _has_documented_highpass(text),
+        "lowpass_filter": _has_documented_lowpass(text),
+    }
+    for name, present in directional_filters.items():
+        documented_finding = _documented_or_unknown(
+            present, True, "EEG history/comments"
+        )
+        findings[name] = _prefer_documented(documented_finding, signal.get(name))
+
     for name, needles in {
-        "highpass_filter": ("highpass", "high-pass", "pop_eegfilt", "eegfilt"),
-        "lowpass_filter": ("lowpass", "low-pass", "pop_eegfilt", "eegfilt"),
         "baseline_applied": ("baseline", "pop_rmbase", "rmbase"),
         "ica_pruned": ("subcomp", "reject component", "ica prune"),
     }.items():
@@ -435,15 +444,9 @@ def _merge_findings(
     for freq in POWERLINE_FREQS:
         key = f"notch_filter_{int(freq)}hz"
         documented_finding = _documented_or_unknown(
-            any(
-                token in text
-                for token in (f"notch {int(freq)}", f"{int(freq)}hz", f"{int(freq)} hz")
-            ),
-            True,
-            "EEG history/comments",
+            _has_documented_notch(text, freq), True, "EEG history/comments"
         )
         findings[key] = _prefer_documented(documented_finding, signal.get(key))
-
     findings["eog_ecg_misc_channel_presence"] = signal.get(
         "eog_ecg_misc_channel_presence", _unknown("channel type inference unavailable")
     )
@@ -451,6 +454,33 @@ def _merge_findings(
         "channel_count_suggests_dropping", _unknown("channel count unavailable")
     )
     return findings
+
+
+def _has_documented_highpass(text: str) -> bool:
+    return bool(
+        re.search(r"\bhigh[-\s]?pass(?:ed|ing)?\b", text)
+        or re.search(r"\bhp(?:f)?\b", text)
+        or re.search(r"\blocutoff\s*[=:]\s*(?!0+(?:\.0+)?\b)\d", text)
+    )
+
+
+def _has_documented_lowpass(text: str) -> bool:
+    return bool(
+        re.search(r"\blow[-\s]?pass(?:ed|ing)?\b", text)
+        or re.search(r"\blp(?:f)?\b", text)
+        or re.search(r"\bhicutoff\s*[=:]\s*(?!0+(?:\.0+)?\b)\d", text)
+    )
+
+
+def _has_documented_notch(text: str, freq: float) -> bool:
+    freq_text = str(int(freq)) if float(freq).is_integer() else str(freq)
+    frequency = rf"(?<![\d.]){re.escape(freq_text)}(?:\s*hz|\b)"
+    context = r"(?:notch|band[-\s]?stop|line[-\s]?noise|cleanline|zapline)"
+    nearby = 80
+    return bool(
+        re.search(rf"{context}[^.;\n]{{0,{nearby}}}{frequency}", text)
+        or re.search(rf"{frequency}[^.;\n]{{0,{nearby}}}{context}", text)
+    )
 
 
 def _infer_notches(
@@ -707,10 +737,24 @@ def _epoch_window(
 
 
 def _reference(info: Mapping[str, Any]) -> Any:
+    for key in ("reference", "ref", "description"):
+        value = info.get(key, UNAVAILABLE)
+        if isinstance(value, str) and value.strip() not in {UNAVAILABLE, UNKNOWN}:
+            return value
+
     custom_ref = info.get("custom_ref_applied", UNAVAILABLE)
-    if custom_ref not in (None, False, UNAVAILABLE):
+    if isinstance(custom_ref, str) and custom_ref.strip().lower() not in {
+        "false",
+        "0",
+        "none",
+        "unknown",
+    }:
         return custom_ref
-    return info.get("description", UNAVAILABLE)
+    if custom_ref is True:
+        return "custom reference applied"
+    if custom_ref not in (None, False, 0, UNAVAILABLE):
+        return "custom reference applied"
+    return UNAVAILABLE
 
 
 def _ica_present(ica: Any) -> dict[str, Any]:

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -7,6 +7,7 @@ hard failures, unless callers opt into strict validation handling.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -27,6 +28,8 @@ UNKNOWN = "unknown"
 UNAVAILABLE = "unavailable"
 SCHEMA_VERSION = "1.0"
 POWERLINE_FREQS = (50.0, 60.0, 100.0, 120.0)
+MISSING_SOURCE_PREFIX = "__missing_source__:"
+ESCAPED_SOURCE_PREFIX = "__named_source__:"
 DATASET_LOCK_TIMEOUT_SECONDS = 10.0
 DATASET_LOCK_RETRY_SECONDS = 0.05
 
@@ -219,13 +222,11 @@ def _append_prior_preprocessing_dataset_summary(
 
     row = dict(summary.get("summary_row", {}))
     source_file = row.get("source_file")
-    if source_file:
-        rows = [
-            existing for existing in rows if existing.get("source_file") != source_file
-        ]
+    row_key = _dataset_row_key(row)
+    rows = [existing for existing in rows if _dataset_row_key(existing) != row_key]
     rows.append(row)
     rows.sort(key=lambda item: str(item.get("source_file") or ""))
-    contribution_key = str(source_file or f"__row_{len(rows) - 1}")
+    contribution_key = _warning_contribution_key(row)
     warning_counts_by_source[contribution_key] = dict(
         Counter(str(warning) for warning in summary.get("warnings", []))
     )
@@ -247,6 +248,29 @@ def _append_prior_preprocessing_dataset_summary(
     if warning_counts_migration:
         dataset_summary["warning_counts_migration"] = warning_counts_migration
     return dataset_summary
+
+
+def _dataset_row_key(row: Mapping[str, Any]) -> tuple[str, str]:
+    """Return a stable identity for row replacement and warning contributions."""
+
+    source_file = row.get("source_file")
+    if source_file:
+        return ("named", str(source_file))
+    canonical = json.dumps(_json_safe(row), sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return ("anonymous", digest)
+
+
+def _warning_contribution_key(row: Mapping[str, Any]) -> str:
+    """Keep ordinary source keys while separating reserved key domains."""
+
+    source_file = row.get("source_file")
+    if source_file:
+        source_key = str(source_file)
+        if source_key.startswith((MISSING_SOURCE_PREFIX, ESCAPED_SOURCE_PREFIX)):
+            return f"{ESCAPED_SOURCE_PREFIX}{source_key}"
+        return source_key
+    return f"{MISSING_SOURCE_PREFIX}{_dataset_row_key(row)[1]}"
 
 
 def render_prior_preprocessing_report(summary: Mapping[str, Any]) -> str:
@@ -438,9 +462,9 @@ def _extract_documented_metadata(
         import_metadata.get("n_epochs"),
         _safe_len(eeg_data) if is_epochs else UNAVAILABLE,
     )
-    epoch_window = _first_known(
-        summary_row.get("epoch_window"),
+    epoch_window = _normalize_epoch_window(
         documented.get("epoch_window"),
+        summary_row.get("epoch_window"),
         _epoch_window(eeg_data, import_metadata),
     )
     events_doc = (
@@ -872,6 +896,25 @@ def _epoch_window(
     if tmin == UNAVAILABLE and tmax == UNAVAILABLE:
         return UNAVAILABLE
     return {"tmin": tmin, "tmax": tmax}
+
+
+def _normalize_epoch_window(*candidates: Any) -> dict[str, Any] | str:
+    """Normalize EEGLAB and MNE epoch windows to ``tmin``/``tmax`` keys."""
+
+    for candidate in candidates:
+        value = candidate
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                continue
+        if not isinstance(value, Mapping):
+            continue
+        tmin = _first_known(value.get("tmin"), value.get("xmin"))
+        tmax = _first_known(value.get("tmax"), value.get("xmax"))
+        if tmin != UNAVAILABLE or tmax != UNAVAILABLE:
+            return {"tmin": tmin, "tmax": tmax}
+    return UNAVAILABLE
 
 
 def _reference(info: Mapping[str, Any]) -> Any:

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -42,7 +42,7 @@ def detect_prior_preprocessing(
     """Return a conservative prior-preprocessing status summary.
 
     Parameters are deliberately plain mappings/objects so tests and importers can
-    pass MNE Raw/Epochs, light stubs, or #202 EEGLAB provenance summaries.
+    pass MNE Raw/Epochs, light stubs, or EEGLAB provenance summaries.
     """
 
     import_metadata = import_metadata or {}
@@ -119,6 +119,8 @@ def _dataset_summary_lock(dataset_path: Path):
 
     lock_path = dataset_path.with_name(f"{dataset_path.name}.lock")
     with lock_path.open("a+b") as lock_file:
+        # Windows byte-range locking requires this byte to exist. Initialize it
+        # before acquisition; the persistent lock file is coordination state.
         lock_file.seek(0)
         if lock_file.read(1) == b"":
             lock_file.write(b"\0")
@@ -305,11 +307,11 @@ def resolve_prior_preprocessing_dir(autoclean_dict: Mapping[str, Any]) -> Path:
 def resolve_prior_preprocessing_provenance(
     import_metadata: Mapping[str, Any], autoclean_dict: Mapping[str, Any]
 ) -> Mapping[str, Any] | None:
-    """Return the richest available #202-style provenance summary.
+    """Return the richest available EEGLAB provenance summary.
 
     Prefer a caller-provided full summary. Fall back to compact import metadata
-    (`metadata["import_eeg"]["eeglab_provenance"]`) when #202 has already run but
-    only persisted summary fields are available.
+    (`metadata["import_eeg"]["eeglab_provenance"]`) when only persisted summary
+    fields are available.
     """
 
     direct = autoclean_dict.get("eeglab_provenance")
@@ -948,21 +950,21 @@ def _provenance_integration_status(
     if not provenance_summary:
         return {
             "status": "unavailable",
-            "detail": "No #202 provenance summary was provided.",
+            "detail": "No EEGLAB provenance summary was provided.",
         }
     if provenance_summary.get("documented_provenance"):
         return {
             "status": "full_summary",
-            "detail": "Full #202 documented_provenance fields are available.",
+            "detail": "Full EEGLAB documented_provenance fields are available.",
         }
     if provenance_summary.get("summary_row"):
         return {
             "status": "summary_row_only",
-            "detail": "Only compact #202 summary_row metadata is available; full documented fields require #202 integration.",
+            "detail": "Only compact EEGLAB summary_row metadata is available; full documented fields require a full provenance summary.",
         }
     return {
         "status": "unknown_shape",
-        "detail": "Provided provenance summary did not match the #202 contract.",
+        "detail": "Provided provenance summary did not match the EEGLAB provenance contract.",
     }
 
 

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -11,6 +11,7 @@ import json
 import os
 import re
 import tempfile
+import time
 from collections import Counter
 from contextlib import contextmanager
 from pathlib import Path
@@ -26,6 +27,8 @@ UNKNOWN = "unknown"
 UNAVAILABLE = "unavailable"
 SCHEMA_VERSION = "1.0"
 POWERLINE_FREQS = (50.0, 60.0, 100.0, 120.0)
+DATASET_LOCK_TIMEOUT_SECONDS = 10.0
+DATASET_LOCK_RETRY_SECONDS = 0.05
 
 
 def detect_prior_preprocessing(
@@ -124,7 +127,11 @@ def _dataset_summary_lock(dataset_path: Path):
         if os.name == "nt":
             import msvcrt
 
-            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            _acquire_windows_lock(
+                lock_file,
+                msvcrt.locking,
+                msvcrt.LK_NBLCK,
+            )
         else:
             import fcntl
 
@@ -137,6 +144,31 @@ def _dataset_summary_lock(dataset_path: Path):
                 msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
             else:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _acquire_windows_lock(
+    lock_file: Any,
+    locking: Any,
+    nonblocking_mode: int,
+    *,
+    timeout: float = DATASET_LOCK_TIMEOUT_SECONDS,
+    retry_interval: float = DATASET_LOCK_RETRY_SECONDS,
+) -> None:
+    """Acquire a Windows byte-range lock with a bounded retry loop."""
+
+    deadline = time.monotonic() + timeout
+    while True:
+        lock_file.seek(0)
+        try:
+            locking(lock_file.fileno(), nonblocking_mode, 1)
+            return
+        except OSError as error:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    "Timed out acquiring dataset summary lock: " f"{lock_file.name}"
+                ) from error
+            time.sleep(min(retry_interval, remaining))
 
 
 def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
@@ -179,6 +211,8 @@ def _append_prior_preprocessing_dataset_summary(
             warning_counts_migration = {
                 "status": "legacy_aggregate_reset",
                 "reason": "per-source warning contributions were unavailable",
+                "warning_counts_complete": False,
+                "warning_counts_scope": "partial_current_sources_only",
             }
 
     row = dict(summary.get("summary_row", {}))
@@ -188,6 +222,7 @@ def _append_prior_preprocessing_dataset_summary(
             existing for existing in rows if existing.get("source_file") != source_file
         ]
     rows.append(row)
+    rows.sort(key=lambda item: str(item.get("source_file") or ""))
     contribution_key = str(source_file or f"__row_{len(rows) - 1}")
     warning_counts_by_source[contribution_key] = dict(
         Counter(str(warning) for warning in summary.get("warnings", []))
@@ -195,6 +230,10 @@ def _append_prior_preprocessing_dataset_summary(
     warning_counts: Counter[str] = Counter()
     for contribution in warning_counts_by_source.values():
         warning_counts.update(contribution)
+    warning_counts_by_source = {
+        source: dict(sorted(contribution.items()))
+        for source, contribution in sorted(warning_counts_by_source.items())
+    }
 
     dataset_summary = {
         "schema_version": SCHEMA_VERSION,

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -1,0 +1,946 @@
+"""Prior preprocessing detection and reporting helpers.
+
+The detector keeps documented metadata separate from signal-based inference. It
+is intentionally conservative: findings are warnings and confidence labels, not
+hard failures, unless callers opt into strict validation handling.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+CONFIDENCE_DOCUMENTED = "documented"
+CONFIDENCE_LIKELY = "likely"
+CONFIDENCE_POSSIBLE = "possible"
+CONFIDENCE_UNKNOWN = "unknown"
+UNKNOWN = "unknown"
+UNAVAILABLE = "unavailable"
+SCHEMA_VERSION = "1.0"
+POWERLINE_FREQS = (50.0, 60.0, 100.0, 120.0)
+
+
+def detect_prior_preprocessing(
+    eeg_data: Any | None = None,
+    *,
+    import_metadata: Mapping[str, Any] | None = None,
+    provenance_summary: Mapping[str, Any] | None = None,
+    task_config: Mapping[str, Any] | None = None,
+    strict: bool = False,
+) -> dict[str, Any]:
+    """Return a conservative prior-preprocessing status summary.
+
+    Parameters are deliberately plain mappings/objects so tests and importers can
+    pass MNE Raw/Epochs, light stubs, or #202 EEGLAB provenance summaries.
+    """
+
+    import_metadata = import_metadata or {}
+    task_config = task_config or {}
+    documented = _extract_documented_metadata(
+        eeg_data=eeg_data,
+        import_metadata=import_metadata,
+        provenance_summary=provenance_summary,
+    )
+    signal = _infer_from_signal(eeg_data)
+    findings = _merge_findings(documented, signal)
+    warnings = build_prior_preprocessing_warnings(findings, task_config)
+    strict_violations = warnings if strict else []
+    summary_row = _build_summary_row(findings, documented, signal, warnings)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "documented_metadata": documented,
+        "signal_inference": signal,
+        "findings": findings,
+        "warnings": warnings,
+        "strict_validation": bool(strict),
+        "strict_violations": strict_violations,
+        "summary_row": summary_row,
+        "artifact_paths": {},
+    }
+
+
+def build_prior_preprocessing_dataset_summary(
+    summaries: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Aggregate per-file prior-preprocessing summaries."""
+
+    rows = [dict(summary.get("summary_row", {})) for summary in summaries]
+    warning_counts = Counter(
+        warning for summary in summaries for warning in summary.get("warnings", [])
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "rows": rows,
+        "warning_counts": dict(sorted(warning_counts.items())),
+        "warnings": _dataset_consistency_warnings(rows),
+    }
+
+
+def write_prior_preprocessing_artifacts(
+    summary: dict[str, Any], output_dir: Path, stem: str
+) -> dict[str, str]:
+    """Write machine-readable, Markdown, and aggregate summary artifacts."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / f"{stem}_prior_preprocessing.json"
+    report_path = output_dir / f"{stem}_prior_preprocessing.md"
+    dataset_path = output_dir / "prior_preprocessing_dataset_summary.json"
+    artifact_paths = {
+        "json": str(json_path),
+        "report": str(report_path),
+        "dataset_summary": str(dataset_path),
+    }
+    summary["artifact_paths"] = artifact_paths
+    json_path.write_text(json.dumps(_json_safe(summary), indent=2), encoding="utf-8")
+    report_path.write_text(render_prior_preprocessing_report(summary), encoding="utf-8")
+    dataset_summary = _append_prior_preprocessing_dataset_summary(dataset_path, summary)
+    dataset_path.write_text(
+        json.dumps(_json_safe(dataset_summary), indent=2), encoding="utf-8"
+    )
+    return artifact_paths
+
+
+def _append_prior_preprocessing_dataset_summary(
+    dataset_path: Path, summary: Mapping[str, Any]
+) -> dict[str, Any]:
+    rows = []
+    warning_counts: Counter[str] = Counter()
+    if dataset_path.exists():
+        try:
+            existing = json.loads(dataset_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+        rows = [dict(row) for row in existing.get("rows", [])]
+        warning_counts.update(existing.get("warning_counts", {}))
+
+    row = dict(summary.get("summary_row", {}))
+    source_file = row.get("source_file")
+    if source_file:
+        rows = [
+            existing for existing in rows if existing.get("source_file") != source_file
+        ]
+    rows.append(row)
+    warning_counts.update(summary.get("warnings", []))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "rows": rows,
+        "warning_counts": dict(sorted(warning_counts.items())),
+        "warnings": _dataset_consistency_warnings(rows),
+    }
+
+
+def render_prior_preprocessing_report(summary: Mapping[str, Any]) -> str:
+    """Render a concise Markdown report for human review."""
+
+    row = summary["summary_row"]
+    lines = [
+        f"# Prior Preprocessing Status: {row.get('source_file', UNAVAILABLE)}",
+        "",
+        "## Documented Metadata",
+    ]
+    documented = summary.get("documented_metadata", {})
+    for key in (
+        "file_type",
+        "importer",
+        "data_type",
+        "sampling_rate",
+        "channel_count",
+        "epoch_count",
+        "epoch_window",
+        "reference",
+        "event_labels",
+        "event_codes",
+        "event_counts",
+    ):
+        lines.append(f"- {key}: {_compact(documented.get(key, UNAVAILABLE))}")
+
+    lines.extend(["", "## Signal-Based Inference"])
+    for key, finding in summary.get("findings", {}).items():
+        lines.append(
+            f"- {key}: {finding.get('confidence', CONFIDENCE_UNKNOWN)}"
+            f" ({finding.get('evidence', UNAVAILABLE)})"
+        )
+
+    lines.extend(["", "## Warnings"])
+    warnings = summary.get("warnings", [])
+    (
+        lines.extend(f"- {warning}" for warning in warnings)
+        if warnings
+        else lines.append("- none")
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def resolve_prior_preprocessing_dir(autoclean_dict: Mapping[str, Any]) -> Path:
+    """Resolve artifact directory using existing run directory conventions."""
+
+    if autoclean_dict.get("reports_dir"):
+        return (
+            Path(autoclean_dict["reports_dir"]) / "run_reports" / "prior_preprocessing"
+        )
+    if autoclean_dict.get("metadata_dir"):
+        return Path(autoclean_dict["metadata_dir"]) / "prior_preprocessing"
+    return Path(autoclean_dict["unprocessed_file"]).parent / "prior_preprocessing"
+
+
+def resolve_prior_preprocessing_provenance(
+    import_metadata: Mapping[str, Any], autoclean_dict: Mapping[str, Any]
+) -> Mapping[str, Any] | None:
+    """Return the richest available #202-style provenance summary.
+
+    Prefer a caller-provided full summary. Fall back to compact import metadata
+    (`metadata["import_eeg"]["eeglab_provenance"]`) when #202 has already run but
+    only persisted summary fields are available.
+    """
+
+    direct = autoclean_dict.get("eeglab_provenance")
+    if isinstance(direct, Mapping):
+        return direct
+
+    from_import = import_metadata.get("eeglab_provenance")
+    if isinstance(from_import, Mapping):
+        return from_import
+
+    return None
+
+
+def build_prior_preprocessing_warnings(
+    findings: Mapping[str, Mapping[str, Any]], task_config: Mapping[str, Any]
+) -> list[str]:
+    """Warn when task config may repeat likely/documented prior steps."""
+
+    warnings: list[str] = []
+    if _step_enabled(task_config, "filtering"):
+        if _is_known(findings.get("highpass_filter")) or _is_known(
+            findings.get("lowpass_filter")
+        ):
+            warnings.append("Task filtering may repeat prior high/low-pass filtering")
+        notch_freqs = _configured_notches(task_config)
+        repeated = [
+            freq
+            for freq in notch_freqs
+            if _is_known(findings.get(f"notch_filter_{int(freq)}hz"))
+        ]
+        if repeated:
+            joined = ", ".join(str(int(freq)) for freq in repeated)
+            warnings.append(
+                f"Task notch filtering may repeat prior notch at {joined} Hz"
+            )
+
+    baseline_step = _nested(task_config, "epoch_settings", "remove_baseline")
+    if isinstance(baseline_step, Mapping) and baseline_step.get("enabled", False):
+        if _is_known(findings.get("baseline_applied")):
+            warnings.append(
+                "Task baseline correction may repeat prior baseline correction"
+            )
+
+    if _step_enabled(task_config, "ICA") and _is_known(findings.get("ica_present")):
+        warnings.append("Task ICA may repeat prior ICA decomposition")
+
+    if _step_enabled(task_config, "reference_step") and _is_known(
+        findings.get("reference")
+    ):
+        warnings.append("Task rereferencing may repeat or replace documented reference")
+
+    if _step_enabled(task_config, "epoch_settings") and _is_known(
+        findings.get("epoching")
+    ):
+        warnings.append("Task epoching may repeat prior epoching")
+
+    expected_events = _nested(task_config, "epoch_settings", "event_id")
+    documented_events = findings.get("event_codes", {})
+    if isinstance(expected_events, Mapping) and documented_events.get("value") not in (
+        None,
+        UNKNOWN,
+        UNAVAILABLE,
+    ):
+        observed = {str(item) for item in _as_list(documented_events.get("value"))}
+        expected = {str(item) for item in expected_events.values()}
+        if expected and observed and expected.isdisjoint(observed):
+            warnings.append("Task event codes do not match documented event codes")
+
+    return warnings
+
+
+def _extract_documented_metadata(
+    *,
+    eeg_data: Any | None,
+    import_metadata: Mapping[str, Any],
+    provenance_summary: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    documented = dict((provenance_summary or {}).get("documented_provenance", {}))
+    summary_row = dict((provenance_summary or {}).get("summary_row", {}))
+
+    info = getattr(eeg_data, "info", {}) or {}
+    ch_names = list(getattr(eeg_data, "ch_names", []) or [])
+    is_epochs = _is_epochs_like(eeg_data, import_metadata)
+    events = getattr(eeg_data, "events", None)
+
+    channel_types = _channel_types(eeg_data, ch_names)
+    source_file = import_metadata.get("unprocessedFile") or summary_row.get(
+        "source_file"
+    )
+    sampling_rate = _first_known(
+        summary_row.get("srate"),
+        documented.get("srate"),
+        import_metadata.get("sampleRate"),
+        info.get("sfreq"),
+    )
+    channel_count = _first_known(
+        summary_row.get("nbchan"),
+        documented.get("nbchan"),
+        import_metadata.get("channelCount"),
+        len(ch_names) or UNAVAILABLE,
+    )
+    epoch_count = _first_known(
+        summary_row.get("trials"),
+        documented.get("trials"),
+        import_metadata.get("n_epochs"),
+        _safe_len(eeg_data) if is_epochs else UNAVAILABLE,
+    )
+    epoch_window = _first_known(
+        summary_row.get("epoch_window"),
+        documented.get("epoch_window"),
+        _epoch_window(eeg_data, import_metadata),
+    )
+    events_doc = (
+        documented.get("events", {})
+        if isinstance(documented.get("events"), Mapping)
+        else {}
+    )
+    channels_doc = (
+        documented.get("channels", {})
+        if isinstance(documented.get("channels"), Mapping)
+        else {}
+    )
+
+    return {
+        "source_file": source_file or UNAVAILABLE,
+        "file_type": import_metadata.get("file_format", UNAVAILABLE),
+        "importer": import_metadata.get("plugin_used", UNAVAILABLE),
+        "data_type": "epochs" if is_epochs else "raw",
+        "continuous_or_epoched": "epoched" if is_epochs else "continuous",
+        "sampling_rate": sampling_rate,
+        "channel_count": channel_count,
+        "epoch_count": epoch_count,
+        "epoch_window": epoch_window,
+        "reference": _first_known(
+            summary_row.get("reference"), documented.get("reference"), _reference(info)
+        ),
+        "ica": documented.get("ica", UNAVAILABLE),
+        "iclabel": documented.get("iclabel", UNAVAILABLE),
+        "bad_or_interpolated_channels": _first_known(
+            documented.get("interpolation"), info.get("bads"), UNAVAILABLE
+        ),
+        "channel_labels": _first_known(
+            channels_doc.get("labels"), ch_names or UNAVAILABLE
+        ),
+        "channel_types": _first_known(
+            channels_doc.get("types"), channel_types or UNAVAILABLE
+        ),
+        "event_labels": _first_known(
+            events_doc.get("labels"), import_metadata.get("event_dict"), UNAVAILABLE
+        ),
+        "event_codes": _first_known(
+            events_doc.get("codes"),
+            _event_codes(events),
+            import_metadata.get("unique_event_types"),
+            UNAVAILABLE,
+        ),
+        "event_counts": _first_known(
+            events_doc.get("counts"), _event_counts(events), UNAVAILABLE
+        ),
+        "history": documented.get("history", UNAVAILABLE),
+        "comments": documented.get("comments", UNAVAILABLE),
+        "etc_keys": documented.get("etc_keys", UNAVAILABLE),
+        "provenance_integration": _provenance_integration_status(provenance_summary),
+    }
+
+
+def _infer_from_signal(eeg_data: Any | None) -> dict[str, Any]:
+    if eeg_data is None:
+        return _unknown_signal_inference("no signal object provided")
+
+    info = getattr(eeg_data, "info", {}) or {}
+    ch_names = list(getattr(eeg_data, "ch_names", []) or [])
+    data = _get_data(eeg_data)
+    times = np.asarray(getattr(eeg_data, "times", []), dtype=float)
+    sfreq = _to_float(info.get("sfreq"))
+    channel_types = _channel_types(eeg_data, ch_names)
+    inference: dict[str, Any] = {
+        "data_shape": list(data.shape) if data is not None else UNAVAILABLE,
+        "eog_ecg_misc_channel_presence": _infer_aux_channels(channel_types, ch_names),
+        "channel_count_suggests_dropping": _infer_channel_count_drop(len(ch_names)),
+        "baseline_applied": _infer_baseline(data, times),
+        "highpass_filter": _infer_highpass(data, sfreq),
+        "lowpass_filter": _infer_lowpass(data, sfreq),
+        "ica_pruned": _possible("ICA pruning cannot be confirmed from signal alone"),
+        "ica_capable": _finding(
+            CONFIDENCE_POSSIBLE if len(ch_names) >= 2 else CONFIDENCE_UNKNOWN,
+            len(ch_names) >= 2,
+            (
+                f"{len(ch_names)} channels available for ICA"
+                if ch_names
+                else "channel names unavailable"
+            ),
+        ),
+    }
+    inference.update(_infer_notches(data, sfreq))
+    return inference
+
+
+def _merge_findings(
+    documented: Mapping[str, Any], signal: Mapping[str, Any]
+) -> dict[str, dict[str, Any]]:
+    findings = {
+        "epoching": _documented_or_unknown(
+            documented.get("continuous_or_epoched") == "epoched",
+            documented.get("continuous_or_epoched"),
+            "import metadata data_type",
+        ),
+        "sampling_rate": _documented_value(documented.get("sampling_rate")),
+        "epoch_window": _documented_value(documented.get("epoch_window")),
+        "reference": _documented_value(documented.get("reference")),
+        "event_codes": _documented_value(documented.get("event_codes")),
+        "event_counts": _documented_value(documented.get("event_counts")),
+        "ica_present": _ica_present(documented.get("ica")),
+        "iclabel_present": _iclabel_present(documented.get("iclabel")),
+        "interpolated_channels": _documented_value(
+            documented.get("bad_or_interpolated_channels")
+        ),
+        "channel_types": _documented_value(documented.get("channel_types")),
+    }
+
+    text = " ".join(
+        str(documented.get(key, "")) for key in ("history", "comments", "etc_keys")
+    ).lower()
+    for name, needles in {
+        "highpass_filter": ("highpass", "high-pass", "pop_eegfilt", "eegfilt"),
+        "lowpass_filter": ("lowpass", "low-pass", "pop_eegfilt", "eegfilt"),
+        "baseline_applied": ("baseline", "pop_rmbase", "rmbase"),
+        "ica_pruned": ("subcomp", "reject component", "ica prune"),
+    }.items():
+        documented_finding = _documented_or_unknown(
+            any(needle in text for needle in needles), True, "EEG history/comments"
+        )
+        findings[name] = _prefer_documented(documented_finding, signal.get(name))
+
+    for freq in POWERLINE_FREQS:
+        key = f"notch_filter_{int(freq)}hz"
+        documented_finding = _documented_or_unknown(
+            any(
+                token in text
+                for token in (f"notch {int(freq)}", f"{int(freq)}hz", f"{int(freq)} hz")
+            ),
+            True,
+            "EEG history/comments",
+        )
+        findings[key] = _prefer_documented(documented_finding, signal.get(key))
+
+    findings["eog_ecg_misc_channel_presence"] = signal.get(
+        "eog_ecg_misc_channel_presence", _unknown("channel type inference unavailable")
+    )
+    findings["channel_count_suggests_dropping"] = signal.get(
+        "channel_count_suggests_dropping", _unknown("channel count unavailable")
+    )
+    return findings
+
+
+def _infer_notches(
+    data: np.ndarray | None, sfreq: float | None
+) -> dict[str, dict[str, Any]]:
+    result = {}
+    freqs, spectrum = _mean_spectrum(data, sfreq)
+    for freq in POWERLINE_FREQS:
+        key = f"notch_filter_{int(freq)}hz"
+        if freqs is None or spectrum is None or sfreq is None or freq >= sfreq / 2:
+            result[key] = _unknown("frequency outside available Nyquist range")
+            continue
+        ratio = _band_power_ratio(
+            freqs, spectrum, freq, inner_width=1.0, outer_width=4.0
+        )
+        if ratio is None:
+            result[key] = _unknown("insufficient spectral bins")
+        elif ratio < 0.45:
+            result[key] = _finding(
+                CONFIDENCE_LIKELY,
+                True,
+                f"attenuation ratio {ratio:.2f} near {freq:g} Hz",
+            )
+        elif ratio < 0.75:
+            result[key] = _finding(
+                CONFIDENCE_POSSIBLE,
+                True,
+                f"attenuation ratio {ratio:.2f} near {freq:g} Hz",
+            )
+        else:
+            result[key] = _unknown(f"no clear attenuation near {freq:g} Hz")
+    return result
+
+
+def _infer_highpass(data: np.ndarray | None, sfreq: float | None) -> dict[str, Any]:
+    freqs, spectrum = _mean_spectrum(data, sfreq)
+    if freqs is None or spectrum is None:
+        return _unknown("spectrum unavailable")
+    low = _mean_power(freqs, spectrum, 0.1, 0.8)
+    mid = _mean_power(freqs, spectrum, 2.0, 8.0)
+    if low is None or mid is None or mid <= 0:
+        return _unknown("insufficient low-frequency bins")
+    ratio = low / mid
+    if ratio < 0.25:
+        return _finding(CONFIDENCE_POSSIBLE, True, f"sub-1 Hz power ratio {ratio:.2f}")
+    return _unknown(f"sub-1 Hz power ratio {ratio:.2f}")
+
+
+def _infer_lowpass(data: np.ndarray | None, sfreq: float | None) -> dict[str, Any]:
+    freqs, spectrum = _mean_spectrum(data, sfreq)
+    if freqs is None or spectrum is None or sfreq is None or sfreq < 80:
+        return _unknown("spectrum unavailable or Nyquist too low")
+    high_start = min(70.0, sfreq / 2 * 0.7)
+    high = _mean_power(freqs, spectrum, high_start, sfreq / 2 * 0.95)
+    mid = _mean_power(freqs, spectrum, 10.0, min(30.0, sfreq / 2 * 0.6))
+    if high is None or mid is None or mid <= 0:
+        return _unknown("insufficient high-frequency bins")
+    ratio = high / mid
+    if ratio < 0.2:
+        return _finding(
+            CONFIDENCE_POSSIBLE, True, f"high-frequency power ratio {ratio:.2f}"
+        )
+    return _unknown(f"high-frequency power ratio {ratio:.2f}")
+
+
+def _infer_baseline(data: np.ndarray | None, times: np.ndarray) -> dict[str, Any]:
+    if data is None or times.size == 0 or data.ndim < 2:
+        return _unknown("data or times unavailable")
+    baseline_mask = (times >= -0.25) & (times <= 0.0)
+    if not np.any(baseline_mask):
+        return _unknown("no pre-stimulus baseline window")
+    time_axis = data.ndim - 1
+    baseline = np.take(data, np.where(baseline_mask)[0], axis=time_axis)
+    all_scale = float(np.nanstd(data))
+    baseline_mean = float(abs(np.nanmean(baseline)))
+    if all_scale <= 0:
+        return _unknown("flat or unavailable signal scale")
+    ratio = baseline_mean / all_scale
+    if ratio < 0.05:
+        return _finding(
+            CONFIDENCE_POSSIBLE, True, f"baseline mean/std ratio {ratio:.3f}"
+        )
+    return _unknown(f"baseline mean/std ratio {ratio:.3f}")
+
+
+def _infer_aux_channels(
+    channel_types: Mapping[str, int], ch_names: Sequence[str]
+) -> dict[str, Any]:
+    present = {
+        kind: count
+        for kind, count in channel_types.items()
+        if kind in {"eog", "ecg", "misc"}
+    }
+    if present:
+        return _finding(
+            CONFIDENCE_LIKELY, present, f"typed auxiliary channels {present}"
+        )
+    name_hits = [
+        name
+        for name in ch_names
+        if any(token in name.lower() for token in ("eog", "ecg", "ekg", "emg", "misc"))
+    ]
+    if name_hits:
+        return _finding(
+            CONFIDENCE_POSSIBLE,
+            name_hits,
+            f"auxiliary-looking channel names {name_hits}",
+        )
+    return _unknown("no auxiliary channel types or names detected")
+
+
+def _infer_channel_count_drop(channel_count: int) -> dict[str, Any]:
+    common_counts = (32, 64, 128, 129, 256)
+    if channel_count <= 0:
+        return _unknown("channel count unavailable")
+    if any(
+        0 < expected - channel_count <= max(2, expected * 0.1)
+        for expected in common_counts
+    ):
+        return _finding(
+            CONFIDENCE_POSSIBLE,
+            True,
+            f"{channel_count} channels is just below a common montage count",
+        )
+    return _unknown(f"{channel_count} channels does not suggest dropping by itself")
+
+
+def _mean_spectrum(
+    data: np.ndarray | None, sfreq: float | None
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    if data is None or sfreq is None or sfreq <= 0:
+        return None, None
+    arr = np.asarray(data, dtype=float)
+    if arr.ndim == 3:
+        arr = arr.reshape((-1, arr.shape[-1]))
+    elif arr.ndim == 2:
+        pass
+    elif arr.ndim == 1:
+        arr = arr.reshape((1, -1))
+    else:
+        return None, None
+    if arr.shape[-1] < 4:
+        return None, None
+    arr = arr - np.nanmean(arr, axis=-1, keepdims=True)
+    spectrum = np.nanmean(np.abs(np.fft.rfft(arr, axis=-1)) ** 2, axis=0)
+    freqs = np.fft.rfftfreq(arr.shape[-1], d=1.0 / sfreq)
+    return freqs, spectrum
+
+
+def _band_power_ratio(
+    freqs: np.ndarray,
+    spectrum: np.ndarray,
+    center: float,
+    *,
+    inner_width: float,
+    outer_width: float,
+) -> float | None:
+    inner = (freqs >= center - inner_width) & (freqs <= center + inner_width)
+    outer = (freqs >= center - outer_width) & (freqs <= center + outer_width) & ~inner
+    inner_power = _safe_mean(spectrum[inner])
+    outer_power = _safe_mean(spectrum[outer])
+    if inner_power is None or outer_power is None or outer_power <= 0:
+        return None
+    return inner_power / outer_power
+
+
+def _mean_power(
+    freqs: np.ndarray, spectrum: np.ndarray, low: float, high: float
+) -> float | None:
+    mask = (freqs >= low) & (freqs <= high)
+    return _safe_mean(spectrum[mask])
+
+
+def _safe_mean(values: np.ndarray) -> float | None:
+    if values.size == 0:
+        return None
+    mean = float(np.nanmean(values))
+    return mean if np.isfinite(mean) else None
+
+
+def _get_data(eeg_data: Any) -> np.ndarray | None:
+    if eeg_data is None or not hasattr(eeg_data, "get_data"):
+        return None
+    try:
+        data = eeg_data.get_data()
+    except TypeError:
+        data = eeg_data.get_data(copy=False)
+    except Exception:  # pragma: no cover - defensive for third-party objects
+        return None
+    return np.asarray(data, dtype=float)
+
+
+def _is_epochs_like(eeg_data: Any | None, import_metadata: Mapping[str, Any]) -> bool:
+    if import_metadata.get("data_type") == "epochs":
+        return True
+    return (
+        hasattr(eeg_data, "events")
+        and hasattr(eeg_data, "tmin")
+        and hasattr(eeg_data, "tmax")
+    )
+
+
+def _channel_types(eeg_data: Any | None, ch_names: Sequence[str]) -> dict[str, int]:
+    if eeg_data is not None and hasattr(eeg_data, "get_channel_types"):
+        try:
+            return dict(
+                Counter(str(kind).lower() for kind in eeg_data.get_channel_types())
+            )
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return dict(Counter(_type_from_name(name) for name in ch_names))
+
+
+def _type_from_name(name: str) -> str:
+    lowered = name.lower()
+    if "eog" in lowered:
+        return "eog"
+    if "ecg" in lowered or "ekg" in lowered:
+        return "ecg"
+    if "misc" in lowered or "stim" in lowered or "status" in lowered:
+        return "misc"
+    return "eeg"
+
+
+def _event_codes(events: Any) -> list[int] | str:
+    if events is None:
+        return UNAVAILABLE
+    arr = np.asarray(events)
+    if arr.ndim != 2 or arr.shape[1] < 3:
+        return UNAVAILABLE
+    return sorted(int(value) for value in set(arr[:, 2].tolist()))
+
+
+def _event_counts(events: Any) -> dict[str, int] | str:
+    codes = _event_codes(events)
+    if codes == UNAVAILABLE:
+        return UNAVAILABLE
+    arr = np.asarray(events)
+    return {str(code): int(np.sum(arr[:, 2] == code)) for code in codes}
+
+
+def _epoch_window(
+    eeg_data: Any | None, import_metadata: Mapping[str, Any]
+) -> dict[str, Any] | str:
+    tmin = _first_known(
+        import_metadata.get("tmin"), getattr(eeg_data, "tmin", UNAVAILABLE)
+    )
+    tmax = _first_known(
+        import_metadata.get("tmax"), getattr(eeg_data, "tmax", UNAVAILABLE)
+    )
+    if tmin == UNAVAILABLE and tmax == UNAVAILABLE:
+        return UNAVAILABLE
+    return {"tmin": tmin, "tmax": tmax}
+
+
+def _reference(info: Mapping[str, Any]) -> Any:
+    custom_ref = info.get("custom_ref_applied", UNAVAILABLE)
+    if custom_ref not in (None, False, UNAVAILABLE):
+        return custom_ref
+    return info.get("description", UNAVAILABLE)
+
+
+def _ica_present(ica: Any) -> dict[str, Any]:
+    if isinstance(ica, Mapping):
+        present = any(
+            isinstance(value, Mapping) and value.get("present")
+            for value in ica.values()
+        )
+        return _documented_or_unknown(present, present, "documented ICA fields")
+    return _unknown("ICA metadata unavailable")
+
+
+def _iclabel_present(iclabel: Any) -> dict[str, Any]:
+    if isinstance(iclabel, Mapping):
+        present = bool(iclabel.get("present"))
+        return _documented_or_unknown(present, present, "documented ICLabel fields")
+    return _unknown("ICLabel metadata unavailable")
+
+
+def _documented_value(value: Any) -> dict[str, Any]:
+    if value in (None, UNAVAILABLE, UNKNOWN, [], {}):
+        return _unknown("documented value unavailable")
+    return _finding(CONFIDENCE_DOCUMENTED, value, "documented metadata")
+
+
+def _documented_or_unknown(
+    condition: bool, value: Any, evidence: str
+) -> dict[str, Any]:
+    if condition:
+        return _finding(CONFIDENCE_DOCUMENTED, value, evidence)
+    return _unknown(evidence)
+
+
+def _prefer_documented(
+    documented: Mapping[str, Any], signal: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    if documented.get("confidence") == CONFIDENCE_DOCUMENTED:
+        return dict(documented)
+    return dict(signal or documented)
+
+
+def _finding(confidence: str, value: Any, evidence: str) -> dict[str, Any]:
+    return {"confidence": confidence, "value": _json_safe(value), "evidence": evidence}
+
+
+def _unknown(evidence: str) -> dict[str, Any]:
+    return _finding(CONFIDENCE_UNKNOWN, UNKNOWN, evidence)
+
+
+def _possible(evidence: str) -> dict[str, Any]:
+    return _finding(CONFIDENCE_POSSIBLE, UNKNOWN, evidence)
+
+
+def _unknown_signal_inference(evidence: str) -> dict[str, Any]:
+    result = {
+        "data_shape": UNAVAILABLE,
+        "eog_ecg_misc_channel_presence": _unknown(evidence),
+        "channel_count_suggests_dropping": _unknown(evidence),
+        "baseline_applied": _unknown(evidence),
+        "highpass_filter": _unknown(evidence),
+        "lowpass_filter": _unknown(evidence),
+        "ica_pruned": _unknown(evidence),
+        "ica_capable": _unknown(evidence),
+    }
+    result.update(
+        {f"notch_filter_{int(freq)}hz": _unknown(evidence) for freq in POWERLINE_FREQS}
+    )
+    return result
+
+
+def _provenance_integration_status(
+    provenance_summary: Mapping[str, Any] | None,
+) -> dict[str, str]:
+    if not provenance_summary:
+        return {
+            "status": "unavailable",
+            "detail": "No #202 provenance summary was provided.",
+        }
+    if provenance_summary.get("documented_provenance"):
+        return {
+            "status": "full_summary",
+            "detail": "Full #202 documented_provenance fields are available.",
+        }
+    if provenance_summary.get("summary_row"):
+        return {
+            "status": "summary_row_only",
+            "detail": "Only compact #202 summary_row metadata is available; full documented fields require #202 integration.",
+        }
+    return {
+        "status": "unknown_shape",
+        "detail": "Provided provenance summary did not match the #202 contract.",
+    }
+
+
+def _build_summary_row(
+    findings: Mapping[str, Mapping[str, Any]],
+    documented: Mapping[str, Any],
+    signal: Mapping[str, Any],
+    warnings: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "source_file": documented.get("source_file", UNAVAILABLE),
+        "data_type": documented.get("data_type", UNAVAILABLE),
+        "sampling_rate": _finding_value(findings.get("sampling_rate")),
+        "channel_count": documented.get("channel_count", UNAVAILABLE),
+        "epoching": _finding_confidence(findings.get("epoching")),
+        "epoch_window": _finding_value(findings.get("epoch_window")),
+        "reference": _finding_confidence(findings.get("reference")),
+        "ica_present": _finding_confidence(findings.get("ica_present")),
+        "ica_pruned": _finding_confidence(findings.get("ica_pruned")),
+        "baseline_applied": _finding_confidence(findings.get("baseline_applied")),
+        "notch_filter_50hz": _finding_confidence(findings.get("notch_filter_50hz")),
+        "notch_filter_60hz": _finding_confidence(findings.get("notch_filter_60hz")),
+        "notch_filter_100hz": _finding_confidence(findings.get("notch_filter_100hz")),
+        "notch_filter_120hz": _finding_confidence(findings.get("notch_filter_120hz")),
+        "interpolated_or_dropped_channels": _finding_confidence(
+            findings.get("interpolated_channels")
+        ),
+        "event_codes": _finding_confidence(findings.get("event_codes")),
+        "event_code_values": _compact(_finding_value(findings.get("event_codes"))),
+        "highpass_filter": _finding_confidence(findings.get("highpass_filter")),
+        "lowpass_filter": _finding_confidence(findings.get("lowpass_filter")),
+        "aux_channels": _finding_confidence(
+            findings.get("eog_ecg_misc_channel_presence")
+        ),
+        "signal_shape": _compact(signal.get("data_shape", UNAVAILABLE)),
+        "warning_count": len(warnings),
+    }
+
+
+def _dataset_consistency_warnings(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    warnings = []
+    for key in ("sampling_rate", "epoch_window", "reference"):
+        values = {
+            str(row.get(key))
+            for row in rows
+            if row.get(key) not in (None, UNKNOWN, UNAVAILABLE)
+        }
+        if len(values) > 1:
+            warnings.append(
+                f"Inconsistent prior preprocessing {key}: {', '.join(sorted(values))}"
+            )
+    return warnings
+
+
+def _configured_notches(task_config: Mapping[str, Any]) -> list[float]:
+    notch = _nested(task_config, "filtering", "value", "notch_freqs")
+    return [
+        _to_float(value) for value in _as_list(notch) if _to_float(value) is not None
+    ]
+
+
+def _step_enabled(task_config: Mapping[str, Any], key: str) -> bool:
+    step = task_config.get(key)
+    return isinstance(step, Mapping) and bool(step.get("enabled", False))
+
+
+def _nested(mapping: Mapping[str, Any], *keys: str) -> Any:
+    current: Any = mapping
+    for key in keys:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _is_known(finding: Mapping[str, Any] | None) -> bool:
+    return bool(finding) and finding.get("confidence") in {
+        CONFIDENCE_DOCUMENTED,
+        CONFIDENCE_LIKELY,
+        CONFIDENCE_POSSIBLE,
+    }
+
+
+def _finding_confidence(finding: Mapping[str, Any] | None) -> str:
+    return str((finding or {}).get("confidence", CONFIDENCE_UNKNOWN))
+
+
+def _finding_value(finding: Mapping[str, Any] | None) -> Any:
+    return (finding or {}).get("value", UNKNOWN)
+
+
+def _first_known(*values: Any) -> Any:
+    for value in values:
+        if value not in (None, UNAVAILABLE, UNKNOWN, [], {}):
+            return value
+    return UNAVAILABLE
+
+
+def _safe_len(value: Any) -> int | str:
+    try:
+        return len(value)
+    except Exception:
+        return UNAVAILABLE
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _compact(value: Any) -> str:
+    if value in (None, UNKNOWN, UNAVAILABLE):
+        return UNAVAILABLE if value is None else str(value)
+    if isinstance(value, str):
+        return value
+    return json.dumps(_json_safe(value), sort_keys=True)

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -221,7 +221,6 @@ def _append_prior_preprocessing_dataset_summary(
             }
 
     row = dict(summary.get("summary_row", {}))
-    source_file = row.get("source_file")
     row_key = _dataset_row_key(row)
     rows = [existing for existing in rows if _dataset_row_key(existing) != row_key]
     rows.append(row)

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -8,8 +8,11 @@ hard failures, unless callers opt into strict validation handling.
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
 from collections import Counter
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -99,25 +102,84 @@ def write_prior_preprocessing_artifacts(
     summary["artifact_paths"] = artifact_paths
     json_path.write_text(json.dumps(_json_safe(summary), indent=2), encoding="utf-8")
     report_path.write_text(render_prior_preprocessing_report(summary), encoding="utf-8")
-    dataset_summary = _append_prior_preprocessing_dataset_summary(dataset_path, summary)
-    dataset_path.write_text(
-        json.dumps(_json_safe(dataset_summary), indent=2), encoding="utf-8"
-    )
+    with _dataset_summary_lock(dataset_path):
+        dataset_summary = _append_prior_preprocessing_dataset_summary(
+            dataset_path, summary
+        )
+        _atomic_write_json(dataset_path, dataset_summary)
     return artifact_paths
+
+
+@contextmanager
+def _dataset_summary_lock(dataset_path: Path):
+    """Serialize the complete dataset-summary read/modify/write operation."""
+
+    lock_path = dataset_path.with_name(f"{dataset_path.name}.lock")
+    with lock_path.open("a+b") as lock_file:
+        lock_file.seek(0)
+        if lock_file.read(1) == b"":
+            lock_file.write(b"\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            lock_file.seek(0)
+            if os.name == "nt":
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
+    """Atomically replace *path* using a temporary file in the same directory."""
+
+    fd, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as temporary_file:
+            json.dump(_json_safe(value), temporary_file, indent=2)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 
 def _append_prior_preprocessing_dataset_summary(
     dataset_path: Path, summary: Mapping[str, Any]
 ) -> dict[str, Any]:
     rows = []
-    warning_counts: Counter[str] = Counter()
+    warning_counts_by_source: dict[str, dict[str, int]] = {}
+    warning_counts_migration = None
     if dataset_path.exists():
         try:
             existing = json.loads(dataset_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             existing = {}
         rows = [dict(row) for row in existing.get("rows", [])]
-        warning_counts.update(existing.get("warning_counts", {}))
+        warning_counts_migration = existing.get("warning_counts_migration")
+        stored_contributions = existing.get("warning_counts_by_source")
+        if isinstance(stored_contributions, Mapping):
+            warning_counts_by_source = {
+                str(source): dict(counts)
+                for source, counts in stored_contributions.items()
+                if isinstance(counts, Mapping)
+            }
+        elif isinstance(existing.get("warning_counts"), Mapping):
+            # Legacy aggregates cannot be safely attributed to individual rows.
+            warning_counts_migration = {
+                "status": "legacy_aggregate_reset",
+                "reason": "per-source warning contributions were unavailable",
+            }
 
     row = dict(summary.get("summary_row", {}))
     source_file = row.get("source_file")
@@ -126,14 +188,24 @@ def _append_prior_preprocessing_dataset_summary(
             existing for existing in rows if existing.get("source_file") != source_file
         ]
     rows.append(row)
-    warning_counts.update(summary.get("warnings", []))
+    contribution_key = str(source_file or f"__row_{len(rows) - 1}")
+    warning_counts_by_source[contribution_key] = dict(
+        Counter(str(warning) for warning in summary.get("warnings", []))
+    )
+    warning_counts: Counter[str] = Counter()
+    for contribution in warning_counts_by_source.values():
+        warning_counts.update(contribution)
 
-    return {
+    dataset_summary = {
         "schema_version": SCHEMA_VERSION,
         "rows": rows,
         "warning_counts": dict(sorted(warning_counts.items())),
+        "warning_counts_by_source": warning_counts_by_source,
         "warnings": _dataset_consistency_warnings(rows),
     }
+    if warning_counts_migration:
+        dataset_summary["warning_counts_migration"] = warning_counts_migration
+    return dataset_summary
 
 
 def render_prior_preprocessing_report(summary: Mapping[str, Any]) -> str:

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -710,6 +710,8 @@ def _infer_lowpass(
 def _infer_baseline(data: np.ndarray | None, times: np.ndarray) -> dict[str, Any]:
     if data is None or times.size == 0 or data.ndim < 2:
         return _unknown("data or times unavailable")
+    if not np.any(times < 0.0):
+        return _unknown("no pre-stimulus baseline window")
     baseline_mask = (times >= -0.25) & (times <= 0.0)
     if not np.any(baseline_mask):
         return _unknown("no pre-stimulus baseline window")

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -375,13 +375,14 @@ def _infer_from_signal(eeg_data: Any | None) -> dict[str, Any]:
     times = np.asarray(getattr(eeg_data, "times", []), dtype=float)
     sfreq = _to_float(info.get("sfreq"))
     channel_types = _channel_types(eeg_data, ch_names)
+    freqs, spectrum = _mean_spectrum(data, sfreq)
     inference: dict[str, Any] = {
         "data_shape": list(data.shape) if data is not None else UNAVAILABLE,
         "eog_ecg_misc_channel_presence": _infer_aux_channels(channel_types, ch_names),
         "channel_count_suggests_dropping": _infer_channel_count_drop(len(ch_names)),
         "baseline_applied": _infer_baseline(data, times),
-        "highpass_filter": _infer_highpass(data, sfreq),
-        "lowpass_filter": _infer_lowpass(data, sfreq),
+        "highpass_filter": _infer_highpass(freqs, spectrum),
+        "lowpass_filter": _infer_lowpass(freqs, spectrum, sfreq),
         "ica_pruned": _possible("ICA pruning cannot be confirmed from signal alone"),
         "ica_capable": _finding(
             CONFIDENCE_POSSIBLE if len(ch_names) >= 2 else CONFIDENCE_UNKNOWN,
@@ -393,7 +394,7 @@ def _infer_from_signal(eeg_data: Any | None) -> dict[str, Any]:
             ),
         ),
     }
-    inference.update(_infer_notches(data, sfreq))
+    inference.update(_infer_notches(freqs, spectrum, sfreq))
     return inference
 
 
@@ -484,10 +485,11 @@ def _has_documented_notch(text: str, freq: float) -> bool:
 
 
 def _infer_notches(
-    data: np.ndarray | None, sfreq: float | None
+    freqs: np.ndarray | None,
+    spectrum: np.ndarray | None,
+    sfreq: float | None,
 ) -> dict[str, dict[str, Any]]:
     result = {}
-    freqs, spectrum = _mean_spectrum(data, sfreq)
     for freq in POWERLINE_FREQS:
         key = f"notch_filter_{int(freq)}hz"
         if freqs is None or spectrum is None or sfreq is None or freq >= sfreq / 2:
@@ -515,8 +517,9 @@ def _infer_notches(
     return result
 
 
-def _infer_highpass(data: np.ndarray | None, sfreq: float | None) -> dict[str, Any]:
-    freqs, spectrum = _mean_spectrum(data, sfreq)
+def _infer_highpass(
+    freqs: np.ndarray | None, spectrum: np.ndarray | None
+) -> dict[str, Any]:
     if freqs is None or spectrum is None:
         return _unknown("spectrum unavailable")
     low = _mean_power(freqs, spectrum, 0.1, 0.8)
@@ -529,8 +532,11 @@ def _infer_highpass(data: np.ndarray | None, sfreq: float | None) -> dict[str, A
     return _unknown(f"sub-1 Hz power ratio {ratio:.2f}")
 
 
-def _infer_lowpass(data: np.ndarray | None, sfreq: float | None) -> dict[str, Any]:
-    freqs, spectrum = _mean_spectrum(data, sfreq)
+def _infer_lowpass(
+    freqs: np.ndarray | None,
+    spectrum: np.ndarray | None,
+    sfreq: float | None,
+) -> dict[str, Any]:
     if freqs is None or spectrum is None or sfreq is None or sfreq < 80:
         return _unknown("spectrum unavailable or Nyquist too low")
     high_start = min(70.0, sfreq / 2 * 0.7)

--- a/src/autoclean/utils/prior_preprocessing.py
+++ b/src/autoclean/utils/prior_preprocessing.py
@@ -561,6 +561,16 @@ def _infer_from_signal(eeg_data: Any | None) -> dict[str, Any]:
 def _merge_findings(
     documented: Mapping[str, Any], signal: Mapping[str, Any]
 ) -> dict[str, dict[str, Any]]:
+    reference = documented.get("reference")
+    reference_finding = (
+        _finding(
+            CONFIDENCE_POSSIBLE,
+            reference,
+            "MNE custom_ref_applied flag",
+        )
+        if reference == "custom reference applied"
+        else _documented_value(reference)
+    )
     findings = {
         "epoching": _documented_or_unknown(
             documented.get("continuous_or_epoched") == "epoched",
@@ -569,7 +579,7 @@ def _merge_findings(
         ),
         "sampling_rate": _documented_value(documented.get("sampling_rate")),
         "epoch_window": _documented_value(documented.get("epoch_window")),
-        "reference": _documented_value(documented.get("reference")),
+        "reference": reference_finding,
         "event_codes": _documented_value(documented.get("event_codes")),
         "event_counts": _documented_value(documented.get("event_counts")),
         "ica_present": _ica_present(documented.get("ica")),

--- a/tests/config/test_config_validation_messages.py
+++ b/tests/config/test_config_validation_messages.py
@@ -53,6 +53,18 @@ def _minimal_config() -> dict:
     }
 
 
+def test_schema_accepts_prior_preprocessing_detection() -> None:
+    config = _minimal_config()
+    config["prior_preprocessing_detection"] = {
+        "enabled": True,
+        "strict": False,
+    }
+
+    validated = validate_task_module_config(config)
+
+    assert validated["prior_preprocessing_detection"]["enabled"] is True
+
+
 def _formatted_error(config: dict, *, debug: bool | None = None) -> str:
     with pytest.raises(Exception) as exc_info:
         validate_task_module_config(config)

--- a/tests/unit/core/test_task.py
+++ b/tests/unit/core/test_task.py
@@ -516,6 +516,48 @@ class TestTaskErrorHandling:
     @pytest.mark.skipif(
         not TASK_AVAILABLE, reason="Task module not available for import"
     )
+    @patch("autoclean.core.task.save_raw_to_set")
+    @patch("autoclean.core.task.import_eeg")
+    def test_import_raw_forwards_python_task_detection_settings(
+        self, mock_import_eeg, mock_save_raw_to_set
+    ):
+        """Python task detection settings reach the normal import path."""
+
+        class TestTask(Task):
+            def __init__(self, config):
+                self.settings = {
+                    "montage": {"enabled": False},
+                    "prior_preprocessing_detection": {
+                        "enabled": True,
+                        "strict": True,
+                    },
+                }
+                super().__init__(config)
+
+            def run(self):
+                pass
+
+        task = TestTask(
+            {
+                "run_id": "test_detection_settings",
+                "unprocessed_file": Path("/path/to/test.fif"),
+                "task": "test_task",
+            }
+        )
+        task.create_bids_path = lambda *args, **kwargs: None
+        mock_import_eeg.return_value = SimpleNamespace(duration=120.0)
+
+        task.import_raw()
+
+        runtime_config = mock_import_eeg.call_args.args[0]
+        assert runtime_config["prior_preprocessing_detection"] == {
+            "enabled": True,
+            "strict": True,
+        }
+
+    @pytest.mark.skipif(
+        not TASK_AVAILABLE, reason="Task module not available for import"
+    )
     def test_get_raw_returns_raw_after_set(self):
         """get_raw() returns self.raw once it has been populated."""
 

--- a/tests/unit/io/test_eeglab_provenance.py
+++ b/tests/unit/io/test_eeglab_provenance.py
@@ -103,6 +103,31 @@ def test_extract_from_loaded_mne_data_does_not_reparse_set(tmp_path) -> None:
     assert documented["history"] == "unavailable"
 
 
+def test_extract_from_loaded_epochs_preserves_event_codes_without_reparse(
+    tmp_path,
+) -> None:
+    set_file = tmp_path / "epochs.set"
+    set_file.write_bytes(b"not parsed")
+    info = mne.create_info(["Cz"], 250, ["eeg"])
+    events = np.array([[0, 0, 11], [100, 0, 22]])
+    epochs = mne.EpochsArray(
+        np.zeros((2, 1, 25)),
+        info,
+        events=events,
+        event_id={"standard": 11, "target": 22},
+        verbose=False,
+    )
+
+    with patch("autoclean.io.eeglab_provenance.sio.loadmat") as loadmat:
+        summary = extract_eeglab_provenance(set_file, epochs)
+
+    loadmat.assert_not_called()
+    documented_events = summary["documented_provenance"]["events"]
+    assert documented_events["labels"] == ["standard", "target"]
+    assert documented_events["codes"] == ["11", "22"]
+    assert summary["documented_provenance"]["reference"] == "unavailable"
+
+
 def test_render_eeglab_provenance_report_labels_missing_as_unavailable() -> None:
     summary = summarize_eeglab_provenance(_ns(), "empty.set")
 

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -204,6 +204,16 @@ def test_boolean_custom_reference_flag_is_not_reported_as_label():
     assert summary["findings"]["reference"]["value"] is not True
 
 
+def test_info_description_is_not_treated_as_reference_metadata():
+    raw = _RawStub(np.zeros((2, 128)))
+    raw.info["custom_ref_applied"] = False
+    raw.info["description"] = "Participant completed resting-state recording"
+
+    summary = detect_prior_preprocessing(raw)
+
+    assert summary["documented_metadata"]["reference"] == "unavailable"
+
+
 def test_signal_inference_flags_likely_notch_and_aux_channels():
     raw = _RawStub(_notch_like_data())
 

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -25,9 +25,13 @@ class _RawStub:
         self._channel_types = channel_types or ["eeg", "eeg", "eog", "misc"]
         self.n_times = self._data.shape[-1]
         self.times = np.arange(self.n_times) / sfreq
+        self.last_picks = None
 
-    def get_data(self):
-        return self._data
+    def get_data(self, picks=None):
+        self.last_picks = picks
+        if picks is None:
+            return self._data
+        return np.take(self._data, picks, axis=-2)
 
     def get_channel_types(self):
         return self._channel_types
@@ -250,6 +254,26 @@ def test_signal_inference_flags_likely_notch_and_aux_channels():
     aux = summary["findings"]["eog_ecg_misc_channel_presence"]
     assert aux["confidence"] == "likely"
     assert aux["value"] == {"eog": 1, "misc": 1}
+
+
+def test_signal_inference_reads_only_eeg_channels():
+    eeg_data = _notch_like_data()
+    auxiliary_data = np.vstack(
+        [np.full(eeg_data.shape[-1], 1e6), np.arange(eeg_data.shape[-1])]
+    )
+    raw = _RawStub(
+        np.vstack([eeg_data, auxiliary_data]),
+        ch_names=["Cz", "Pz", "VEOG", "Status"],
+        channel_types=["eeg", "eeg", "eog", "misc"],
+    )
+
+    summary = detect_prior_preprocessing(raw)
+
+    assert raw.last_picks == [0, 1]
+    assert summary["signal_inference"]["data_shape"] == [2, eeg_data.shape[-1]]
+    assert summary["signal_inference"]["ica_capable"]["evidence"] == (
+        "2 EEG channels available for ICA"
+    )
 
 
 def test_signal_inference_does_not_infer_baseline_from_raw_time_zero():

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+from autoclean.utils.prior_preprocessing import (
+    build_prior_preprocessing_dataset_summary,
+    detect_prior_preprocessing,
+)
+
+
+class _RawStub:
+    def __init__(self, data, sfreq=256.0, ch_names=None, channel_types=None):
+        self._data = np.asarray(data, dtype=float)
+        self.info = {"sfreq": sfreq, "custom_ref_applied": "A1/A2"}
+        self.ch_names = ch_names or ["Cz", "Pz", "VEOG", "Status"]
+        self._channel_types = channel_types or ["eeg", "eeg", "eog", "misc"]
+        self.n_times = self._data.shape[-1]
+        self.times = np.arange(self.n_times) / sfreq
+
+    def get_data(self):
+        return self._data
+
+    def get_channel_types(self):
+        return self._channel_types
+
+
+class _EpochsStub(_RawStub):
+    def __init__(self, data, sfreq=128.0):
+        super().__init__(data, sfreq=sfreq, ch_names=["Cz", "Pz"])
+        self.tmin = -0.2
+        self.tmax = 0.8
+        self.times = np.linspace(self.tmin, self.tmax, self._data.shape[-1])
+        self.events = np.array([[0, 0, 11], [128, 0, 22], [256, 0, 11]])
+
+    def __len__(self):
+        return self._data.shape[0]
+
+
+def _provenance_summary():
+    return {
+        "documented_provenance": {
+            "srate": 500,
+            "nbchan": 63,
+            "trials": 120,
+            "epoch_window": {"xmin": -0.2, "xmax": 0.8},
+            "reference": "A1/A2",
+            "history": "pop_eegfiltnew highpass; notch 60 Hz; pop_rmbase; runica; pop_epoch",
+            "comments": "ICA components manually rejected.",
+            "etc_keys": ["interpolated_channels"],
+            "channels": {
+                "labels": ["Cz", "Pz"],
+                "types": {"EEG": 2},
+            },
+            "events": {
+                "labels": ["standard", "target"],
+                "codes": ["11", "22"],
+                "counts": {"standard": 2, "target": 1},
+            },
+            "ica": {"icaweights": {"present": True, "shape": [62, 63]}},
+            "iclabel": {"present": True},
+            "interpolation": {"interpolated_channels": ["Oz"]},
+        },
+        "summary_row": {
+            "source_file": "sub-01.set",
+            "srate": 500,
+            "nbchan": 63,
+            "trials": 120,
+            "epoch_window": '{"xmax": 0.8, "xmin": -0.2}',
+            "reference": "A1/A2",
+            "event_codes": '["11", "22"]',
+            "event_counts": '{"standard": 2, "target": 1}',
+        },
+    }
+
+
+def _notch_like_data(sfreq=256.0, n_times=1024):
+    times = np.arange(n_times) / sfreq
+    signal = np.sin(2 * np.pi * 55 * times) + np.sin(2 * np.pi * 65 * times)
+    return np.vstack([signal, signal * 0.5])
+
+
+def test_detect_prior_preprocessing_uses_202_documented_schema():
+    raw = _RawStub(_notch_like_data())
+
+    summary = detect_prior_preprocessing(
+        raw,
+        import_metadata={"file_format": "EEGLAB_SET", "plugin_used": "EEGLAB"},
+        provenance_summary=_provenance_summary(),
+    )
+
+    assert summary["documented_metadata"]["reference"] == "A1/A2"
+    assert summary["findings"]["reference"]["confidence"] == "documented"
+    assert summary["findings"]["ica_present"]["confidence"] == "documented"
+    assert summary["findings"]["notch_filter_60hz"]["confidence"] == "documented"
+    assert summary["findings"]["baseline_applied"]["confidence"] == "documented"
+    assert summary["summary_row"]["source_file"] == "sub-01.set"
+
+
+def test_signal_inference_flags_likely_notch_and_aux_channels():
+    raw = _RawStub(_notch_like_data())
+
+    summary = detect_prior_preprocessing(raw)
+
+    assert summary["signal_inference"]["notch_filter_60hz"]["confidence"] == "likely"
+    aux = summary["findings"]["eog_ecg_misc_channel_presence"]
+    assert aux["confidence"] == "likely"
+    assert aux["value"] == {"eog": 1, "misc": 1}
+
+
+def test_task_config_warnings_are_non_blocking_unless_strict():
+    raw = _EpochsStub(np.zeros((3, 2, 64)))
+    task_config = {
+        "filtering": {
+            "enabled": True,
+            "value": {"l_freq": 1.0, "h_freq": 80.0, "notch_freqs": [60]},
+        },
+        "epoch_settings": {
+            "enabled": True,
+            "event_id": {"rare": 99},
+            "remove_baseline": {"enabled": True, "window": [-0.2, 0.0]},
+        },
+        "ICA": {"enabled": True, "value": {"method": "infomax"}},
+        "reference_step": {"enabled": True, "value": "average"},
+    }
+
+    summary = detect_prior_preprocessing(
+        raw,
+        provenance_summary=_provenance_summary(),
+        task_config=task_config,
+        strict=False,
+    )
+    strict_summary = detect_prior_preprocessing(
+        raw,
+        provenance_summary=_provenance_summary(),
+        task_config=task_config,
+        strict=True,
+    )
+
+    assert any("notch" in warning for warning in summary["warnings"])
+    assert any("baseline" in warning for warning in summary["warnings"])
+    assert any("ICA" in warning for warning in summary["warnings"])
+    assert any("event codes" in warning for warning in summary["warnings"])
+    assert summary["strict_violations"] == []
+    assert strict_summary["strict_violations"] == strict_summary["warnings"]
+
+
+def test_dataset_summary_counts_warnings():
+    first = detect_prior_preprocessing(
+        _RawStub(_notch_like_data()), provenance_summary=_provenance_summary()
+    )
+    second = detect_prior_preprocessing(
+        _RawStub(_notch_like_data(sfreq=512.0), sfreq=512.0),
+        import_metadata={"sampleRate": 512},
+    )
+    first["warnings"] = ["Task ICA may repeat prior ICA decomposition"]
+    second["warnings"] = ["Task ICA may repeat prior ICA decomposition"]
+
+    dataset = build_prior_preprocessing_dataset_summary([first, second])
+
+    assert len(dataset["rows"]) == 2
+    assert dataset["warning_counts"] == {
+        "Task ICA may repeat prior ICA decomposition": 2
+    }
+
+
+class _ImportPathPlugin:
+    def __init__(self, raw):
+        self._raw = raw
+
+    def import_and_configure(self, file_path, autoclean_dict, preload=True):
+        return self._raw
+
+    def process_events(self, raw):
+        return None, None, None
+
+    def get_metadata(self):
+        provenance = _provenance_summary()
+        return {
+            "plugin_name": self.__class__.__name__,
+            "eeglab_provenance": {
+                "schema_version": "1.0",
+                "summary_row": provenance["summary_row"],
+            },
+        }
+
+
+def _load_import_module():
+    module_path = (
+        Path(__file__).resolve().parents[3] / "src" / "autoclean" / "io" / "import_.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "autoclean_io_import_for_prior_preprocessing_test", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_import_eeg_attaches_prior_preprocessing_metadata_and_artifacts(tmp_path):
+    import_module = _load_import_module()
+    raw = _RawStub(_notch_like_data(), sfreq=500.0, ch_names=["Cz", "Pz"])
+    input_file = tmp_path / "sub-01.set"
+    input_file.write_text("stub", encoding="utf-8")
+    database_updates = []
+
+    import_module.get_plugin_for_combination = lambda format_id, montage: (
+        _ImportPathPlugin(raw)
+    )
+    import_module.manage_database_conditionally = (
+        lambda **kwargs: database_updates.append(kwargs)
+    )
+    import_module.message = lambda *args, **kwargs: None
+
+    result = import_module.import_eeg(
+        {
+            "unprocessed_file": str(input_file),
+            "eeg_system": "standard_1020",
+            "run_id": "run-203",
+            "reports_dir": str(tmp_path),
+            "prior_preprocessing_detection": {"enabled": True, "strict": True},
+            "settings": {
+                "filtering": {
+                    "enabled": True,
+                    "value": {"notch_freqs": [60]},
+                },
+                "reference_step": {"enabled": True, "value": "average"},
+            },
+        }
+    )
+
+    assert result is raw
+    import_metadata = database_updates[0]["update_record"]["metadata"]["import_eeg"]
+    prior_metadata = import_metadata["prior_preprocessing"]
+    assert prior_metadata["available"] is True
+    assert prior_metadata["schema_version"] == "1.0"
+    assert prior_metadata["summary_row"]["source_file"] == "sub-01.set"
+    assert prior_metadata["strict_violations"] == prior_metadata["warnings"]
+    assert prior_metadata["artifact_paths"].keys() == {
+        "json",
+        "report",
+        "dataset_summary",
+    }
+    for artifact_path in prior_metadata["artifact_paths"].values():
+        assert Path(artifact_path).exists()

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -232,7 +232,10 @@ def test_boolean_custom_reference_flag_is_not_reported_as_label():
     summary = detect_prior_preprocessing(raw)
 
     assert summary["documented_metadata"]["reference"] == "custom reference applied"
-    assert summary["findings"]["reference"]["value"] is not True
+    reference = summary["findings"]["reference"]
+    assert reference["value"] == "custom reference applied"
+    assert reference["confidence"] == "possible"
+    assert reference["evidence"] == "MNE custom_ref_applied flag"
 
 
 def test_info_description_is_not_treated_as_reference_metadata():

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -6,6 +6,7 @@ from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import autoclean.utils.prior_preprocessing as prior_preprocessing_module
 from autoclean.utils.prior_preprocessing import (
@@ -258,6 +259,20 @@ def test_dataset_summary_source_replacement_is_idempotent(tmp_path):
     assert dataset["warning_counts_by_source"] == {"sub-01.set": {warning: 1}}
 
 
+def test_dataset_summary_serialization_order_is_deterministic(tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    for source in ("sub-02.set", "sub-01.set"):
+        _write_dataset_summary(str(first_dir), source, [f"warning {source}"])
+    for source in ("sub-01.set", "sub-02.set"):
+        _write_dataset_summary(str(second_dir), source, [f"warning {source}"])
+
+    filename = "prior_preprocessing_dataset_summary.json"
+    assert (first_dir / filename).read_text(encoding="utf-8") == (
+        second_dir / filename
+    ).read_text(encoding="utf-8")
+
+
 def test_dataset_summary_reprocessing_legacy_source_resets_unattributed_counts(
     tmp_path,
 ):
@@ -266,8 +281,11 @@ def test_dataset_summary_reprocessing_legacy_source_resets_unattributed_counts(
         json.dumps(
             {
                 "schema_version": "1.0",
-                "rows": [{"source_file": "legacy.set"}],
-                "warning_counts": {"legacy warning": 1},
+                "rows": [
+                    {"source_file": "untouched.set"},
+                    {"source_file": "legacy.set"},
+                ],
+                "warning_counts": {"legacy warning": 2},
                 "warnings": [],
             }
         ),
@@ -277,13 +295,58 @@ def test_dataset_summary_reprocessing_legacy_source_resets_unattributed_counts(
     _write_dataset_summary(str(tmp_path), "legacy.set", ["current warning"])
 
     dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
-    assert dataset["rows"] == [{"source_file": "legacy.set"}]
+    assert dataset["rows"] == [
+        {"source_file": "legacy.set"},
+        {"source_file": "untouched.set"},
+    ]
     assert dataset["warning_counts"] == {"current warning": 1}
     assert dataset["warning_counts_by_source"] == {"legacy.set": {"current warning": 1}}
     assert dataset["warning_counts_migration"] == {
         "status": "legacy_aggregate_reset",
         "reason": "per-source warning contributions were unavailable",
+        "warning_counts_complete": False,
+        "warning_counts_scope": "partial_current_sources_only",
     }
+
+
+def test_windows_lock_retries_then_succeeds(tmp_path, monkeypatch):
+    attempts = []
+    times = iter([0.0, 0.0])
+
+    def locking(*args):
+        attempts.append(args)
+        if len(attempts) == 1:
+            raise OSError("busy")
+
+    monkeypatch.setattr(
+        prior_preprocessing_module.time, "monotonic", lambda: next(times)
+    )
+    monkeypatch.setattr(prior_preprocessing_module.time, "sleep", lambda _: None)
+    with (tmp_path / "summary.lock").open("w+b") as lock_file:
+        prior_preprocessing_module._acquire_windows_lock(
+            lock_file, locking, 2, timeout=1.0
+        )
+
+    assert len(attempts) == 2
+
+
+def test_windows_lock_timeout_is_clear(tmp_path, monkeypatch):
+    times = iter([0.0, 0.0, 1.0])
+
+    def locking(*args):
+        raise OSError("busy")
+
+    monkeypatch.setattr(
+        prior_preprocessing_module.time, "monotonic", lambda: next(times)
+    )
+    monkeypatch.setattr(prior_preprocessing_module.time, "sleep", lambda _: None)
+    with (
+        (tmp_path / "summary.lock").open("w+b") as lock_file,
+        pytest.raises(TimeoutError, match="dataset summary lock"),
+    ):
+        prior_preprocessing_module._acquire_windows_lock(
+            lock_file, locking, 2, timeout=0.5
+        )
 
 
 def test_dataset_summary_concurrent_writers_preserve_all_rows(tmp_path):

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +11,7 @@ import autoclean.utils.prior_preprocessing as prior_preprocessing_module
 from autoclean.utils.prior_preprocessing import (
     build_prior_preprocessing_dataset_summary,
     detect_prior_preprocessing,
+    write_prior_preprocessing_artifacts,
 )
 
 
@@ -81,6 +84,19 @@ def _notch_like_data(sfreq=256.0, n_times=1024):
     times = np.arange(n_times) / sfreq
     signal = np.sin(2 * np.pi * 55 * times) + np.sin(2 * np.pi * 65 * times)
     return np.vstack([signal, signal * 0.5])
+
+
+def _write_dataset_summary(
+    output_dir: str, source_file: str, warnings: list[str]
+) -> None:
+    summary = {
+        "summary_row": {"source_file": source_file},
+        "warnings": warnings,
+        "artifact_paths": {},
+    }
+    write_prior_preprocessing_artifacts(
+        summary, Path(output_dir), Path(source_file).stem
+    )
 
 
 def test_detect_prior_preprocessing_uses_202_documented_schema():
@@ -227,6 +243,66 @@ def test_dataset_summary_counts_warnings():
     assert dataset["warning_counts"] == {
         "Task ICA may repeat prior ICA decomposition": 2
     }
+
+
+def test_dataset_summary_source_replacement_is_idempotent(tmp_path):
+    warning = "Task ICA may repeat prior ICA decomposition"
+
+    _write_dataset_summary(str(tmp_path), "sub-01.set", [warning])
+    _write_dataset_summary(str(tmp_path), "sub-01.set", [warning])
+
+    dataset_path = tmp_path / "prior_preprocessing_dataset_summary.json"
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert dataset["rows"] == [{"source_file": "sub-01.set"}]
+    assert dataset["warning_counts"] == {warning: 1}
+    assert dataset["warning_counts_by_source"] == {"sub-01.set": {warning: 1}}
+
+
+def test_dataset_summary_reprocessing_legacy_source_resets_unattributed_counts(
+    tmp_path,
+):
+    dataset_path = tmp_path / "prior_preprocessing_dataset_summary.json"
+    dataset_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "rows": [{"source_file": "legacy.set"}],
+                "warning_counts": {"legacy warning": 1},
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _write_dataset_summary(str(tmp_path), "legacy.set", ["current warning"])
+
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert dataset["rows"] == [{"source_file": "legacy.set"}]
+    assert dataset["warning_counts"] == {"current warning": 1}
+    assert dataset["warning_counts_by_source"] == {"legacy.set": {"current warning": 1}}
+    assert dataset["warning_counts_migration"] == {
+        "status": "legacy_aggregate_reset",
+        "reason": "per-source warning contributions were unavailable",
+    }
+
+
+def test_dataset_summary_concurrent_writers_preserve_all_rows(tmp_path):
+    sources = [f"sub-{index:02d}.set" for index in range(12)]
+
+    with ProcessPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(
+                _write_dataset_summary, str(tmp_path), source, ["shared warning"]
+            )
+            for source in sources
+        ]
+        for future in futures:
+            future.result(timeout=30)
+
+    dataset_path = tmp_path / "prior_preprocessing_dataset_summary.json"
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert {row["source_file"] for row in dataset["rows"]} == set(sources)
+    assert dataset["warning_counts"] == {"shared warning": len(sources)}
 
 
 class _ImportPathPlugin:

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -12,6 +12,7 @@ import autoclean.utils.prior_preprocessing as prior_preprocessing_module
 from autoclean.utils.prior_preprocessing import (
     build_prior_preprocessing_dataset_summary,
     detect_prior_preprocessing,
+    resolve_prior_preprocessing_provenance,
     write_prior_preprocessing_artifacts,
 )
 
@@ -149,6 +150,48 @@ def test_documented_highpass_history_does_not_imply_lowpass_filtering():
 
     assert summary["findings"]["highpass_filter"]["confidence"] == "documented"
     assert summary["findings"]["lowpass_filter"]["confidence"] != "documented"
+
+
+def test_provenance_resolution_prefers_full_plugin_over_compact_extracted():
+    full = _provenance_summary()
+    compact = {"summary_row": full["summary_row"]}
+
+    resolved = resolve_prior_preprocessing_provenance(
+        {"eeglab_provenance": full}, {}, compact
+    )
+
+    assert resolved is full
+
+
+def test_provenance_resolution_uses_extracted_when_plugin_is_absent():
+    extracted = _provenance_summary()
+
+    resolved = resolve_prior_preprocessing_provenance({}, {}, extracted)
+
+    assert resolved is extracted
+
+
+def test_provenance_resolution_uses_full_extracted_over_compact_plugin():
+    extracted = _provenance_summary()
+    compact = {"summary_row": extracted["summary_row"]}
+
+    resolved = resolve_prior_preprocessing_provenance(
+        {"eeglab_provenance": compact}, {}, extracted
+    )
+
+    assert resolved is extracted
+
+
+def test_provenance_resolution_keeps_explicit_caller_precedence():
+    direct = {"summary_row": {"source_file": "caller.set"}}
+
+    resolved = resolve_prior_preprocessing_provenance(
+        {"eeglab_provenance": _provenance_summary()},
+        {"eeglab_provenance": direct},
+        _provenance_summary(),
+    )
+
+    assert resolved is direct
 
 
 def test_boolean_custom_reference_flag_is_not_reported_as_label():

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 
+import autoclean.utils.prior_preprocessing as prior_preprocessing_module
 from autoclean.utils.prior_preprocessing import (
     build_prior_preprocessing_dataset_summary,
     detect_prior_preprocessing,
@@ -154,6 +155,24 @@ def test_signal_inference_flags_likely_notch_and_aux_channels():
     assert aux["value"] == {"eog": 1, "misc": 1}
 
 
+def test_signal_inference_computes_mean_spectrum_once(monkeypatch):
+    raw = _RawStub(_notch_like_data())
+    original = prior_preprocessing_module._mean_spectrum
+    calls = []
+
+    def counting_mean_spectrum(data, sfreq):
+        calls.append((data, sfreq))
+        return original(data, sfreq)
+
+    monkeypatch.setattr(
+        prior_preprocessing_module, "_mean_spectrum", counting_mean_spectrum
+    )
+
+    detect_prior_preprocessing(raw)
+
+    assert len(calls) == 1
+
+
 def test_task_config_warnings_are_non_blocking_unless_strict():
     raw = _EpochsStub(np.zeros((3, 2, 64)))
     task_config = {
@@ -291,3 +310,36 @@ def test_import_eeg_attaches_prior_preprocessing_metadata_and_artifacts(tmp_path
     }
     for artifact_path in prior_metadata["artifact_paths"].values():
         assert Path(artifact_path).exists()
+
+
+def test_import_eeg_does_not_read_signal_when_detection_is_not_enabled(tmp_path):
+    import_module = _load_import_module()
+    raw = _RawStub(_notch_like_data(), sfreq=500.0, ch_names=["Cz", "Pz"])
+    input_file = tmp_path / "sub-01.set"
+    input_file.write_text("stub", encoding="utf-8")
+    database_updates = []
+
+    def fail_get_data():
+        raise AssertionError("disabled detection must not read signal data")
+
+    raw.get_data = fail_get_data
+    import_module.get_plugin_for_combination = lambda format_id, montage: (
+        _ImportPathPlugin(raw)
+    )
+    import_module.manage_database_conditionally = (
+        lambda **kwargs: database_updates.append(kwargs)
+    )
+    import_module.message = lambda *args, **kwargs: None
+
+    result = import_module.import_eeg(
+        {
+            "unprocessed_file": str(input_file),
+            "eeg_system": "standard_1020",
+            "run_id": "run-203-disabled",
+            "reports_dir": str(tmp_path),
+        }
+    )
+
+    assert result is raw
+    import_metadata = database_updates[0]["update_record"]["metadata"]["import_eeg"]
+    assert "prior_preprocessing" not in import_metadata

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -99,6 +99,50 @@ def test_detect_prior_preprocessing_uses_202_documented_schema():
     assert summary["summary_row"]["source_file"] == "sub-01.set"
 
 
+def test_documented_filter_cutoffs_do_not_imply_notch_filtering():
+    provenance = _provenance_summary()
+    provenance["documented_provenance"] = {
+        **provenance["documented_provenance"],
+        "history": "Applied 1-60Hz bandpass; later 0.1-150Hz filter.",
+    }
+
+    summary = detect_prior_preprocessing(
+        _RawStub(np.zeros((2, 512)), sfreq=512.0),
+        provenance_summary=provenance,
+    )
+
+    assert summary["findings"]["notch_filter_60hz"]["confidence"] != "documented"
+    assert summary["findings"]["notch_filter_50hz"]["confidence"] != "documented"
+    assert summary["findings"]["notch_filter_100hz"]["confidence"] != "documented"
+    assert summary["findings"]["notch_filter_120hz"]["confidence"] != "documented"
+
+
+def test_documented_highpass_history_does_not_imply_lowpass_filtering():
+    provenance = _provenance_summary()
+    provenance["documented_provenance"] = {
+        **provenance["documented_provenance"],
+        "history": "pop_eegfiltnew EEG locutoff=1 hicutoff=0; highpass only.",
+    }
+
+    summary = detect_prior_preprocessing(
+        _RawStub(np.zeros((2, 512)), sfreq=512.0),
+        provenance_summary=provenance,
+    )
+
+    assert summary["findings"]["highpass_filter"]["confidence"] == "documented"
+    assert summary["findings"]["lowpass_filter"]["confidence"] != "documented"
+
+
+def test_boolean_custom_reference_flag_is_not_reported_as_label():
+    raw = _RawStub(np.zeros((2, 128)))
+    raw.info["custom_ref_applied"] = True
+
+    summary = detect_prior_preprocessing(raw)
+
+    assert summary["documented_metadata"]["reference"] == "custom reference applied"
+    assert summary["findings"]["reference"]["value"] is not True
+
+
 def test_signal_inference_flags_likely_notch_and_aux_channels():
     raw = _RawStub(_notch_like_data())
 

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -382,10 +382,7 @@ class _ImportPathPlugin:
         provenance = _provenance_summary()
         return {
             "plugin_name": self.__class__.__name__,
-            "eeglab_provenance": {
-                "schema_version": "1.0",
-                "summary_row": provenance["summary_row"],
-            },
+            "eeglab_provenance": provenance,
         }
 
 
@@ -441,6 +438,8 @@ def test_import_eeg_attaches_prior_preprocessing_metadata_and_artifacts(tmp_path
     assert prior_metadata["available"] is True
     assert prior_metadata["schema_version"] == "1.0"
     assert prior_metadata["summary_row"]["source_file"] == "sub-01.set"
+    assert prior_metadata["findings"]["highpass_filter"]["confidence"] == "documented"
+    assert prior_metadata["findings"]["ica_present"]["confidence"] == "documented"
     assert prior_metadata["strict_violations"] == prior_metadata["warnings"]
     assert prior_metadata["artifact_paths"].keys() == {
         "json",

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -118,6 +118,33 @@ def test_detect_prior_preprocessing_uses_202_documented_schema():
     assert summary["summary_row"]["source_file"] == "sub-01.set"
 
 
+def test_epoch_window_is_canonical_across_provenance_and_local_paths():
+    raw = _EpochsStub(np.zeros((3, 2, 64)))
+    provenance = _provenance_summary()
+    full = detect_prior_preprocessing(raw, provenance_summary=provenance)
+    compact = detect_prior_preprocessing(
+        raw,
+        provenance_summary={
+            "summary_row": {
+                "source_file": "compact.set",
+                "epoch_window": '{"xmax": 0.8, "xmin": -0.2}',
+            }
+        },
+    )
+    local = detect_prior_preprocessing(raw)
+
+    expected = {"tmin": -0.2, "tmax": 0.8}
+    assert full["documented_metadata"]["epoch_window"] == expected
+    assert compact["documented_metadata"]["epoch_window"] == expected
+    assert local["documented_metadata"]["epoch_window"] == expected
+    assert full["summary_row"]["epoch_window"] == expected
+    assert compact["summary_row"]["epoch_window"] == expected
+    assert local["summary_row"]["epoch_window"] == expected
+
+    dataset = build_prior_preprocessing_dataset_summary([full, compact, local])
+    assert not any("epoch_window" in warning for warning in dataset["warnings"])
+
+
 def test_documented_filter_cutoffs_do_not_imply_notch_filtering():
     provenance = _provenance_summary()
     provenance["documented_provenance"] = {
@@ -310,6 +337,64 @@ def test_dataset_summary_source_replacement_is_idempotent(tmp_path):
     assert dataset["rows"] == [{"source_file": "sub-01.set"}]
     assert dataset["warning_counts"] == {warning: 1}
     assert dataset["warning_counts_by_source"] == {"sub-01.set": {warning: 1}}
+
+
+def test_dataset_summary_missing_source_replacement_is_idempotent(tmp_path):
+    warning = "warning for unknown source"
+    summary = {
+        "summary_row": {"sampling_rate": 250},
+        "warnings": [warning],
+        "artifact_paths": {},
+    }
+
+    write_prior_preprocessing_artifacts(summary, tmp_path, "unknown")
+    write_prior_preprocessing_artifacts(summary, tmp_path, "unknown")
+
+    dataset_path = tmp_path / "prior_preprocessing_dataset_summary.json"
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert dataset["rows"] == [{"sampling_rate": 250}]
+    assert dataset["warning_counts"] == {warning: 1}
+    assert len(dataset["warning_counts_by_source"]) == 1
+    contribution_key = next(iter(dataset["warning_counts_by_source"]))
+    assert contribution_key.startswith("__missing_source__:")
+    assert dataset["warning_counts_by_source"][contribution_key] == {warning: 1}
+
+
+def test_named_source_cannot_collide_with_anonymous_contribution_key(tmp_path):
+    anonymous = {
+        "summary_row": {"sampling_rate": 250},
+        "warnings": ["anonymous warning"],
+        "artifact_paths": {},
+    }
+    write_prior_preprocessing_artifacts(anonymous, tmp_path, "anonymous")
+    dataset_path = tmp_path / "prior_preprocessing_dataset_summary.json"
+    initial = json.loads(dataset_path.read_text(encoding="utf-8"))
+    anonymous_key = next(iter(initial["warning_counts_by_source"]))
+
+    named = {
+        "summary_row": {"source_file": anonymous_key, "sampling_rate": 500},
+        "warnings": ["named warning"],
+        "artifact_paths": {},
+    }
+    write_prior_preprocessing_artifacts(named, tmp_path, "named")
+
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert len(dataset["rows"]) == 2
+    assert {row.get("source_file") for row in dataset["rows"]} == {
+        None,
+        anonymous_key,
+    }
+    assert dataset["warning_counts"] == {
+        "anonymous warning": 1,
+        "named warning": 1,
+    }
+    assert dataset["warning_counts_by_source"][anonymous_key] == {
+        "anonymous warning": 1
+    }
+    escaped_named_key = f"__named_source__:{anonymous_key}"
+    assert dataset["warning_counts_by_source"][escaped_named_key] == {
+        "named warning": 1
+    }
 
 
 def test_dataset_summary_serialization_order_is_deterministic(tmp_path):

--- a/tests/unit/utils/test_prior_preprocessing.py
+++ b/tests/unit/utils/test_prior_preprocessing.py
@@ -252,6 +252,35 @@ def test_signal_inference_flags_likely_notch_and_aux_channels():
     assert aux["value"] == {"eog": 1, "misc": 1}
 
 
+def test_signal_inference_does_not_infer_baseline_from_raw_time_zero():
+    data = np.ones((4, 128))
+    data[:, 0] = [-1.0, 1.0, -1.0, 1.0]
+    raw = _RawStub(data)
+
+    summary = detect_prior_preprocessing(raw)
+
+    baseline = summary["signal_inference"]["baseline_applied"]
+    assert baseline["confidence"] == "unknown"
+    assert baseline["evidence"] == "no pre-stimulus baseline window"
+
+
+def test_signal_only_notch_inference_reaches_summary_and_warnings():
+    raw = _RawStub(_notch_like_data())
+    task_config = {
+        "filtering": {
+            "enabled": True,
+            "value": {"notch_freqs": [60]},
+        }
+    }
+
+    summary = detect_prior_preprocessing(raw, task_config=task_config)
+
+    assert summary["summary_row"]["notch_filter_60hz"] == "likely"
+    assert summary["warnings"] == [
+        "Task notch filtering may repeat prior notch at 60 Hz"
+    ]
+
+
 def test_signal_inference_computes_mean_spectrum_once(monkeypatch):
     raw = _RawStub(_notch_like_data())
     original = prior_preprocessing_module._mean_spectrum


### PR DESCRIPTION
Closes #203.

## Summary
- Add conservative prior preprocessing detection with documented/likely/possible/unknown confidence labels.
- Record non-blocking warnings for repeated filtering, notch filtering, ICA, rereferencing, baseline correction, epoching, and event-code mismatches.
- Write per-file JSON/Markdown artifacts and append/update a dataset summary artifact.
- Attach prior preprocessing metadata to import records, including strict violations when strict mode is enabled.
- Bridge #202-shaped EEGLAB provenance when available for richer documented evidence.

## Verification
- python -B -m pytest -p no:cacheprovider --no-cov --basetemp=.\\pytest-codex-temp tests\\unit\\utils\\test_prior_preprocessing.py -q
- python -B -m ruff check src\\autoclean\\io\\import_.py src\\autoclean\\utils\\prior_preprocessing.py tests\\unit\\utils\\test_prior_preprocessing.py
- git diff --check

## Dependency / Sequencing
- Draft PR for issue #203.
- Depends on #202 / PR #239 for the richest EEGLAB documented provenance handoff.
- This branch also touches src/autoclean/io/import_.py, so merge after #202 or rebase after #202 lands.