### PR TITLE
feat: summarize EEGLAB provenance on import

### DIFF
--- a/src/autoclean/io/eeglab_provenance.py
+++ b/src/autoclean/io/eeglab_provenance.py
@@ -10,8 +10,13 @@ blank/ambiguous, and ``"unavailable"`` when the field is absent.
 from __future__ import annotations
 
 import csv
+import io
 import json
+import os
+import tempfile
+import time
 from collections import Counter
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -24,6 +29,9 @@ UNAVAILABLE = "unavailable"
 SCHEMA_VERSION = "1.0"
 DATASET_JSON_NAME = "dataset_eeglab_provenance.json"
 DATASET_TABLE_NAME = "dataset_eeglab_provenance.csv"
+DATASET_LOCK_NAME = "dataset_eeglab_provenance.lock"
+DATASET_LOCK_TIMEOUT_SECONDS = 10.0
+DATASET_LOCK_RETRY_SECONDS = 0.05
 
 
 def extract_eeglab_provenance(file_path: Path) -> dict[str, Any]:
@@ -87,7 +95,7 @@ def write_eeglab_provenance_artifacts(
         "report": str(report_path),
     }
     summary["artifact_paths"] = artifact_paths
-    json_path.write_text(json.dumps(_json_safe(summary), indent=2), encoding="utf-8")
+    _atomic_write_text(json_path, json.dumps(_json_safe(summary), indent=2))
     report_path.write_text(render_eeglab_provenance_report(summary), encoding="utf-8")
     return artifact_paths
 
@@ -96,31 +104,106 @@ def write_eeglab_dataset_artifacts(output_dir: Path) -> dict[str, str]:
     """Aggregate all per-file provenance summaries and persist dataset artifacts."""
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    summaries = []
-    for json_path in sorted(output_dir.glob("*_eeglab_provenance.json")):
-        if json_path.name == DATASET_JSON_NAME:
-            continue
-        summary = json.loads(json_path.read_text(encoding="utf-8"))
-        if isinstance(summary, dict) and isinstance(summary.get("summary_row"), dict):
-            summaries.append(summary)
-
-    dataset_summary = build_eeglab_dataset_summary(summaries)
     json_path = output_dir / DATASET_JSON_NAME
     table_path = output_dir / DATASET_TABLE_NAME
     artifact_paths = {"json": str(json_path), "table": str(table_path)}
-    dataset_summary["artifact_paths"] = artifact_paths
-    json_path.write_text(
-        json.dumps(_json_safe(dataset_summary), indent=2), encoding="utf-8"
-    )
 
-    rows = dataset_summary["rows"]
+    with _dataset_artifact_lock(output_dir):
+        summaries = []
+        for source_path in sorted(output_dir.glob("*_eeglab_provenance.json")):
+            if source_path.name == DATASET_JSON_NAME:
+                continue
+            summary = json.loads(source_path.read_text(encoding="utf-8"))
+            if isinstance(summary, dict) and isinstance(
+                summary.get("summary_row"), dict
+            ):
+                summaries.append(summary)
+
+        dataset_summary = build_eeglab_dataset_summary(summaries)
+        dataset_summary["artifact_paths"] = artifact_paths
+        _atomic_write_text(json_path, json.dumps(_json_safe(dataset_summary), indent=2))
+        _atomic_write_text(
+            table_path, _render_dataset_table(dataset_summary["rows"]), newline=""
+        )
+
+    return artifact_paths
+
+
+def _render_dataset_table(rows: list[dict[str, Any]]) -> str:
     keys = {key for row in rows for key in row}
     fieldnames = ["source_file", *sorted(keys - {"source_file"})]
-    with table_path.open("w", newline="", encoding="utf-8") as csv_file:
-        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
-        writer.writeheader()
-        writer.writerows(rows)
-    return artifact_paths
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _atomic_write_text(path: Path, payload: str, *, newline: str | None = None) -> None:
+    """Replace a text artifact only after its complete payload is durable."""
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(
+            descriptor, "w", encoding="utf-8", newline=newline
+        ) as temporary_file:
+            temporary_file.write(payload)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def _dataset_artifact_lock(output_dir: Path):
+    """Serialize the dataset scan/build/replace transaction across processes."""
+
+    lock_path = output_dir / DATASET_LOCK_NAME
+    with lock_path.open("a+b") as lock_file:
+        if os.fstat(lock_file.fileno()).st_size == 0:
+            lock_file.seek(0)
+            lock_file.write(b"\0")
+            lock_file.flush()
+        _acquire_dataset_lock(lock_file)
+        try:
+            yield
+        finally:
+            lock_file.seek(0)
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _acquire_dataset_lock(lock_file: Any) -> None:
+    deadline = time.monotonic() + DATASET_LOCK_TIMEOUT_SECONDS
+    while True:
+        lock_file.seek(0)
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except OSError as error:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Timed out acquiring EEGLAB dataset lock: {lock_file.name}"
+                ) from error
+            time.sleep(min(DATASET_LOCK_RETRY_SECONDS, remaining))
 
 
 def render_eeglab_provenance_report(summary: dict[str, Any]) -> str:

