### PR TITLE
fix: scope Queue detail retry

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -495,7 +495,8 @@ export const api = {
   getQueueStats: () => json<QueueStats>("/api/queue/stats"),
   getQueueEntries: (routeId?: string) =>
     json<QueueEntriesResponse>(`/api/queue/entries${routeId ? `?route_id=${encodeURIComponent(routeId)}` : ""}`),
-  retryFailed: () => json<{ retried: number }>("/api/queue/retry", "POST", {}),
+  retryFailed: (paths?: string[]) =>
+    json<{ retried: number }>("/api/queue/retry", "POST", paths ? { paths } : {}),
   clearProcessed: () => json<{ cleared: number }>("/api/queue/processed", "DELETE"),
   removeEntry: (path: string) => json<{ cleared?: number }>(`/api/queue/entry/${encodeURIComponent(path)}`, "DELETE"),
 

--- a/web/src/pages/Queue.test.tsx
+++ b/web/src/pages/Queue.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { api } = vi.hoisted(() => ({
+  api: {
+    getQueueEntries: vi.fn(),
+    getQueueStats: vi.fn(),
+    getRoutes: vi.fn(),
+    getStatus: vi.fn(),
+    retryFailed: vi.fn(),
+    clearProcessed: vi.fn(),
+    removeEntry: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/api", () => ({ api }));
+vi.mock("../contexts/TutorialContext", () => ({
+  useTutorial: () => ({ isActive: false, currentStep: 0, nextStep: vi.fn() }),
+}));
+vi.mock("../hooks/useTutorialTarget", () => ({
+  useTutorialTarget: () => null,
+}));
+
+import Queue from "./Queue";
+
+const selectedPath = "C:\\EEG data\\selected file.set";
+const otherPath = "C:\\EEG data\\other.set";
+
+function renderQueue() {
+  return render(
+    <MemoryRouter>
+      <Queue />
+    </MemoryRouter>,
+  );
+}
+
+describe("Queue retry scope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getQueueEntries.mockResolvedValue({
+      entries: [
+        {
+          path: selectedPath,
+          status: "failed",
+          route_id: "route-a",
+          last_error: "failed",
+        },
+        {
+          path: otherPath,
+          status: "failed",
+          route_id: "route-b",
+          last_error: "failed",
+        },
+      ],
+      total: 2,
+    });
+    api.getQueueStats.mockResolvedValue({
+      pending: 0,
+      processing: 0,
+      processed: 0,
+      failed: 2,
+      total: 2,
+    });
+    api.getRoutes.mockResolvedValue([]);
+    api.getStatus.mockResolvedValue({ service: { running: false } });
+    api.retryFailed.mockResolvedValue({ retried: 1 });
+  });
+
+  it("retries only the selected failed entry from the detail panel", async () => {
+    renderQueue();
+
+    fireEvent.click(await screen.findByText("selected file.set"));
+    const retryButtons = screen.getAllByRole("button", { name: "Retry Failed" });
+    expect(retryButtons).toHaveLength(2);
+
+    fireEvent.click(retryButtons[1]!);
+
+    await waitFor(() => {
+      expect(api.retryFailed).toHaveBeenCalledWith([selectedPath]);
+    });
+    expect(api.retryFailed).not.toHaveBeenCalledWith([otherPath]);
+  });
+
+  it("keeps the page-level retry action unscoped", async () => {
+    renderQueue();
+
+    const retryButton = await screen.findByRole("button", { name: "Retry Failed" });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(api.retryFailed).toHaveBeenCalledWith(undefined);
+    });
+  });
+});

--- a/web/src/pages/Queue.tsx
+++ b/web/src/pages/Queue.tsx
@@ -130,10 +130,10 @@ export default function Queue() {
     noticeTimerRef.current = setTimeout(() => setNotice(null), 4000);
   };
 
-  const handleRetry = async () => {
+  const handleRetry = async (paths?: string[]) => {
     setActing(true);
     try {
-      const res = await api.retryFailed();
+      const res = await api.retryFailed(paths);
       showNotice("success", `Retried ${res.retried} ${res.retried === 1 ? "entry" : "entries"}`);
       refresh();
       refreshStats();
@@ -199,7 +199,7 @@ export default function Queue() {
             <RefreshCw className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`} />
           </button>
           <button
-            onClick={handleRetry}
+            onClick={() => handleRetry()}
             disabled={acting || !stats?.failed}
             className="rounded-md px-3 py-1.5 text-sm font-medium border border-border text-zinc-300 hover:bg-surface-50 transition-colors duration-150 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
@@ -523,7 +523,7 @@ export default function Queue() {
             <div className="pt-2 border-t border-border-subtle space-y-2">
               {selectedEntry.status === "failed" && (
                 <button
-                  onClick={handleRetry}
+                  onClick={() => handleRetry([selectedEntry.path])}
                   disabled={acting}
                   className="w-full rounded-md px-3 py-1.5 text-sm font-medium bg-emerald-600 text-white hover:bg-emerald-500 transition-colors duration-150 flex items-center justify-center gap-2 disabled:opacity-50"
                 >


### PR DESCRIPTION
## Summary

- scope the Queue detail retry action to the selected failed entry
- preserve the page-level retry-all action
- add focused regression coverage for both behaviors

## Root cause

Both controls shared a parameterless frontend handler even though the backend supports an optional list of paths.

## Validation

- Queue focused tests: 2 passed
- TypeScript no-emit validation passed
- independent Cricket QA passed

Closes #242
