### PR TITLE
feat: add assr analysis profiles

### DIFF
--- a/src/autoclean/calc/assr_analysis.py
+++ b/src/autoclean/calc/assr_analysis.py
@@ -86,6 +86,8 @@ def _json_ready(value: Any) -> Any:
         return [_json_ready(item) for item in value]
     if isinstance(value, list):
         return [_json_ready(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return [_json_ready(item) for item in value.tolist()]
     if isinstance(value, np.generic):
         return value.item()
     return value
@@ -437,6 +439,17 @@ def compute_metrics(
     valid_windows = _validate_time_windows(time_windows, itc[1].times, audit)
     valid_bands = _validate_freq_bands(freq_bands, freqs, audit)
     valid_combined_bands = _validate_freq_bands(combined_bands, freqs, audit)
+    metric_band_names = {
+        band_name for band_name in valid_bands if not band_name.startswith("itc")
+    }
+    for band_name in sorted(metric_band_names & set(valid_combined_bands)):
+        _record_skip(
+            audit,
+            "skipped_combined_bands",
+            band_name,
+            "name_conflicts_with_freq_bands",
+        )
+        del valid_combined_bands[band_name]
     all_window = valid_windows.get("all")
 
     if hasattr(epochs, "filename") and epochs.filename is not None:
@@ -546,16 +559,20 @@ def _write_analysis_metadata(
     settings: dict[str, Any],
     audit: dict[str, Any],
 ) -> None:
-    payload = {
+    settings_payload = {
         "analysis_settings": _json_ready(settings),
+    }
+    log_payload = {
         "analysis_audit": _json_ready(audit),
+        "analysis_profile": _json_ready(settings.get("profile")),
+        "saved_tfr": bool(settings.get("save_tfr")),
     }
     metadata_file = data_dir / f"{file_basename}_assr_analysis_settings.json"
     log_file = data_dir / f"{file_basename}_assr_analysis_log.json"
     with metadata_file.open("w", encoding="utf8") as handle:
-        json.dump(payload, handle, indent=2)
+        json.dump(settings_payload, handle, indent=2)
     with log_file.open("w", encoding="utf8") as handle:
-        json.dump(payload, handle, indent=2)
+        json.dump(log_payload, handle, indent=2)
 
 
 def analyze_assr(
@@ -593,6 +610,7 @@ def analyze_assr(
     audit = {
         "profile": analysis_settings.get("profile"),
         "skipped_freq_bands": [],
+        "skipped_combined_bands": [],
         "skipped_time_windows": [],
         "excluded_channels": [],
     }

--- a/src/autoclean/calc/assr_analysis.py
+++ b/src/autoclean/calc/assr_analysis.py
@@ -1,9 +1,138 @@
 import argparse
+import copy
+import json
+import warnings
 from pathlib import Path
+from typing import Any
 
 import mne
 import numpy as np
 import pandas as pd
+
+DEFAULT_ASSR_FREQ_BANDS = {
+    "alpha": (8, 13),
+    "theta": (4, 7),
+    "gamma1": (30, 55),
+    "gamma2": (65, 80),
+    "itc40": (35, 45),
+    "itc80": (75, 85),
+    "itc_onset": (2, 13),
+}
+
+DEFAULT_ASSR_TIME_WINDOWS = {
+    "all": (0, 3.0),
+    "itc_onset": (0.092, 0.308),
+    "itc_offset": (2.8, 3.0),
+}
+
+DEFAULT_ASSR_COMBINED_BANDS = {
+    "gamma": (30, 80),
+}
+
+LEGACY_ASSR_METRIC_COLUMNS = [
+    "eegid",
+    "trials",
+    "chan",
+    "rejtrials",
+    "stp_gamma",
+    "stp_gamma1",
+    "stp_gamma2",
+    "stp_alpha",
+    "stp_theta",
+    "ersp_gamma",
+    "ersp_gamma1",
+    "ersp_gamma2",
+    "ersp_alpha",
+    "ersp_theta",
+    "itc40",
+    "itc80",
+    "itconset",
+    "itcoffset",
+]
+
+LEGACY_ASSR_SETTINGS = {
+    "profile": None,
+    "baseline": (-0.5, 0),
+    "time_windows": DEFAULT_ASSR_TIME_WINDOWS,
+    "freq_bands": DEFAULT_ASSR_FREQ_BANDS,
+    "combined_bands": DEFAULT_ASSR_COMBINED_BANDS,
+    "exclude_channel_types": [],
+    "save_tfr": False,
+}
+
+ASSR_ANALYSIS_PROFILES = {
+    "assr_epochs": {
+        "profile": "assr_epochs",
+        "baseline": (-0.2, 0.0),
+        "time_windows": {
+            "all": (0.0, 0.7),
+            "itc_onset": (0.092, 0.308),
+            "itc_offset": (0.5, 0.7),
+        },
+        "freq_bands": DEFAULT_ASSR_FREQ_BANDS,
+        "combined_bands": {
+            "gamma_combined": [(30, 55), (65, 80)],
+        },
+        "exclude_channel_types": ["eog", "ecg", "misc"],
+        "save_tfr": False,
+    }
+}
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _json_ready(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def resolve_assr_analysis_settings(
+    profile: str | None = None,
+    overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve ASSR analysis profile settings plus task/runner overrides."""
+    if profile is None and overrides is None:
+        return copy.deepcopy(LEGACY_ASSR_SETTINGS)
+
+    if profile is None:
+        settings = copy.deepcopy(LEGACY_ASSR_SETTINGS)
+    else:
+        if profile not in ASSR_ANALYSIS_PROFILES:
+            available = ", ".join(sorted(ASSR_ANALYSIS_PROFILES))
+            raise ValueError(
+                f"Unknown ASSR analysis profile '{profile}'. Available: {available}"
+            )
+        settings = copy.deepcopy(ASSR_ANALYSIS_PROFILES[profile])
+
+    if overrides:
+        settings = _deep_merge(settings, overrides)
+    return settings
+
+
+def resolve_assr_analysis_config(
+    analysis_profile: str | None = None,
+    analysis_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve settings from explicit args or a task-style config mapping."""
+    config = analysis_config or {}
+    profile = analysis_profile or config.get("profile")
+    overrides = {key: value for key, value in config.items() if key != "profile"}
+    return resolve_assr_analysis_settings(profile=profile, overrides=overrides or None)
 
 
 def load_epochs(file_path):
@@ -125,259 +254,391 @@ def compute_time_frequency(epochs, freqs=None, n_cycles=None, baseline=(-0.5, 0)
     }
 
 
-def compute_metrics(tf_data, epochs, freq_bands=None, time_windows=None):
-    """
-    Compute various metrics from time-frequency data
+def _record_skip(audit: dict[str, Any], category: str, name: str, reason: str) -> None:
+    audit.setdefault(category, []).append({"name": name, "reason": reason})
+    warnings.warn(
+        f"Skipping ASSR {category.removeprefix('skipped_')} '{name}': {reason}"
+    )
 
-    Parameters:
-    -----------
-    tf_data : dict
-        Output from compute_time_frequency function
-    epochs : mne.Epochs
-        Epochs object used for computation
-    freq_bands : dict, optional
-        Dictionary of frequency bands to analyze
-    time_windows : dict, optional
-        Dictionary of time windows to analyze
 
-    Returns:
-    --------
-    results_df : pandas.DataFrame
-        DataFrame containing computed metrics for each channel
+def _normalize_segments(value: Any) -> list[tuple[float, float]] | None:
+    if value is None:
+        return None
+    if (
+        isinstance(value, (list, tuple))
+        and len(value) == 2
+        and all(isinstance(item, (int, float)) for item in value)
+    ):
+        return [(float(value[0]), float(value[1]))]
+
+    segments = []
+    if isinstance(value, (list, tuple)):
+        for segment in value:
+            if not (
+                isinstance(segment, (list, tuple))
+                and len(segment) == 2
+                and all(isinstance(item, (int, float)) for item in segment)
+            ):
+                return []
+            segments.append((float(segment[0]), float(segment[1])))
+        return segments
+    return []
+
+
+def _validate_time_windows(
+    time_windows: dict[str, Any] | None,
+    times: np.ndarray,
+    audit: dict[str, Any],
+) -> dict[str, tuple[float, float]]:
+    valid = {}
+    if not time_windows:
+        return valid
+
+    time_min = float(np.min(times))
+    time_max = float(np.max(times))
+    for name, window in time_windows.items():
+        if not (
+            isinstance(window, (list, tuple))
+            and len(window) == 2
+            and all(isinstance(item, (int, float)) for item in window)
+        ):
+            _record_skip(audit, "skipped_time_windows", name, "invalid_shape")
+            continue
+        tmin = float(window[0])
+        tmax = float(window[1])
+        if tmin > tmax:
+            _record_skip(audit, "skipped_time_windows", name, "min_greater_than_max")
+            continue
+        if tmax < time_min or tmin > time_max:
+            _record_skip(audit, "skipped_time_windows", name, "outside_epoch_range")
+            continue
+        indices = np.where((times >= tmin) & (times <= tmax))[0]
+        if len(indices) == 0:
+            _record_skip(audit, "skipped_time_windows", name, "no_time_bins")
+            continue
+        valid[name] = (tmin, tmax)
+    return valid
+
+
+def _validate_freq_bands(
+    freq_bands: dict[str, Any] | None,
+    freqs: np.ndarray,
+    audit: dict[str, Any],
+) -> dict[str, list[tuple[float, float]]]:
+    valid = {}
+    if freq_bands is None:
+        _record_skip(audit, "skipped_freq_bands", "freq_bands", "not_configured")
+        return valid
+
+    freq_min = float(np.min(freqs))
+    freq_max = float(np.max(freqs))
+    for name, band in freq_bands.items():
+        segments = _normalize_segments(band)
+        if segments is None:
+            _record_skip(audit, "skipped_freq_bands", name, "not_configured")
+            continue
+        if not segments:
+            _record_skip(audit, "skipped_freq_bands", name, "invalid_shape")
+            continue
+
+        valid_segments = []
+        for fmin, fmax in segments:
+            if fmin > fmax:
+                _record_skip(audit, "skipped_freq_bands", name, "min_greater_than_max")
+                valid_segments = []
+                break
+            if fmax < freq_min or fmin > freq_max:
+                continue
+            indices = np.where((freqs >= fmin) & (freqs <= fmax))[0]
+            if len(indices) > 0:
+                valid_segments.append((fmin, fmax))
+        if valid_segments:
+            valid[name] = valid_segments
+        else:
+            _record_skip(
+                audit, "skipped_freq_bands", name, "outside_tfr_frequency_range"
+            )
+    return valid
+
+
+def _segment_freq_indices(
+    freqs: np.ndarray,
+    segments: list[tuple[float, float]],
+) -> np.ndarray:
+    index_parts = [
+        np.where((freqs >= fmin) & (freqs <= fmax))[0] for fmin, fmax in segments
+    ]
+    if not index_parts:
+        return np.array([], dtype=int)
+    return np.unique(np.concatenate(index_parts)).astype(int)
+
+
+def _time_indices(times: np.ndarray, window: tuple[float, float]) -> np.ndarray:
+    return np.where((times >= window[0]) & (times <= window[1]))[0]
+
+
+def _channel_indices_for_metrics(
+    epochs: Any,
+    exclude_channel_types: list[str] | None,
+    audit: dict[str, Any],
+) -> list[tuple[int, str]]:
+    excluded_types = {item.lower() for item in (exclude_channel_types or [])}
+    if not excluded_types:
+        return list(enumerate(epochs.ch_names))
+
+    channel_types = []
+    if hasattr(epochs, "get_channel_types"):
+        channel_types = [item.lower() for item in epochs.get_channel_types()]
+    else:
+        channel_types = ["eeg"] * len(epochs.ch_names)
+
+    included = []
+    excluded_channels = []
+    for index, (channel, channel_type) in enumerate(
+        zip(epochs.ch_names, channel_types)
+    ):
+        if channel_type in excluded_types:
+            excluded_channels.append({"channel": channel, "type": channel_type})
+        else:
+            included.append((index, channel))
+    audit["excluded_channels"] = excluded_channels
+    return included
+
+
+def compute_metrics(
+    tf_data,
+    epochs,
+    freq_bands=None,
+    time_windows=None,
+    combined_bands=None,
+    exclude_channel_types=None,
+    audit=None,
+):
     """
-    # Unpack time-frequency data
+    Compute ASSR metrics from time-frequency data.
+
+    Invalid or unavailable configured bands/windows are skipped and recorded in
+    ``audit`` instead of producing all-NaN metric columns silently.
+    """
+    audit = audit if audit is not None else {}
     itc = tf_data["itc"]
     single_trial_power = tf_data["single_trial_power"]
     ersp = tf_data["ersp"]
-    freqs = tf_data["freqs"]
+    freqs = np.asarray(tf_data["freqs"])
 
-    # Define frequency bands if not provided
-    if freq_bands is None:
-        freq_bands = {
-            "alpha": (8, 13),
-            "theta": (4, 7),
-            "gamma1": (30, 55),
-            "gamma2": (65, 80),
-            "itc40": (35, 45),
-            "itc80": (75, 85),
-            "itc_onset": (2, 13),
-        }
-
-    # Define time windows if not provided
+    if freq_bands is None and combined_bands is None:
+        freq_bands = DEFAULT_ASSR_FREQ_BANDS
+        combined_bands = DEFAULT_ASSR_COMBINED_BANDS
     if time_windows is None:
-        time_windows = {
-            "all": (0, 3.0),
-            "itc_onset": (0.092, 0.308),
-            "itc_offset": (2.8, 3.0),
-        }
+        time_windows = DEFAULT_ASSR_TIME_WINDOWS
+    if combined_bands is None:
+        combined_bands = {}
 
-    # Helper functions to find indices
-    def find_freq_indices(freqs, fmin, fmax):
-        return np.where((freqs >= fmin) & (freqs <= fmax))[0]
+    valid_windows = _validate_time_windows(time_windows, itc[1].times, audit)
+    valid_bands = _validate_freq_bands(freq_bands, freqs, audit)
+    valid_combined_bands = _validate_freq_bands(combined_bands, freqs, audit)
+    all_window = valid_windows.get("all")
 
-    def find_time_indices(times, tmin, tmax):
-        return np.where((times >= tmin) & (times <= tmax))[0]
-
-    # Calculate file info and rejected trials
     if hasattr(epochs, "filename") and epochs.filename is not None:
         file_path = Path(epochs.filename)
         file_basename = file_path.stem
     else:
-        # For synthetic/in-memory epochs without a filename
-        file_path = Path("synthetic_data")
         file_basename = "synthetic_epochs"
 
     n_total_trials = len(epochs.drop_log)
-    n_rejected_trials = sum(
-        1 for log in epochs.drop_log if log
-    )  # Count non-empty drop logs
+    n_rejected_trials = sum(1 for log in epochs.drop_log if log)
+    channel_indices = _channel_indices_for_metrics(epochs, exclude_channel_types, audit)
 
-    # Create a list to store results
     results = []
+    for ch_idx, ch_name in channel_indices:
+        row = {
+            "eegid": file_basename,
+            "trials": n_total_trials,
+            "chan": ch_name,
+            "rejtrials": n_rejected_trials,
+        }
 
-    # Process each channel
-    for ch_idx, ch_name in enumerate(epochs.ch_names):
-        # Calculate ITC40 (mean ITC from 0-3s in 35-45 Hz)
-        itc40_idx = find_freq_indices(freqs, *freq_bands["itc40"])
-        time_all_idx = find_time_indices(
-            itc[1].times, *time_windows["all"]
-        )  # itc[1] for actual ITC values
-        itc40 = np.mean(itc[1].data[ch_idx, itc40_idx][:, time_all_idx])
+        if all_window is not None:
+            time_all_idx = _time_indices(itc[1].times, all_window)
+            if "itc40" in valid_bands:
+                indices = _segment_freq_indices(freqs, valid_bands["itc40"])
+                row["itc40"] = np.mean(itc[1].data[ch_idx, indices][:, time_all_idx])
+            if "itc80" in valid_bands:
+                indices = _segment_freq_indices(freqs, valid_bands["itc80"])
+                row["itc80"] = np.mean(itc[1].data[ch_idx, indices][:, time_all_idx])
 
-        # Calculate ITC80 (mean ITC from 0-3s in 75-85 Hz)
-        itc80_idx = find_freq_indices(freqs, *freq_bands["itc80"])
-        itc80 = np.mean(itc[1].data[ch_idx, itc80_idx][:, time_all_idx])
+        if "itc_onset" in valid_bands and "itc_onset" in valid_windows:
+            freq_idx = _segment_freq_indices(freqs, valid_bands["itc_onset"])
+            time_idx = _time_indices(itc[1].times, valid_windows["itc_onset"])
+            row["itconset"] = np.mean(itc[1].data[ch_idx, freq_idx][:, time_idx])
 
-        # Calculate ITC onset (2-13 Hz, 92-308 ms)
-        itc_onset_freq_idx = find_freq_indices(freqs, *freq_bands["itc_onset"])
-        itc_onset_time_idx = find_time_indices(itc[1].times, *time_windows["itc_onset"])
-        itc_onset = np.mean(
-            itc[1].data[ch_idx, itc_onset_freq_idx][:, itc_onset_time_idx]
-        )
+        if "itc_onset" in valid_bands and "itc_offset" in valid_windows:
+            freq_idx = _segment_freq_indices(freqs, valid_bands["itc_onset"])
+            time_idx = _time_indices(itc[1].times, valid_windows["itc_offset"])
+            row["itcoffset"] = np.mean(itc[1].data[ch_idx, freq_idx][:, time_idx])
 
-        # Calculate ITC offset (2-13 Hz, 2800-3000 ms)
-        itc_offset_freq_idx = find_freq_indices(
-            freqs, *freq_bands["itc_onset"]
-        )  # Same frequency band as onset
-        itc_offset_time_idx = find_time_indices(
-            itc[1].times, *time_windows["itc_offset"]
-        )
-        itc_offset = np.mean(
-            itc[1].data[ch_idx, itc_offset_freq_idx][:, itc_offset_time_idx]
-        )
+        for band_name, segments in valid_bands.items():
+            if band_name.startswith("itc"):
+                continue
+            freq_idx = _segment_freq_indices(freqs, segments)
+            row[f"stp_{band_name}"] = np.mean(
+                single_trial_power.data[:, ch_idx, freq_idx, :]
+            )
+            row[f"ersp_{band_name}"] = np.mean(ersp.data[ch_idx, freq_idx, :])
 
-        # Calculate single trial power (STP) for different frequency bands
-        stp_gamma1_idx = find_freq_indices(freqs, *freq_bands["gamma1"])
-        stp_gamma1 = np.mean(single_trial_power.data[:, ch_idx, stp_gamma1_idx, :])
+        for band_name, segments in valid_combined_bands.items():
+            freq_idx = _segment_freq_indices(freqs, segments)
+            row[f"stp_{band_name}"] = np.mean(
+                single_trial_power.data[:, ch_idx, freq_idx, :]
+            )
+            row[f"ersp_{band_name}"] = np.mean(ersp.data[ch_idx, freq_idx, :])
 
-        stp_gamma2_idx = find_freq_indices(freqs, *freq_bands["gamma2"])
-        stp_gamma2 = np.mean(single_trial_power.data[:, ch_idx, stp_gamma2_idx, :])
+        results.append(row)
 
-        stp_alpha_idx = find_freq_indices(freqs, *freq_bands["alpha"])
-        stp_alpha = np.mean(single_trial_power.data[:, ch_idx, stp_alpha_idx, :])
-
-        stp_theta_idx = find_freq_indices(freqs, *freq_bands["theta"])
-        stp_theta = np.mean(single_trial_power.data[:, ch_idx, stp_theta_idx, :])
-
-        # Calculate combined gamma (30-80 Hz)
-        stp_gamma_idx = find_freq_indices(freqs, 30, 80)
-        stp_gamma = np.mean(single_trial_power.data[:, ch_idx, stp_gamma_idx, :])
-
-        # Calculate ERSP for different frequency bands
-        ersp_gamma1_idx = find_freq_indices(freqs, *freq_bands["gamma1"])
-        ersp_gamma1 = np.mean(ersp.data[ch_idx, ersp_gamma1_idx, :])
-
-        ersp_gamma2_idx = find_freq_indices(freqs, *freq_bands["gamma2"])
-        ersp_gamma2 = np.mean(ersp.data[ch_idx, ersp_gamma2_idx, :])
-
-        ersp_alpha_idx = find_freq_indices(freqs, *freq_bands["alpha"])
-        ersp_alpha = np.mean(ersp.data[ch_idx, ersp_alpha_idx, :])
-
-        ersp_theta_idx = find_freq_indices(freqs, *freq_bands["theta"])
-        ersp_theta = np.mean(ersp.data[ch_idx, ersp_theta_idx, :])
-
-        # Calculate combined gamma ERSP (30-80 Hz)
-        ersp_gamma_idx = find_freq_indices(freqs, 30, 80)
-        ersp_gamma = np.mean(ersp.data[ch_idx, ersp_gamma_idx, :])
-
-        # Store results for this channel
-        results.append(
-            {
-                "eegid": file_basename,
-                "trials": n_total_trials,
-                "chan": ch_name,
-                "rejtrials": n_rejected_trials,
-                "stp_gamma": stp_gamma,
-                "stp_gamma1": stp_gamma1,
-                "stp_gamma2": stp_gamma2,
-                "stp_alpha": stp_alpha,
-                "stp_theta": stp_theta,
-                "ersp_gamma": ersp_gamma,
-                "ersp_gamma1": ersp_gamma1,
-                "ersp_gamma2": ersp_gamma2,
-                "ersp_alpha": ersp_alpha,
-                "ersp_theta": ersp_theta,
-                "itc40": itc40,
-                "itc80": itc80,
-                "itconset": itc_onset,
-                "itcoffset": itc_offset,
-            }
-        )
-
-    # Create DataFrame from results
     results_df = pd.DataFrame(results)
-    return results_df
+    ordered_columns = [
+        column for column in LEGACY_ASSR_METRIC_COLUMNS if column in results_df.columns
+    ]
+    ordered_columns.extend(
+        column for column in results_df.columns if column not in ordered_columns
+    )
+    return results_df.loc[:, ordered_columns]
+
+
+def _resolve_file_basename(
+    file_path: Any, epochs: Any, file_basename: str | None
+) -> str:
+    if file_basename is not None:
+        return file_basename
+    if file_path is not None:
+        return Path(file_path).stem
+    if hasattr(epochs, "filename") and epochs.filename is not None:
+        return Path(epochs.filename).stem
+    return "assr_analysis"
+
+
+def _save_tfr_artifacts(
+    tf_data: dict[str, Any],
+    data_dir: Path,
+    file_basename: str,
+    audit: dict[str, Any],
+) -> None:
+    saved = []
+    for name in ("power", "ersp", "single_trial_power"):
+        tfr = tf_data.get(name)
+        if tfr is None or not hasattr(tfr, "save"):
+            continue
+        output_file = data_dir / f"{file_basename}_{name}_assr-tfr.h5"
+        tfr.save(output_file, overwrite=True)
+        saved.append(str(output_file))
+
+    itc = tf_data.get("itc")
+    if isinstance(itc, tuple) and len(itc) > 1 and hasattr(itc[1], "save"):
+        output_file = data_dir / f"{file_basename}_itc_assr-tfr.h5"
+        itc[1].save(output_file, overwrite=True)
+        saved.append(str(output_file))
+    audit["saved_tfr_artifacts"] = saved
+
+
+def _write_analysis_metadata(
+    data_dir: Path,
+    file_basename: str,
+    settings: dict[str, Any],
+    audit: dict[str, Any],
+) -> None:
+    payload = {
+        "analysis_settings": _json_ready(settings),
+        "analysis_audit": _json_ready(audit),
+    }
+    metadata_file = data_dir / f"{file_basename}_assr_analysis_settings.json"
+    log_file = data_dir / f"{file_basename}_assr_analysis_log.json"
+    with metadata_file.open("w", encoding="utf8") as handle:
+        json.dump(payload, handle, indent=2)
+    with log_file.open("w", encoding="utf8") as handle:
+        json.dump(payload, handle, indent=2)
 
 
 def analyze_assr(
-    file_path=None, output_dir=None, save_results=True, epochs=None, file_basename=None
+    file_path=None,
+    output_dir=None,
+    save_results=True,
+    epochs=None,
+    file_basename=None,
+    analysis_profile=None,
+    analysis_config=None,
 ):
     """
-    Main function to analyze ASSR data
+    Main function to analyze ASSR data.
 
-    Parameters:
-    -----------
-    file_path : str or Path, optional
-        Path to the EEGLAB .set file. Not required if epochs are provided directly.
-    output_dir : str or Path, optional
-        Directory to save results
-    save_results : bool, optional
-        Whether to save results to disk
-    epochs : mne.Epochs, optional
-        Pre-loaded MNE Epochs object. If provided, file_path is ignored.
-    file_basename : str, optional
-        Base filename to use for saving results when epochs don't have a filename.
-        Takes precedence over automatically extracted filenames.
-
-    Returns:
-    --------
-    dict : Dictionary containing analysis results
-        - 'results_df': DataFrame with computed metrics
-        - 'tf_data': Time-frequency data
-        - 'epochs': MNE Epochs object
-        - 'file_basename': Basename used for saving files
+    ``analysis_profile`` may be set to ``"assr_epochs"``. ``analysis_config``
+    can supply task/runner overrides such as ``time_windows``, ``freq_bands``,
+    ``combined_bands``, ``baseline``, ``exclude_channel_types``, and
+    ``save_tfr``. When neither is supplied, legacy defaults are preserved.
     """
-    # Set up output directory
     if output_dir is None:
         output_dir = Path(".")
     else:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Load epochs if not provided
     if epochs is None:
         if file_path is None:
             raise ValueError("Either file_path or epochs must be provided")
         epochs = load_epochs(file_path)
 
-    # Compute time-frequency representations
-    tf_data = compute_time_frequency(epochs)
+    analysis_settings = resolve_assr_analysis_config(
+        analysis_profile=analysis_profile,
+        analysis_config=analysis_config,
+    )
+    audit = {
+        "profile": analysis_settings.get("profile"),
+        "skipped_freq_bands": [],
+        "skipped_time_windows": [],
+        "excluded_channels": [],
+    }
 
-    # Compute metrics
-    results_df = compute_metrics(tf_data, epochs)
+    tf_data = compute_time_frequency(epochs, baseline=analysis_settings["baseline"])
+    results_df = compute_metrics(
+        tf_data,
+        epochs,
+        freq_bands=analysis_settings.get("freq_bands"),
+        time_windows=analysis_settings.get("time_windows"),
+        combined_bands=analysis_settings.get("combined_bands"),
+        exclude_channel_types=analysis_settings.get("exclude_channel_types"),
+        audit=audit,
+    )
 
-    # Print summary information
     freq_idx = np.argmin(np.abs(tf_data["freqs"] - 40))
     print(
         f"Maximum ITC value at 40 Hz: {np.max(tf_data['itc'][1].data[:, freq_idx, :]):.3f}"
     )
 
-    # Find midrange frequencies around 40 Hz to compute resolution
     freqs_mid = [f for f in tf_data["freqs"] if 30 <= f <= 50]
     if len(freqs_mid) > 1:
         print(
             f"Frequency resolution around 40 Hz: {freqs_mid[1] - freqs_mid[0]:.2f} Hz"
         )
 
-    # Save results if requested
+    resolved_basename = _resolve_file_basename(file_path, epochs, file_basename)
     if save_results:
-        # Determine file basename with explicit parameter taking precedence
-        if file_basename is not None:
-            # Use provided basename
-            pass
-        elif file_path is not None:
-            file_basename = Path(file_path).stem
-        elif hasattr(epochs, "filename") and epochs.filename is not None:
-            file_basename = Path(epochs.filename).stem
-        else:
-            # Use a default name if no file path or filename is provided
-            file_basename = "assr_analysis"
-
-        # Create data subdirectory
         data_dir = output_dir / "data"
         data_dir.mkdir(parents=True, exist_ok=True)
 
-        # Save with descriptive filename including basename
-        output_filename = data_dir / f"{file_basename}_metrics_assr.csv"
+        output_filename = data_dir / f"{resolved_basename}_metrics_assr.csv"
         results_df.to_csv(output_filename, index=False)
         print(f"Saved analysis results to {output_filename}")
 
-    # Return results as dictionary
+        if analysis_settings.get("save_tfr"):
+            _save_tfr_artifacts(tf_data, data_dir, resolved_basename, audit)
+        _write_analysis_metadata(data_dir, resolved_basename, analysis_settings, audit)
+
     return {
         "results_df": results_df,
         "tf_data": tf_data,
         "epochs": epochs,
-        "file_basename": file_basename,
+        "file_basename": resolved_basename,
+        "analysis_settings": analysis_settings,
+        "analysis_audit": audit,
     }
 
 
@@ -395,7 +656,33 @@ if __name__ == "__main__":
         dest="save_results",
         help="Do not save results to disk",
     )
+    parser.add_argument(
+        "--analysis_profile",
+        type=str,
+        default=None,
+        help="Optional ASSR analysis profile, e.g. assr_epochs",
+    )
+    parser.add_argument(
+        "--analysis_config",
+        type=str,
+        default=None,
+        help="Optional JSON object or JSON file path with ASSR analysis overrides",
+    )
 
     args = parser.parse_args()
 
-    analyze_assr(args.file_path, args.output_dir, args.save_results)
+    analysis_config = None
+    if args.analysis_config:
+        config_arg = Path(args.analysis_config)
+        if config_arg.exists():
+            analysis_config = json.loads(config_arg.read_text(encoding="utf8"))
+        else:
+            analysis_config = json.loads(args.analysis_config)
+
+    analyze_assr(
+        args.file_path,
+        args.output_dir,
+        args.save_results,
+        analysis_profile=args.analysis_profile,
+        analysis_config=analysis_config,
+    )

--- a/src/autoclean/calc/assr_runner.py
+++ b/src/autoclean/calc/assr_runner.py
@@ -7,6 +7,7 @@ It handles command line arguments and runs the appropriate functions.
 """
 
 import argparse
+import json
 
 # Make sure the current directory is in the path so modules can be imported
 import os
@@ -144,6 +145,16 @@ def create_specific_plots(analysis_results, output_dir=None):
     return {"global_itc": global_itc_fig, "topomap": topo_fig}
 
 
+def _load_analysis_config(analysis_config):
+    if not analysis_config:
+        return None
+
+    config_arg = Path(analysis_config)
+    if config_arg.exists():
+        return json.loads(config_arg.read_text(encoding="utf8"))
+    return json.loads(analysis_config)
+
+
 def main():
     """Main function to parse arguments and run analysis"""
     parser = argparse.ArgumentParser(description="ASSR Analysis Runner")
@@ -167,17 +178,30 @@ def main():
         default=None,
         help="Optional ASSR analysis profile, e.g. assr_epochs",
     )
+    parser.add_argument(
+        "--analysis_config",
+        type=str,
+        default=None,
+        help="Optional JSON object or JSON file path with ASSR analysis overrides",
+    )
 
     args = parser.parse_args()
+    analysis_config = _load_analysis_config(args.analysis_config)
 
     if args.analysis_type == "complete":
         run_complete_analysis(
-            args.file_path, args.output_dir, analysis_profile=args.analysis_profile
+            args.file_path,
+            args.output_dir,
+            analysis_profile=args.analysis_profile,
+            analysis_config=analysis_config,
         )
 
     elif args.analysis_type == "analysis_only":
         run_analysis_only(
-            args.file_path, args.output_dir, analysis_profile=args.analysis_profile
+            args.file_path,
+            args.output_dir,
+            analysis_profile=args.analysis_profile,
+            analysis_config=analysis_config,
         )
 
     elif args.analysis_type == "plots_only":
@@ -187,6 +211,7 @@ def main():
             args.output_dir,
             save_results=False,
             analysis_profile=args.analysis_profile,
+            analysis_config=analysis_config,
         )
         # Then create only specific plots
         create_specific_plots(analysis_results, args.output_dir)

--- a/src/autoclean/calc/assr_runner.py
+++ b/src/autoclean/calc/assr_runner.py
@@ -23,7 +23,12 @@ from assr_viz import plot_all_figures, plot_global_mean_itc, plot_topomap
 
 
 def run_complete_analysis(
-    file_path=None, output_dir=None, epochs=None, file_basename=None
+    file_path=None,
+    output_dir=None,
+    epochs=None,
+    file_basename=None,
+    analysis_profile=None,
+    analysis_config=None,
 ):
     """
     Run the complete analysis with all plots
@@ -69,6 +74,8 @@ def run_complete_analysis(
         save_results=True,
         epochs=epochs,
         file_basename=file_basename,
+        analysis_profile=analysis_profile,
+        analysis_config=analysis_config,
     )
 
     # Generate all plots
@@ -84,7 +91,9 @@ def run_complete_analysis(
     return analysis_results, figures
 
 
-def run_analysis_only(file_path, output_dir=None):
+def run_analysis_only(
+    file_path, output_dir=None, analysis_profile=None, analysis_config=None
+):
     """Run just the analysis without generating plots"""
     if output_dir is None:
         output_dir = Path("results")
@@ -94,7 +103,13 @@ def run_analysis_only(file_path, output_dir=None):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"Running analysis only on {file_path}")
-    analysis_results = analyze_assr(file_path, output_dir, save_results=True)
+    analysis_results = analyze_assr(
+        file_path,
+        output_dir,
+        save_results=True,
+        analysis_profile=analysis_profile,
+        analysis_config=analysis_config,
+    )
 
     print("Analysis complete!")
     return analysis_results
@@ -146,19 +161,32 @@ def main():
         default="complete",
         help="Type of analysis to run",
     )
+    parser.add_argument(
+        "--analysis_profile",
+        type=str,
+        default=None,
+        help="Optional ASSR analysis profile, e.g. assr_epochs",
+    )
 
     args = parser.parse_args()
 
     if args.analysis_type == "complete":
-        run_complete_analysis(args.file_path, args.output_dir)
+        run_complete_analysis(
+            args.file_path, args.output_dir, analysis_profile=args.analysis_profile
+        )
 
     elif args.analysis_type == "analysis_only":
-        run_analysis_only(args.file_path, args.output_dir)
+        run_analysis_only(
+            args.file_path, args.output_dir, analysis_profile=args.analysis_profile
+        )
 
     elif args.analysis_type == "plots_only":
         # First run the analysis to get the results
         analysis_results = analyze_assr(
-            args.file_path, args.output_dir, save_results=False
+            args.file_path,
+            args.output_dir,
+            save_results=False,
+            analysis_profile=args.analysis_profile,
         )
         # Then create only specific plots
         create_specific_plots(analysis_results, args.output_dir)

--- a/tests/unit/calc/test_assr_analysis_profiles.py
+++ b/tests/unit/calc/test_assr_analysis_profiles.py
@@ -1,7 +1,9 @@
+import json
 from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 import autoclean.calc.assr_runner as assr_runner
 from autoclean.calc import assr_analysis
@@ -131,6 +133,31 @@ def test_compute_metrics_preserves_legacy_default_columns_and_values():
         assert row[column] == value
 
 
+def test_compute_metrics_skips_combined_band_name_collisions():
+    audit = {"skipped_freq_bands": [], "skipped_time_windows": []}
+
+    with pytest.warns(UserWarning, match="name_conflicts_with_freq_bands"):
+        results = assr_analysis.compute_metrics(
+            _legacy_tf_data(),
+            _SingleChannelEpochs(),
+            freq_bands={"alpha": (8, 13)},
+            combined_bands={"alpha": (75, 85)},
+            audit=audit,
+        )
+
+    row = results.iloc[0]
+    freqs = _legacy_tf_data()["freqs"]
+    stp_data = _legacy_tf_data()["single_trial_power"].data[:, 0]
+    alpha_idx = np.where((freqs >= 8) & (freqs <= 13))[0]
+    combined_idx = np.where((freqs >= 75) & (freqs <= 85))[0]
+
+    assert row["stp_alpha"] == np.mean(stp_data[:, alpha_idx, :])
+    assert row["stp_alpha"] != np.mean(stp_data[:, combined_idx, :])
+    assert audit["skipped_combined_bands"] == [
+        {"name": "alpha", "reason": "name_conflicts_with_freq_bands"}
+    ]
+
+
 def test_resolve_assr_epochs_profile_and_overrides():
     settings = assr_analysis.resolve_assr_analysis_settings(
         profile="assr_epochs",
@@ -174,6 +201,42 @@ def test_compute_metrics_excludes_non_eeg_and_records_skips():
     ]
 
 
+def test_write_analysis_metadata_splits_settings_and_log_payloads(tmp_path):
+    settings = {
+        "profile": "assr_epochs",
+        "save_tfr": True,
+        "freq_bands": {"alpha": np.array([8, 13])},
+    }
+    audit = {
+        "profile": "assr_epochs",
+        "skipped_combined_bands": [
+            {"name": "alpha", "reason": "name_conflicts_with_freq_bands"}
+        ],
+    }
+
+    assr_analysis._write_analysis_metadata(tmp_path, "subject01", settings, audit)
+
+    settings_payload = json.loads(
+        (tmp_path / "subject01_assr_analysis_settings.json").read_text(encoding="utf8")
+    )
+    log_payload = json.loads(
+        (tmp_path / "subject01_assr_analysis_log.json").read_text(encoding="utf8")
+    )
+
+    assert settings_payload == {
+        "analysis_settings": {
+            "profile": "assr_epochs",
+            "save_tfr": True,
+            "freq_bands": {"alpha": [8, 13]},
+        }
+    }
+    assert "analysis_audit" not in settings_payload
+    assert log_payload["analysis_audit"] == audit
+    assert log_payload["analysis_profile"] == "assr_epochs"
+    assert log_payload["saved_tfr"] is True
+    assert "analysis_settings" not in log_payload
+
+
 def test_analyze_assr_writes_settings_and_saves_tfr_when_requested():
     epochs = _FakeEpochs()
     tf_data = _fake_tf_data()
@@ -202,6 +265,33 @@ def test_analyze_assr_writes_settings_and_saves_tfr_when_requested():
     save_tfr.assert_called_once()
     write_metadata.assert_called_once()
     assert result["analysis_settings"]["save_tfr"] is True
+
+
+def test_runner_main_forwards_analysis_config_json():
+    argv = [
+        "assr_runner.py",
+        "input.set",
+        "--output_dir",
+        "out",
+        "--analysis_type",
+        "analysis_only",
+        "--analysis_profile",
+        "assr_epochs",
+        "--analysis_config",
+        '{"save_tfr": true}',
+    ]
+
+    with (
+        patch.object(assr_runner.sys, "argv", argv),
+        patch.object(assr_runner.Path, "mkdir"),
+        patch.object(assr_runner, "analyze_assr") as analyze,
+    ):
+        analyze.return_value = {"ok": True}
+        assr_runner.main()
+
+    _, kwargs = analyze.call_args
+    assert kwargs["analysis_profile"] == "assr_epochs"
+    assert kwargs["analysis_config"] == {"save_tfr": True}
 
 
 def test_runner_passes_analysis_config_to_analyze_assr():

--- a/tests/unit/calc/test_assr_analysis_profiles.py
+++ b/tests/unit/calc/test_assr_analysis_profiles.py
@@ -1,0 +1,223 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+import autoclean.calc.assr_runner as assr_runner
+from autoclean.calc import assr_analysis
+
+
+class _FakeTFR:
+    def __init__(self, data, times=None):
+        self.data = np.asarray(data, dtype=float)
+        self.times = np.asarray(times if times is not None else [0.0, 0.1, 0.2])
+        self.saved_to = []
+
+    def save(self, output_file, overwrite=False):
+        self.saved_to.append((Path(output_file), overwrite))
+        Path(output_file).write_text("saved")
+
+
+class _FakeEpochs:
+    filename = None
+
+    def __init__(self):
+        self.ch_names = ["Cz", "HEOG", "EKG", "Status"]
+        self.drop_log = [(), ("BAD",)]
+
+    def get_channel_types(self):
+        return ["eeg", "eog", "ecg", "misc"]
+
+
+def _fake_tf_data():
+    freqs = np.array([4, 8, 12, 35, 40, 50, 70, 80, 90], dtype=float)
+    times = np.array([0.0, 0.1, 0.2, 0.6], dtype=float)
+    avg_data = np.ones((4, len(freqs), len(times)))
+    trial_data = np.ones((2, 4, len(freqs), len(times)))
+    return {
+        "power": _FakeTFR(avg_data, times),
+        "itc": (_FakeTFR(avg_data, times), _FakeTFR(avg_data * 2, times)),
+        "ersp": _FakeTFR(avg_data * 3, times),
+        "single_trial_power": _FakeTFR(trial_data * 4, times),
+        "freqs": freqs,
+    }
+
+
+def _legacy_tf_data():
+    freqs = np.array([4, 5, 8, 10, 12, 35, 40, 45, 75, 80, 85], dtype=float)
+    times = np.array([0.0, 0.1, 0.2, 2.9], dtype=float)
+    avg_data = np.arange(len(freqs) * len(times), dtype=float).reshape(
+        1, len(freqs), len(times)
+    )
+    trial_data = np.stack([avg_data + 100, avg_data + 200], axis=0)
+    return {
+        "power": _FakeTFR(avg_data, times),
+        "itc": (_FakeTFR(avg_data, times), _FakeTFR(avg_data + 1000, times)),
+        "ersp": _FakeTFR(avg_data + 2000, times),
+        "single_trial_power": _FakeTFR(trial_data),
+        "freqs": freqs,
+    }
+
+
+class _SingleChannelEpochs:
+    filename = None
+    ch_names = ["Cz"]
+    drop_log = [(), ("BAD",), ()]
+
+
+def test_compute_metrics_preserves_legacy_default_columns_and_values():
+    tf_data = _legacy_tf_data()
+    results = assr_analysis.compute_metrics(tf_data, _SingleChannelEpochs())
+    row = results.iloc[0]
+
+    assert results.columns.tolist() == [
+        "eegid",
+        "trials",
+        "chan",
+        "rejtrials",
+        "stp_gamma",
+        "stp_gamma1",
+        "stp_gamma2",
+        "stp_alpha",
+        "stp_theta",
+        "ersp_gamma",
+        "ersp_gamma1",
+        "ersp_gamma2",
+        "ersp_alpha",
+        "ersp_theta",
+        "itc40",
+        "itc80",
+        "itconset",
+        "itcoffset",
+    ]
+    assert row["eegid"] == "synthetic_epochs"
+    assert row["trials"] == 3
+    assert row["chan"] == "Cz"
+    assert row["rejtrials"] == 1
+
+    freqs = tf_data["freqs"]
+    times = tf_data["itc"][1].times
+    itc_data = tf_data["itc"][1].data[0]
+    stp_data = tf_data["single_trial_power"].data[:, 0]
+    ersp_data = tf_data["ersp"].data[0]
+
+    def freq_idx(fmin, fmax):
+        return np.where((freqs >= fmin) & (freqs <= fmax))[0]
+
+    def time_idx(tmin, tmax):
+        return np.where((times >= tmin) & (times <= tmax))[0]
+
+    all_time = time_idx(0, 3.0)
+    onset_time = time_idx(0.092, 0.308)
+    offset_time = time_idx(2.8, 3.0)
+
+    expected = {
+        "itc40": np.mean(itc_data[freq_idx(35, 45)][:, all_time]),
+        "itc80": np.mean(itc_data[freq_idx(75, 85)][:, all_time]),
+        "itconset": np.mean(itc_data[freq_idx(2, 13)][:, onset_time]),
+        "itcoffset": np.mean(itc_data[freq_idx(2, 13)][:, offset_time]),
+        "stp_alpha": np.mean(stp_data[:, freq_idx(8, 13), :]),
+        "stp_theta": np.mean(stp_data[:, freq_idx(4, 7), :]),
+        "stp_gamma1": np.mean(stp_data[:, freq_idx(30, 55), :]),
+        "stp_gamma2": np.mean(stp_data[:, freq_idx(65, 80), :]),
+        "stp_gamma": np.mean(stp_data[:, freq_idx(30, 80), :]),
+        "ersp_alpha": np.mean(ersp_data[freq_idx(8, 13), :]),
+        "ersp_theta": np.mean(ersp_data[freq_idx(4, 7), :]),
+        "ersp_gamma1": np.mean(ersp_data[freq_idx(30, 55), :]),
+        "ersp_gamma2": np.mean(ersp_data[freq_idx(65, 80), :]),
+        "ersp_gamma": np.mean(ersp_data[freq_idx(30, 80), :]),
+    }
+    for column, value in expected.items():
+        assert row[column] == value
+
+
+def test_resolve_assr_epochs_profile_and_overrides():
+    settings = assr_analysis.resolve_assr_analysis_settings(
+        profile="assr_epochs",
+        overrides={"save_tfr": True, "time_windows": {"all": (0.0, 0.5)}},
+    )
+
+    assert settings["profile"] == "assr_epochs"
+    assert settings["save_tfr"] is True
+    assert settings["time_windows"]["all"] == (0.0, 0.5)
+    assert settings["time_windows"]["itc_onset"] == (0.092, 0.308)
+    assert settings["combined_bands"]["gamma_combined"] == [(30, 55), (65, 80)]
+
+
+def test_compute_metrics_excludes_non_eeg_and_records_skips():
+    audit = {"skipped_freq_bands": [], "skipped_time_windows": []}
+
+    results = assr_analysis.compute_metrics(
+        _fake_tf_data(),
+        _FakeEpochs(),
+        freq_bands={"alpha": (8, 13), "missing": None, "too_high": (120, 130)},
+        time_windows={"all": (0, 0.2), "bad_window": (3, 4)},
+        combined_bands={"gamma_combined": [(35, 40), (70, 80)]},
+        exclude_channel_types=["eog", "ecg", "misc"],
+        audit=audit,
+    )
+
+    assert results["chan"].tolist() == ["Cz"]
+    assert "stp_gamma_combined" in results.columns
+    assert "ersp_gamma_combined" in results.columns
+    assert audit["excluded_channels"] == [
+        {"channel": "HEOG", "type": "eog"},
+        {"channel": "EKG", "type": "ecg"},
+        {"channel": "Status", "type": "misc"},
+    ]
+    assert {item["name"] for item in audit["skipped_freq_bands"]} >= {
+        "missing",
+        "too_high",
+    }
+    assert audit["skipped_time_windows"] == [
+        {"name": "bad_window", "reason": "outside_epoch_range"}
+    ]
+
+
+def test_analyze_assr_writes_settings_and_saves_tfr_when_requested():
+    epochs = _FakeEpochs()
+    tf_data = _fake_tf_data()
+
+    with (
+        patch.object(
+            assr_analysis, "compute_time_frequency", return_value=tf_data
+        ) as compute,
+        patch.object(assr_analysis.Path, "mkdir") as mkdir,
+        patch("autoclean.calc.assr_analysis.pd.DataFrame.to_csv") as to_csv,
+        patch.object(assr_analysis, "_save_tfr_artifacts") as save_tfr,
+        patch.object(assr_analysis, "_write_analysis_metadata") as write_metadata,
+    ):
+        result = assr_analysis.analyze_assr(
+            output_dir="out",
+            save_results=True,
+            epochs=epochs,
+            file_basename="subject01",
+            analysis_profile="assr_epochs",
+            analysis_config={"save_tfr": True},
+        )
+
+    compute.assert_called_once_with(epochs, baseline=(-0.2, 0.0))
+    assert mkdir.call_count >= 1
+    to_csv.assert_called_once()
+    save_tfr.assert_called_once()
+    write_metadata.assert_called_once()
+    assert result["analysis_settings"]["save_tfr"] is True
+
+
+def test_runner_passes_analysis_config_to_analyze_assr():
+    with (
+        patch.object(assr_runner.Path, "mkdir"),
+        patch.object(assr_runner, "analyze_assr") as analyze,
+    ):
+        analyze.return_value = {"ok": True}
+        result = assr_runner.run_analysis_only(
+            "input.set",
+            "out",
+            analysis_profile="assr_epochs",
+            analysis_config={"save_tfr": True},
+        )
+
+    assert result == {"ok": True}
+    _, kwargs = analyze.call_args
+    assert kwargs["analysis_profile"] == "assr_epochs"
+    assert kwargs["analysis_config"] == {"save_tfr": True}


### PR DESCRIPTION
## Summary
- Add configurable ASSR analysis settings and an assr_epochs profile.
- Support analysis config overrides for windows, bands, combined bands, baseline, channel-type exclusion, and optional TFR saving.
- Exclude non-EEG channel types for the assr_epochs profile while preserving legacy defaults when no profile/config is supplied.
- Write analysis settings/audit metadata and expose profile selection through the direct CLI and runner entry point.
- Preserve legacy metric column ordering and add regression coverage for default metric values.

## Verification
- python -B -m pytest -p no:cacheprovider --no-cov --basetemp=.\\pytest-codex-temp tests\\unit\\calc\\test_assr_analysis_profiles.py -q
- python -B -m ruff check src\\autoclean\\calc\\assr_analysis.py src\\autoclean\\calc\\assr_runner.py tests\\unit\\calc\\test_assr_analysis_profiles.py
- git diff --check

## Notes
- Draft PR for issue #220.
- Focused pytest passed with expected warnings for intentionally skipped invalid bands/windows in the test fixture.