### PR TITLE
fix: gate Apply on configuration validation

### DIFF
--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { api } = vi.hoisted(() => ({
+  api: {
+    getConfigYaml: vi.fn(),
+    getHealth: vi.fn(),
+    validateConfig: vi.fn(),
+    deployConfig: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/api", () => ({ api }));
+vi.mock("../hooks/usePolling", () => ({
+  usePolling: (fetcher: unknown) => ({
+    data:
+      fetcher === api.getConfigYaml
+        ? { content: "tasks: {}" }
+        : { mode: "test" },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  }),
+}));
+vi.mock("../contexts/TutorialContext", () => ({
+  useTutorial: () => ({ isActive: false, currentStep: 0, nextStep: vi.fn() }),
+}));
+vi.mock("../hooks/useTutorialTarget", () => ({
+  useTutorialTarget: () => null,
+}));
+
+import Settings from "./Settings";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const validResult = {
+  valid: true,
+  errors: [],
+  warnings: [],
+};
+
+describe("Settings Apply validation gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps Apply disabled until initial validation finishes", async () => {
+    const validation = deferred<typeof validResult>();
+    api.validateConfig.mockReturnValue(validation.promise);
+
+    render(<Settings />);
+
+    const applyButton = screen.getByRole("button", { name: "Apply" });
+    expect(applyButton).toBeDisabled();
+    expect(applyButton).toHaveAttribute("title", "Wait for validation to finish");
+
+    validation.resolve(validResult);
+
+    await waitFor(() => expect(applyButton).toBeEnabled());
+  });
+
+  it("disables Apply during revalidation and re-enables it for warnings", async () => {
+    const revalidation = deferred<{
+      valid: boolean;
+      errors: string[];
+      warnings: string[];
+    }>();
+    api.validateConfig
+      .mockResolvedValueOnce(validResult)
+      .mockReturnValueOnce(revalidation.promise);
+
+    render(<Settings />);
+
+    const applyButton = screen.getByRole("button", { name: "Apply" });
+    await waitFor(() => expect(applyButton).toBeEnabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    expect(applyButton).toBeDisabled();
+
+    revalidation.resolve({
+      valid: true,
+      errors: [],
+      warnings: ["Review this setting"],
+    });
+
+    await waitFor(() => expect(applyButton).toBeEnabled());
+  });
+});

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -113,8 +113,14 @@ export default function Settings() {
           <button
             ref={applyButtonRef}
             onClick={handleDeploy}
-            disabled={deploying || status === "errors"}
-            title={status === "errors" ? "Fix errors before applying" : "Copy config to deploy/"}
+            disabled={deploying || validating || !validation || status === "errors"}
+            title={
+              validating || !validation
+                ? "Wait for validation to finish"
+                : status === "errors"
+                  ? "Fix errors before applying"
+                  : "Copy config to deploy/"
+            }
             className="rounded-md px-3 py-1.5 text-sm font-medium bg-brand text-surface-500 hover:bg-brand-500 transition-colors duration-150 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Upload className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary

- disable Settings Apply while validation is pending or running
- retain existing deployment/error gating
- preserve deployment when validation returns warnings

## Root cause

The Apply button only considered deployment and error states, so it was actionable before initial validation resolved and during revalidation.

## Validation

- Settings focused tests: 2 passed
- TypeScript no-emit validation passed
- independent Cricket QA passed

Closes #245
