### PR TITLE
Fix mobile dialog overflow

### DIFF
--- a/web/src/components/DialogWidth.test.ts
+++ b/web/src/components/DialogWidth.test.ts
@@ -1,0 +1,21 @@
+// @ts-expect-error -- tests run in Node; the browser app intentionally omits Node types.
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const dialogSources = [
+  "src/components/FolderBrowser.tsx",
+  "src/components/KeyboardShortcutsHelp.tsx",
+  "src/components/tutorial/TutorialWelcome.tsx",
+  "src/components/tutorial/TutorialComplete.tsx",
+  "src/pages/Routes.tsx",
+];
+
+describe("mobile dialog widths", () => {
+  it.each(dialogSources)("keeps 16px viewport gutters in %s", (path) => {
+    const source = readFileSync(path, "utf8");
+
+    expect(source).toContain("w-[calc(100%-2rem)]");
+    expect(source).not.toMatch(/w-full max-w-(?:md|lg|xl)[^"]*mx-4/);
+  });
+});

--- a/web/src/components/FolderBrowser.tsx
+++ b/web/src/components/FolderBrowser.tsx
@@ -97,7 +97,7 @@ export default function FolderBrowser({ onSelect, onClose }: FolderBrowserProps)
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-full max-w-lg mx-4 rounded-lg border border-border bg-surface-200 shadow-2xl flex flex-col max-h-[80vh]">
+      <div className="w-[calc(100%-2rem)] max-w-lg rounded-lg border border-border bg-surface-200 shadow-2xl flex flex-col max-h-[80vh]">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
           <span className="text-sm font-semibold text-zinc-200">Browse Folders</span>

--- a/web/src/components/KeyboardShortcutsHelp.tsx
+++ b/web/src/components/KeyboardShortcutsHelp.tsx
@@ -35,7 +35,7 @@ export default function KeyboardShortcutsHelp({ open, onClose }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
       <div
-        className="bg-surface-200 border border-border rounded-xl shadow-2xl w-full max-w-md mx-4"
+        className="bg-surface-200 border border-border rounded-xl shadow-2xl w-[calc(100%-2rem)] max-w-md"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">

--- a/web/src/components/tutorial/TutorialComplete.tsx
+++ b/web/src/components/tutorial/TutorialComplete.tsx
@@ -29,7 +29,7 @@ export default function TutorialComplete() {
   return (
     <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 backdrop-blur-sm">
       <div
-        className="w-full max-w-md mx-4 rounded-xl border border-border bg-surface-200 p-8 shadow-2xl"
+        className="w-[calc(100%-2rem)] max-w-md rounded-xl border border-border bg-surface-200 p-8 shadow-2xl"
         style={{ animation: "tutorial-enter 0.25s ease-out both" }}
       >
         {/* Checkmark */}

--- a/web/src/components/tutorial/TutorialWelcome.tsx
+++ b/web/src/components/tutorial/TutorialWelcome.tsx
@@ -26,7 +26,7 @@ export default function TutorialWelcome() {
   return (
     <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 backdrop-blur-sm">
       <div
-        className="w-full max-w-md mx-4 rounded-xl border border-border bg-surface-200 p-8 shadow-2xl"
+        className="w-[calc(100%-2rem)] max-w-md rounded-xl border border-border bg-surface-200 p-8 shadow-2xl"
         style={{ animation: "tutorial-enter 0.25s ease-out both" }}
       >
         {/* Icon */}

--- a/web/src/pages/Routes.tsx
+++ b/web/src/pages/Routes.tsx
@@ -757,7 +757,7 @@ export default function RoutesPage() {
 
       {showModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-          <div ref={routeModalRef} className="w-full max-w-xl rounded-lg border border-border bg-surface-200 p-4 sm:p-6 mx-4 sm:mx-auto max-h-[90vh] overflow-y-auto">
+          <div ref={routeModalRef} className="w-[calc(100%-2rem)] max-w-xl rounded-lg border border-border bg-surface-200 p-4 sm:p-6 max-h-[90vh] overflow-y-auto">
             <div className="flex items-center justify-between mb-5">
               <h3 className="text-lg font-semibold text-zinc-100">
                 {editingRoute ? "Edit Route" : "New Route"}


### PR DESCRIPTION
## Summary
- Replace mobile dialog `w-full` plus margin patterns with explicit viewport-gutter widths.
- Apply the containment fix across FolderBrowser, keyboard shortcuts, tutorial dialogs, and the Routes modal.
- Add a focused regression test that checks dialog sources keep 16px viewport gutters.

## Root cause
Several centered dialogs combined full-width sizing with horizontal margins, which could overflow narrow mobile viewports instead of preserving consistent gutters.

## Validation
- Focused Vitest: 5/5 passed
- TypeScript passed
- Echo reported no blockers
- Cricket QA passed

Closes #257