### PR TITLE
fix: show tunnel configuration errors

### DIFF
--- a/web/src/components/TopBar.test.tsx
+++ b/web/src/components/TopBar.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { api } = vi.hoisted(() => ({
+  api: {
+    getHealth: vi.fn(),
+    getTunnelStatus: vi.fn(),
+    startTunnel: vi.fn(),
+    stopTunnel: vi.fn(),
+    getTunnelConfig: vi.fn(),
+    setTunnelConfig: vi.fn(),
+    clearTunnelConfig: vi.fn(),
+    switchMode: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/api", () => ({ api }));
+vi.mock("../hooks/usePolling", () => ({
+  usePolling: (fetcher: unknown) => ({
+    data:
+      fetcher === api.getHealth
+        ? { mode: "test" }
+        : { active: false, url: null, password: null, mode: null },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  }),
+}));
+vi.mock("../contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: "dark", toggle: vi.fn() }),
+}));
+
+import TopBar from "./TopBar";
+
+async function openConfig() {
+  render(
+    <MemoryRouter>
+      <TopBar />
+    </MemoryRouter>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Share" }));
+  await screen.findByText("Share Publicly");
+  fireEvent.click(screen.getByRole("button", { name: "Configure permanent tunnel" }));
+  await screen.findByText("Named Tunnel Setup");
+}
+
+describe("TopBar tunnel configuration errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.startTunnel.mockResolvedValue({ success: true });
+    api.getTunnelConfig.mockResolvedValue({ url: "" });
+  });
+
+  it("shows a retryable error when saving tunnel configuration fails", async () => {
+    api.setTunnelConfig.mockRejectedValue(new Error("Token was rejected"));
+    await openConfig();
+
+    fireEvent.change(screen.getByPlaceholderText("eyJhIjoi..."), {
+      target: { value: "bad-token" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("https://eeg-lab.example.com"), {
+      target: { value: "https://eeg.example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText("Could not save tunnel configuration. Check the values and try again."),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
+    expect(api.setTunnelConfig).toHaveBeenCalledWith(
+      "bad-token",
+      "https://eeg.example.com",
+    );
+  });
+
+  it("shows a retryable error when clearing tunnel configuration fails", async () => {
+    api.clearTunnelConfig.mockRejectedValue(new Error("Configuration could not be cleared"));
+    await openConfig();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(
+      await screen.findByText("Could not clear tunnel configuration. Try again."),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Clear" })).toBeEnabled();
+    });
+    expect(api.clearTunnelConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -69,6 +69,7 @@ export default function TopBar({ onToggleSidebar }: TopBarProps) {
   const [configToken, setConfigToken] = useState("");
   const [configUrl, setConfigUrl] = useState("");
   const [configSaving, setConfigSaving] = useState(false);
+  const [configError, setConfigError] = useState<string | null>(null);
   const [configLoaded, setConfigLoaded] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
 
@@ -286,6 +287,7 @@ export default function TopBar({ onToggleSidebar }: TopBarProps) {
                     </p>
                     <button
                       onClick={() => {
+                        setConfigError(null);
                         setShowConfig(true);
                         if (!configLoaded) {
                           api.getTunnelConfig().then((cfg) => {
@@ -342,16 +344,22 @@ export default function TopBar({ onToggleSidebar }: TopBarProps) {
                         className="w-full px-2 py-1.5 rounded bg-surface-50 border border-border text-xs font-mono text-zinc-300 placeholder-zinc-700 focus:outline-none focus:border-brand/40"
                       />
                     </div>
+                    {configError && (
+                      <div className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+                        {configError}
+                      </div>
+                    )}
                     <div className="flex gap-2">
                       <button
                         onClick={async () => {
                           setConfigSaving(true);
+                          setConfigError(null);
                           try {
                             await api.setTunnelConfig(configToken, configUrl);
                             setConfigToken("");
                             setShowConfig(false);
                           } catch {
-                            // ignore
+                            setConfigError("Could not save tunnel configuration. Check the values and try again.");
                           } finally {
                             setConfigSaving(false);
                           }
@@ -363,12 +371,21 @@ export default function TopBar({ onToggleSidebar }: TopBarProps) {
                       </button>
                       <button
                         onClick={async () => {
-                          await api.clearTunnelConfig();
-                          setConfigToken("");
-                          setConfigUrl("");
-                          setConfigLoaded(false);
+                          setConfigSaving(true);
+                          setConfigError(null);
+                          try {
+                            await api.clearTunnelConfig();
+                            setConfigToken("");
+                            setConfigUrl("");
+                            setConfigLoaded(false);
+                          } catch {
+                            setConfigError("Could not clear tunnel configuration. Try again.");
+                          } finally {
+                            setConfigSaving(false);
+                          }
                         }}
-                        className="rounded-md px-3 py-1.5 text-xs font-medium border border-border text-zinc-500 hover:text-zinc-300 hover:bg-surface-50 transition-colors"
+                        disabled={configSaving}
+                        className="rounded-md px-3 py-1.5 text-xs font-medium border border-border text-zinc-500 hover:text-zinc-300 hover:bg-surface-50 disabled:opacity-40 transition-colors"
                       >
                         Clear
                       </button>


### PR DESCRIPTION
## Summary

- show operation-specific retry guidance when tunnel configuration Save or Clear fails
- keep controls retryable after rejected requests
- preserve successful configuration transitions

## Root cause

Save silently swallowed failures and Clear allowed an unhandled rejection, leaving operators without an actionable error state.

## Validation

- TopBar focused tests: 2 passed
- TypeScript no-emit validation passed
- independent Cricket QA passed

Closes #244
