### PR TITLE
fix: support Windows folder breadcrumbs

### DIFF
--- a/web/src/components/FolderBrowser.test.ts
+++ b/web/src/components/FolderBrowser.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { pathSegments } from "./FolderBrowser";
+
+describe("FolderBrowser pathSegments", () => {
+  it("preserves native Windows drive paths", () => {
+    expect(pathSegments("C:\\Users\\Researcher\\EEG data")).toEqual([
+      { label: "C:\\", path: "C:\\" },
+      { label: "Users", path: "C:\\Users" },
+      { label: "Researcher", path: "C:\\Users\\Researcher" },
+      { label: "EEG data", path: "C:\\Users\\Researcher\\EEG data" },
+    ]);
+  });
+
+  it("preserves Windows drive paths that use forward slashes", () => {
+    expect(pathSegments("D:/Data/Session 01")).toEqual([
+      { label: "D:/", path: "D:/" },
+      { label: "Data", path: "D:/Data" },
+      { label: "Session 01", path: "D:/Data/Session 01" },
+    ]);
+  });
+
+  it("preserves UNC server and share roots", () => {
+    expect(pathSegments("\\\\server\\share\\study\\subject-01")).toEqual([
+      { label: "\\\\server\\share", path: "\\\\server\\share" },
+      { label: "study", path: "\\\\server\\share\\study" },
+      {
+        label: "subject-01",
+        path: "\\\\server\\share\\study\\subject-01",
+      },
+    ]);
+  });
+
+  it("keeps POSIX breadcrumbs unchanged", () => {
+    expect(pathSegments("/home/researcher/data")).toEqual([
+      { label: "/", path: "/" },
+      { label: "home", path: "/home" },
+      { label: "researcher", path: "/home/researcher" },
+      { label: "data", path: "/home/researcher/data" },
+    ]);
+  });
+});

--- a/web/src/components/FolderBrowser.tsx
+++ b/web/src/components/FolderBrowser.tsx
@@ -12,12 +12,41 @@ interface FolderBrowserProps {
 // ── Breadcrumb helpers ────────────────────────────────────────────────────────
 
 /** Split an absolute path into labelled segments for breadcrumb rendering. */
-function pathSegments(absPath: string): { label: string; path: string }[] {
-  // Normalise to forward-slash (safe on all platforms served from Python)
+export function pathSegments(absPath: string): { label: string; path: string }[] {
+  const driveMatch = /^([A-Za-z]:)([\\/])(.*)$/.exec(absPath);
+  if (driveMatch) {
+    const drive = driveMatch[1]!;
+    const separator = driveMatch[2]!;
+    const remainder = driveMatch[3]!;
+    const root = `${drive}${separator}`;
+    const segments = [{ label: root, path: root }];
+    let accumulated = root;
+    for (const part of remainder.split(/[\\/]+/).filter(Boolean)) {
+      accumulated += `${accumulated.endsWith(separator) ? "" : separator}${part}`;
+      segments.push({ label: part, path: accumulated });
+    }
+    return segments;
+  }
+
+  const uncMatch = /^([\\/]{2})([^\\/]+)[\\/]([^\\/]+)(.*)$/.exec(absPath);
+  if (uncMatch) {
+    const prefix = uncMatch[1]!;
+    const server = uncMatch[2]!;
+    const share = uncMatch[3]!;
+    const remainder = uncMatch[4]!;
+    const separator = prefix[0];
+    const root = `${separator}${separator}${server}${separator}${share}`;
+    const segments = [{ label: root, path: root }];
+    let accumulated = root;
+    for (const part of remainder.split(/[\\/]+/).filter(Boolean)) {
+      accumulated += `${separator}${part}`;
+      segments.push({ label: part, path: accumulated });
+    }
+    return segments;
+  }
+
   const parts = absPath.split("/").filter(Boolean);
-  const segments: { label: string; path: string }[] = [
-    { label: "/", path: "/" },
-  ];
+  const segments = [{ label: "/", path: "/" }];
   let accumulated = "";
   for (const part of parts) {
     accumulated += "/" + part;
@@ -115,7 +144,7 @@ export default function FolderBrowser({ onSelect, onClose }: FolderBrowserProps)
             <div className="flex items-center gap-0.5 min-w-0 font-mono text-xs text-zinc-400 whitespace-nowrap">
               {segments.map((seg, idx) => {
                 const isLast = idx === segments.length - 1;
-                const isRoot = seg.path === "/";
+                const isRoot = idx === 0;
                 return (
                   <span key={seg.path} className="flex items-center gap-0.5">
                     {idx > 0 && (


### PR DESCRIPTION
## Summary

- preserve Windows drive and UNC path syntax in folder breadcrumbs
- keep POSIX breadcrumb behavior unchanged
- cover native Windows, forward-slash drive, UNC, and POSIX paths

## Root cause

The breadcrumb helper split only on `/` and reconstructed every path as POSIX, producing invalid navigation paths on Windows hosts.

## Validation

- FolderBrowser focused tests: 4 passed
- TypeScript no-emit validation passed
- independent Cricket QA passed

Closes #243