--- a/src/autoclean/io/eeglab_provenance.py
+++ b/src/autoclean/io/eeglab_provenance.py
@@ -9,6 +9,7 @@ blank/ambiguous, and ``"unavailable"`` when the field is absent.
 
 from __future__ import annotations
 
+import csv
 import json
 from collections import Counter
 from datetime import datetime
@@ -21,6 +22,8 @@ import scipy.io as sio
 UNKNOWN = "unknown"
 UNAVAILABLE = "unavailable"
 SCHEMA_VERSION = "1.0"
+DATASET_JSON_NAME = "dataset_eeglab_provenance.json"
+DATASET_TABLE_NAME = "dataset_eeglab_provenance.csv"
 
 
 def extract_eeglab_provenance(file_path: Path) -> dict[str, Any]:
@@ -89,6 +92,37 @@ def write_eeglab_provenance_artifacts(
     return artifact_paths
 
 
+def write_eeglab_dataset_artifacts(output_dir: Path) -> dict[str, str]:
+    """Aggregate all per-file provenance summaries and persist dataset artifacts."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summaries = []
+    for json_path in sorted(output_dir.glob("*_eeglab_provenance.json")):
+        if json_path.name == DATASET_JSON_NAME:
+            continue
+        summary = json.loads(json_path.read_text(encoding="utf-8"))
+        if isinstance(summary, dict) and isinstance(summary.get("summary_row"), dict):
+            summaries.append(summary)
+
+    dataset_summary = build_eeglab_dataset_summary(summaries)
+    json_path = output_dir / DATASET_JSON_NAME
+    table_path = output_dir / DATASET_TABLE_NAME
+    artifact_paths = {"json": str(json_path), "table": str(table_path)}
+    dataset_summary["artifact_paths"] = artifact_paths
+    json_path.write_text(
+        json.dumps(_json_safe(dataset_summary), indent=2), encoding="utf-8"
+    )
+
+    rows = dataset_summary["rows"]
+    keys = {key for row in rows for key in row}
+    fieldnames = ["source_file", *sorted(keys - {"source_file"})]
+    with table_path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return artifact_paths
+
+
 def render_eeglab_provenance_report(summary: dict[str, Any]) -> str:
     """Render a concise Markdown provenance report."""
 
@@ -154,12 +188,13 @@ def build_eeglab_consistency_warnings(rows: list[dict[str, Any]]) -> list[str]:
 
     checks = {
         "sampling rate": "srate",
-        "channel labels": "channel_labels",
         "epoch window": "epoch_window",
+        "event labels": "event_labels",
+        "channel count": "nbchan",
+        "channel labels": "channel_labels",
         "reference": "reference",
-        "event labels/counts": "event_counts",
-        "ICA structure": "ica_structure",
         "ICLabel structure": "iclabel_structure",
+        "event counts": "event_counts",
     }
     warnings = []
     for label, key in checks.items():

--- a/src/autoclean/io/import_.py
+++ b/src/autoclean/io/import_.py
@@ -21,6 +21,7 @@ import pandas as pd
 from autoclean.io.eeglab_provenance import (
     extract_eeglab_provenance,
     resolve_eeglab_provenance_dir,
+    write_eeglab_dataset_artifacts,
     write_eeglab_provenance_artifacts,
 )
 from autoclean.utils.database import manage_database_conditionally
@@ -463,12 +464,14 @@ def import_eeg(
         # Get plugin metadata
         plugin_metadata = plugin.get_metadata()
         eeglab_provenance = None
+        dataset_artifact_paths = {}
         if format_id == "EEGLAB_SET":
             try:
                 eeglab_provenance = extract_eeglab_provenance(unprocessed_file)
+                provenance_dir = resolve_eeglab_provenance_dir(autoclean_dict)
                 artifact_paths = write_eeglab_provenance_artifacts(
                     eeglab_provenance,
-                    resolve_eeglab_provenance_dir(autoclean_dict),
+                    provenance_dir,
                     unprocessed_file.stem,
                 )
                 message(
@@ -480,6 +483,16 @@ def import_eeg(
                     "warning",
                     f"EEGLAB provenance summary unavailable: {provenance_error}",
                 )
+            else:
+                try:
+                    dataset_artifact_paths = write_eeglab_dataset_artifacts(
+                        provenance_dir
+                    )
+                except Exception as dataset_error:  # pylint: disable=broad-except
+                    message(
+                        "warning",
+                        f"EEGLAB dataset provenance summary unavailable: {dataset_error}",
+                    )
 
         # Prepare metadata
         metadata = {
@@ -511,9 +524,23 @@ def import_eeg(
                 "artifact_paths": (
                     eeglab_provenance.get("artifact_paths") if eeglab_provenance else {}
                 ),
+                "dataset_artifact_paths": dataset_artifact_paths,
                 "summary_row": (
                     eeglab_provenance.get("summary_row") if eeglab_provenance else {}
                 ),
+            }
+            per_file_paths = metadata["import_eeg"]["eeglab_provenance"][
+                "artifact_paths"
+            ]
+            metadata["import_eeg"]["artifact_reports"] = {
+                **{
+                    f"eeglab_provenance_{key}": value
+                    for key, value in per_file_paths.items()
+                },
+                **{
+                    f"eeglab_dataset_provenance_{key}": value
+                    for key, value in dataset_artifact_paths.items()
+                },
             }
 
         # Add additional metadata for Raw data

--- a/tests/unit/io/test_eeglab_provenance.py
+++ b/tests/unit/io/test_eeglab_provenance.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import importlib
 import json
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+import autoclean.io.eeglab_provenance as eeglab_provenance_module
 from autoclean.io.eeglab_provenance import (
     build_eeglab_dataset_summary,
     render_eeglab_provenance_report,
@@ -167,6 +170,72 @@ def test_write_dataset_artifacts_persists_multiple_rows_and_excludes_itself(
     table = (tmp_path / "dataset_eeglab_provenance.csv").read_text(encoding="utf-8")
     assert "a.set" in table
     assert "b.set" in table
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_dataset_artifact_updates_serialize_scan_and_replace(
+    tmp_path, monkeypatch
+) -> None:
+    first_summary = summarize_eeglab_provenance(_ns(srate=250, nbchan=1), "a.set")
+    write_eeglab_provenance_artifacts(first_summary, tmp_path, "a")
+
+    original_build = eeglab_provenance_module.build_eeglab_dataset_summary
+    first_build_started = Event()
+    release_first_build = Event()
+    second_build_started = Event()
+    second_call_started = Event()
+    call_guard = Lock()
+    call_count = 0
+
+    def coordinated_build(summaries):
+        nonlocal call_count
+        with call_guard:
+            call_count += 1
+            current_call = call_count
+        if current_call == 1:
+            first_build_started.set()
+            assert release_first_build.wait(timeout=5)
+        else:
+            second_build_started.set()
+        return original_build(summaries)
+
+    monkeypatch.setattr(
+        eeglab_provenance_module,
+        "build_eeglab_dataset_summary",
+        coordinated_build,
+    )
+
+    def second_update():
+        second_call_started.set()
+        return write_eeglab_dataset_artifacts(tmp_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_update = executor.submit(write_eeglab_dataset_artifacts, tmp_path)
+        assert first_build_started.wait(timeout=5)
+
+        second_summary = summarize_eeglab_provenance(_ns(srate=500, nbchan=2), "b.set")
+        write_eeglab_provenance_artifacts(second_summary, tmp_path, "b")
+        second_update_future = executor.submit(second_update)
+        assert second_call_started.wait(timeout=5)
+
+        entered_while_first_locked = second_build_started.wait(timeout=0.5)
+        release_first_build.set()
+        first_update.result(timeout=5)
+        second_update_future.result(timeout=5)
+
+    assert entered_while_first_locked is False
+    assert second_build_started.is_set()
+    persisted = json.loads(
+        (tmp_path / "dataset_eeglab_provenance.json").read_text(encoding="utf-8")
+    )
+    assert [row["source_file"] for row in persisted["rows"]] == [
+        "a.set",
+        "b.set",
+    ]
+    table = (tmp_path / "dataset_eeglab_provenance.csv").read_text(encoding="utf-8")
+    assert "a.set" in table
+    assert "b.set" in table
+    assert not list(tmp_path.glob(".*.tmp"))
 
 
 @pytest.mark.parametrize("dataset_error", [None, RuntimeError("dataset failed")])

--- a/tests/unit/io/test_eeglab_provenance.py
+++ b/tests/unit/io/test_eeglab_provenance.py
@@ -7,11 +7,13 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from autoclean.io.eeglab_provenance import (
     build_eeglab_dataset_summary,
     render_eeglab_provenance_report,
     summarize_eeglab_provenance,
+    write_eeglab_dataset_artifacts,
     write_eeglab_provenance_artifacts,
 )
 
@@ -95,26 +97,93 @@ def test_render_eeglab_provenance_report_labels_missing_as_unavailable() -> None
 
 def test_dataset_summary_warns_on_batch_inconsistency() -> None:
     first = summarize_eeglab_provenance(
-        _ns(srate=250, ref="average", chanlocs=[_ns(labels="Cz")]), "a.set"
+        _ns(
+            srate=250,
+            xmin=-0.2,
+            xmax=0.8,
+            nbchan=1,
+            ref="average",
+            chanlocs=[_ns(labels="Cz")],
+            event=[_ns(type="standard")],
+            etc=_ns(
+                ic_classification=_ns(
+                    ICLabel=_ns(classes=["brain"], classifications=np.zeros((1, 1)))
+                )
+            ),
+        ),
+        "a.set",
     )
     second = summarize_eeglab_provenance(
-        _ns(srate=500, ref="Cz", chanlocs=[_ns(labels="Pz")]), "b.set"
+        _ns(
+            srate=500,
+            xmin=-0.1,
+            xmax=0.5,
+            nbchan=2,
+            ref="Cz",
+            chanlocs=[_ns(labels="Pz"), _ns(labels="Fz")],
+            event=[_ns(type="target")],
+            etc=_ns(
+                ic_classification=_ns(
+                    ICLabel=_ns(
+                        classes=["brain", "muscle"],
+                        classifications=np.zeros((2, 2)),
+                    )
+                )
+            ),
+        ),
+        "b.set",
     )
 
     dataset_summary = build_eeglab_dataset_summary([first, second])
 
-    assert len(dataset_summary["rows"]) == 2
-    assert any("sampling rate" in item for item in dataset_summary["warnings"])
-    assert any("reference" in item for item in dataset_summary["warnings"])
-    assert any("channel labels" in item for item in dataset_summary["warnings"])
+    warning_text = "\n".join(dataset_summary["warnings"])
+    for field in (
+        "sampling rate",
+        "epoch window",
+        "event labels",
+        "channel count",
+        "channel labels",
+        "reference",
+        "ICLabel structure",
+    ):
+        assert field in warning_text
 
 
-def test_import_eeg_records_eeglab_provenance_metadata(tmp_path) -> None:
+def test_write_dataset_artifacts_persists_multiple_rows_and_excludes_itself(
+    tmp_path,
+) -> None:
+    for stem, rate in (("a", 250), ("b", 500)):
+        summary = summarize_eeglab_provenance(
+            _ns(srate=rate, nbchan=1), f"{stem}.set"
+        )
+        write_eeglab_provenance_artifacts(summary, tmp_path, stem)
+
+    paths = write_eeglab_dataset_artifacts(tmp_path)
+    paths = write_eeglab_dataset_artifacts(tmp_path)
+
+    persisted = json.loads(
+        (tmp_path / "dataset_eeglab_provenance.json").read_text(encoding="utf-8")
+    )
+    assert [row["source_file"] for row in persisted["rows"]] == ["a.set", "b.set"]
+    assert persisted["artifact_paths"] == paths
+    table = (tmp_path / "dataset_eeglab_provenance.csv").read_text(encoding="utf-8")
+    assert "a.set" in table
+    assert "b.set" in table
+
+
+@pytest.mark.parametrize("dataset_error", [None, RuntimeError("dataset failed")])
+def test_import_eeg_records_eeglab_provenance_metadata(
+    tmp_path, dataset_error
+) -> None:
     input_file = tmp_path / "subject.set"
     input_file.write_text("stub", encoding="utf-8")
     artifact_paths = {
         "json": str(tmp_path / "subject_eeglab_provenance.json"),
         "report": str(tmp_path / "subject_eeglab_provenance.md"),
+    }
+    dataset_paths = {
+        "json": str(tmp_path / "dataset_eeglab_provenance.json"),
+        "table": str(tmp_path / "dataset_eeglab_provenance.csv"),
     }
     provenance_summary = {
         "schema_version": "1.0",
@@ -174,21 +243,47 @@ def test_import_eeg_records_eeglab_provenance_metadata(tmp_path) -> None:
             side_effect=_write_artifacts,
         ) as write_artifacts,
         patch.object(
+            import_module,
+            "write_eeglab_dataset_artifacts",
+            return_value=dataset_paths,
+            side_effect=dataset_error,
+        ) as write_dataset_artifacts,
+        patch.object(
             import_module, "resolve_eeglab_provenance_dir", return_value=tmp_path
         ),
         patch.object(import_module, "manage_database_conditionally") as manage_db,
-        patch.object(import_module, "message"),
+        patch.object(import_module, "message") as log_message,
     ):
         result = import_module.import_eeg(autoclean_dict)
 
     assert isinstance(result, _RawLike)
     extract.assert_called_once_with(input_file)
     write_artifacts.assert_called_once_with(provenance_summary, tmp_path, "subject")
+    write_dataset_artifacts.assert_called_once_with(tmp_path)
     update_record = manage_db.call_args.kwargs["update_record"]
     eeglab_metadata = update_record["metadata"]["import_eeg"]["eeglab_provenance"]
     assert eeglab_metadata == {
         "available": True,
         "schema_version": "1.0",
         "artifact_paths": artifact_paths,
+        "dataset_artifact_paths": {} if dataset_error else dataset_paths,
         "summary_row": {"source_file": "subject.set", "srate": 500},
     }
+    assert update_record["metadata"]["import_eeg"]["artifact_reports"] == (
+        {
+            "eeglab_provenance_json": artifact_paths["json"],
+            "eeglab_provenance_report": artifact_paths["report"],
+        }
+        if dataset_error
+        else {
+            "eeglab_provenance_json": artifact_paths["json"],
+            "eeglab_provenance_report": artifact_paths["report"],
+            "eeglab_dataset_provenance_json": dataset_paths["json"],
+            "eeglab_dataset_provenance_table": dataset_paths["table"],
+        }
+    )
+    if dataset_error:
+        assert any(
+            "dataset provenance summary unavailable" in str(call)
+            for call in log_message.call_args_list
+        )

--- a/tests/unit/io/test_eeglab_provenance.py
+++ b/tests/unit/io/test_eeglab_provenance.py
@@ -153,9 +153,7 @@ def test_write_dataset_artifacts_persists_multiple_rows_and_excludes_itself(
     tmp_path,
 ) -> None:
     for stem, rate in (("a", 250), ("b", 500)):
-        summary = summarize_eeglab_provenance(
-            _ns(srate=rate, nbchan=1), f"{stem}.set"
-        )
+        summary = summarize_eeglab_provenance(_ns(srate=rate, nbchan=1), f"{stem}.set")
         write_eeglab_provenance_artifacts(summary, tmp_path, stem)
 
     paths = write_eeglab_dataset_artifacts(tmp_path)
@@ -172,9 +170,7 @@ def test_write_dataset_artifacts_persists_multiple_rows_and_excludes_itself(
 
 
 @pytest.mark.parametrize("dataset_error", [None, RuntimeError("dataset failed")])
-def test_import_eeg_records_eeglab_provenance_metadata(
-    tmp_path, dataset_error
-) -> None:
+def test_import_eeg_records_eeglab_provenance_metadata(tmp_path, dataset_error) -> None:
     input_file = tmp_path / "subject.set"
     input_file.write_text("stub", encoding="utf-8")
     artifact_paths = {


### PR DESCRIPTION
Closes #202.

## What changed

- Persist dataset-level EEGLAB provenance summaries as JSON and CSV.
- Aggregate all per-file provenance records without re-ingesting the dataset summary.
- Report consistency warnings for sampling rate, epoch window, event labels/counts, channel count/labels, reference, and ICLabel structure.
- Record per-file and dataset artifact paths in standard import metadata.
- Preserve per-file provenance when dataset aggregation fails.

## Why

Per-file provenance was already extracted, but the dataset summary was not persisted or linked from the run metadata. This completes the issue's dataset-level reporting path without duplicating the prior-preprocessing detection logic.

## Validation

- `python -B -m ruff check src/autoclean/io/eeglab_provenance.py src/autoclean/io/import_.py tests/unit/io/test_eeglab_provenance.py`
- Focused inconsistency-warning test: passed.
- Focused multi-file JSON/CSV persistence test: passed.
- Import metadata success and aggregation-failure cases: 2 passed.

