### PR TITLE
fix: preserve Exclude autosave route

### DIFF
--- a/web/src/pages/Exclude.test.tsx
+++ b/web/src/pages/Exclude.test.tsx
@@ -300,6 +300,59 @@ describe("ExcludePage", () => {
     }, { timeout: 1500 });
   });
 
+  it("flushes pending autosaves with the route that created them", async () => {
+    api.getRoutes.mockResolvedValue([
+      {
+        id: "route-1",
+        enabled: true,
+        archived: false,
+        modes: ["live"],
+        taskfile: "RestingState_Basic.py",
+        montage: "GSN-HydroCel-129",
+        ingestion_folders: [],
+        file_globs: ["*.set"],
+        recursive: true,
+      },
+      {
+        id: "route-2",
+        enabled: true,
+        archived: false,
+        modes: ["live"],
+        taskfile: "RestingState_Basic.py",
+        montage: "GSN-HydroCel-129",
+        ingestion_folders: [],
+        file_globs: ["*.set"],
+        recursive: true,
+      },
+    ]);
+    renderPage();
+
+    await screen.findByText("Focused epoch: 1");
+    fireEvent.keyDown(document, { key: " " });
+    await screen.findByText("Saving…");
+    fireEvent.change(screen.getByPlaceholderText("Add reviewer notes..."), {
+      target: { value: "pending route-one note" },
+    });
+
+    fireEvent.change(screen.getByLabelText("Route"), {
+      target: { value: "route-2" },
+    });
+
+    await waitFor(() => {
+      expect(api.saveExcludeEpochReview).toHaveBeenCalledWith(
+        "subject01_comp_epo",
+        expect.any(Array),
+        "route-1",
+      );
+      expect(api.saveExcludeNotes).toHaveBeenCalledWith(
+        "subject01_comp_epo",
+        "pending route-one note",
+        "REVIEW",
+        "route-1",
+      );
+    });
+  });
+
   it("adds and removes manual overrides, then saves them", async () => {
     renderPage();
 

--- a/web/src/pages/Exclude.tsx
+++ b/web/src/pages/Exclude.tsx
@@ -631,8 +631,17 @@ export default function ExcludePage() {
   const { data: routes } = usePolling<RouteSpec[]>(api.getRoutes, 30000);
   const epochSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const notesSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastEpochSaveRef = useRef<{ fileKey: string; badEpochs: number[] } | null>(null);
-  const lastNotesSaveRef = useRef<{ fileKey: string; notes: string; status: string } | null>(null);
+  const lastEpochSaveRef = useRef<{
+    fileKey: string;
+    badEpochs: number[];
+    route?: string;
+  } | null>(null);
+  const lastNotesSaveRef = useRef<{
+    fileKey: string;
+    notes: string;
+    status: string;
+    route?: string;
+  } | null>(null);
   const loadedManualBadChannelsRef = useRef<string[]>([]);
   const loadedManualRejectedIcaRef = useRef<number[]>([]);
   const routeOptions = useMemo(() => {
@@ -755,7 +764,7 @@ export default function ExcludePage() {
     }
     setSaveState("saving");
     try {
-      const result = await api.saveExcludeEpochReview(pending.fileKey, pending.badEpochs, selectedRoute || undefined);
+      const result = await api.saveExcludeEpochReview(pending.fileKey, pending.badEpochs, pending.route);
       setActionError(typeof result.warning === "string" && result.warning ? result.warning : null);
       setSaveState("saved");
       lastEpochSaveRef.current = null;
@@ -774,7 +783,7 @@ export default function ExcludePage() {
     }
     setSaveState("saving");
     try {
-      await api.saveExcludeNotes(pending.fileKey, pending.notes, pending.status, selectedRoute || undefined);
+      await api.saveExcludeNotes(pending.fileKey, pending.notes, pending.status, pending.route);
       setSaveState("saved");
       lastNotesSaveRef.current = null;
     } catch {
@@ -1007,10 +1016,15 @@ export default function ExcludePage() {
   function scheduleEpochSave(nextBadEpochs: number[]) {
     if (!selectedKey) return;
     setSaveState("saving");
-    lastEpochSaveRef.current = { fileKey: selectedKey, badEpochs: nextBadEpochs };
+    const pending = {
+      fileKey: selectedKey,
+      badEpochs: nextBadEpochs,
+      route: selectedRoute || undefined,
+    };
+    lastEpochSaveRef.current = pending;
     if (epochSaveTimer.current) clearTimeout(epochSaveTimer.current);
     epochSaveTimer.current = setTimeout(() => {
-      api.saveExcludeEpochReview(selectedKey, nextBadEpochs, selectedRoute || undefined)
+      api.saveExcludeEpochReview(pending.fileKey, pending.badEpochs, pending.route)
         .then((result) => {
           setActionError(typeof result.warning === "string" && result.warning ? result.warning : null);
           setSaveState("saved");
@@ -1044,10 +1058,16 @@ export default function ExcludePage() {
   function scheduleNotesSave(nextNotes: string, nextStatus: string) {
     if (!selectedKey) return;
     setSaveState("saving");
-    lastNotesSaveRef.current = { fileKey: selectedKey, notes: nextNotes, status: nextStatus };
+    const pending = {
+      fileKey: selectedKey,
+      notes: nextNotes,
+      status: nextStatus,
+      route: selectedRoute || undefined,
+    };
+    lastNotesSaveRef.current = pending;
     if (notesSaveTimer.current) clearTimeout(notesSaveTimer.current);
     notesSaveTimer.current = setTimeout(() => {
-      api.saveExcludeNotes(selectedKey, nextNotes, nextStatus, selectedRoute || undefined)
+      api.saveExcludeNotes(pending.fileKey, pending.notes, pending.status, pending.route)
         .then(() => {
           setSaveState("saved");
           lastNotesSaveRef.current = null;


### PR DESCRIPTION
## Summary

- retain the originating route in pending Exclude epoch and notes payloads
- use that stored route for debounced and forced cleanup/pagehide saves
- add a route-switch regression covering both save types

## Root cause

Cleanup callbacks captured the initial render's route and pending payloads did not carry their route identity, allowing navigation-time saves to target the wrong context.

## Validation

- focused route-switch regression passed
- full Exclude suite: 17 passed
- TypeScript no-emit validation passed
- independent Cricket QA passed

Closes #246
