### PR TITLE
fix: surface results decision save failures

### DIFF
--- a/web/src/pages/Results.test.tsx
+++ b/web/src/pages/Results.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { api } = vi.hoisted(() => ({
+  api: { setDecision: vi.fn() },
+}));
+
+vi.mock("../lib/api", () => ({ api }));
+
+import { DecisionBar } from "./Results";
+
+describe("DecisionBar", () => {
+  it("reports a failed save and retries without updating the parent early", async () => {
+    api.setDecision
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(undefined);
+    const onDecisionChange = vi.fn();
+
+    render(
+      <DecisionBar
+        runId="run-1"
+        currentDecision={null}
+        currentNotes="needs review"
+        onDecisionChange={onDecisionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /pass/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Decision could not be saved.",
+    );
+    expect(onDecisionChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(api.setDecision).toHaveBeenCalledTimes(2);
+      expect(onDecisionChange).toHaveBeenCalledWith("pass", "needs review");
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Results.test.tsx
+++ b/web/src/pages/Results.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { api } = vi.hoisted(() => ({
   api: { setDecision: vi.fn() },
@@ -10,6 +10,10 @@ vi.mock("../lib/api", () => ({ api }));
 import { DecisionBar } from "./Results";
 
 describe("DecisionBar", () => {
+  beforeEach(() => {
+    api.setDecision.mockReset();
+  });
+
   it("reports a failed save and retries without updating the parent early", async () => {
     api.setDecision
       .mockRejectedValueOnce(new Error("offline"))
@@ -39,5 +43,51 @@ describe("DecisionBar", () => {
       expect(onDecisionChange).toHaveBeenCalledWith("pass", "needs review");
     });
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not carry a failed decision into another run", async () => {
+    api.setDecision
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(undefined);
+    const onDecisionChange = vi.fn();
+
+    const { rerender } = render(
+      <DecisionBar
+        key="run-1"
+        runId="run-1"
+        currentDecision={null}
+        currentNotes="old run notes"
+        onDecisionChange={onDecisionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /fail/i }));
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    rerender(
+      <DecisionBar
+        key="run-2"
+        runId="run-2"
+        currentDecision={null}
+        currentNotes="new run notes"
+        onDecisionChange={onDecisionChange}
+      />,
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /retry/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /pass/i }));
+
+    await waitFor(() => {
+      expect(api.setDecision).toHaveBeenLastCalledWith(
+        "run-2",
+        "pass",
+        "new run notes",
+      );
+      expect(onDecisionChange).toHaveBeenCalledWith("pass", "new run notes");
+    });
   });
 });

--- a/web/src/pages/Results.test.tsx
+++ b/web/src/pages/Results.test.tsx
@@ -45,6 +45,43 @@ describe("DecisionBar", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
+  it("preserves a failed decision when notes trigger an implicit save", async () => {
+    api.setDecision
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(undefined);
+    const onDecisionChange = vi.fn();
+
+    render(
+      <DecisionBar
+        runId="run-1"
+        currentDecision="review"
+        currentNotes="old notes"
+        onDecisionChange={onDecisionChange}
+      />,
+    );
+
+    const notes = screen.getByRole("textbox");
+    fireEvent.change(notes, { target: { value: "updated notes" } });
+    fireEvent.click(screen.getByRole("button", { name: /pass/i }));
+
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    fireEvent.blur(notes);
+    fireEvent.focus(notes);
+    fireEvent.keyDown(notes, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(api.setDecision).toHaveBeenCalledTimes(1);
+      expect(api.setDecision).toHaveBeenLastCalledWith(
+        "run-1",
+        "pass",
+        "updated notes",
+      );
+      expect(onDecisionChange).not.toHaveBeenCalled();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
   it("does not carry a failed decision into another run", async () => {
     api.setDecision
       .mockRejectedValueOnce(new Error("offline"))

--- a/web/src/pages/Results.tsx
+++ b/web/src/pages/Results.tsx
@@ -857,7 +857,7 @@ function isTypingInInput(e: KeyboardEvent): boolean {
   return false;
 }
 
-function DecisionBar({
+export function DecisionBar({
   runId,
   currentDecision,
   currentNotes,
@@ -870,6 +870,8 @@ function DecisionBar({
 }) {
   const [notes, setNotes] = useState(currentNotes);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+  const [failedDecision, setFailedDecision] = useState<DecisionValue>(null);
   const notesRef = useRef(notes);
   notesRef.current = notes;
 
@@ -884,8 +886,11 @@ function DecisionBar({
         await api.setDecision(runId, decision, notesRef.current);
       }
       onDecisionChange(decision, notesRef.current);
+      setSaveError(false);
+      setFailedDecision(null);
     } catch {
-      // ignore
+      setSaveError(true);
+      setFailedDecision(decision);
     } finally {
       setSaving(false);
     }
@@ -927,6 +932,7 @@ function DecisionBar({
         {currentDecision && (
           <button
             onClick={() => handleDecision(null)}
+            disabled={saving}
             className="px-2 py-1 rounded text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
           >
             Clear
@@ -934,6 +940,19 @@ function DecisionBar({
           </button>
         )}
       </div>
+      {saveError && (
+        <div role="alert" className="mb-2 flex items-center gap-2 text-xs text-red-400">
+          <span>Decision could not be saved.</span>
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => handleDecision(failedDecision)}
+            className="underline underline-offset-2 hover:text-red-300 disabled:opacity-50"
+          >
+            Retry
+          </button>
+        </div>
+      )}
       <input
         type="text"
         value={notes}

--- a/web/src/pages/Results.tsx
+++ b/web/src/pages/Results.tsx
@@ -957,8 +957,14 @@ export function DecisionBar({
         type="text"
         value={notes}
         onChange={(e) => setNotes(e.target.value)}
-        onBlur={() => { if (currentDecision) handleDecision(currentDecision); }}
-        onKeyDown={(e) => { if (e.key === "Enter" && currentDecision) handleDecision(currentDecision); }}
+        onBlur={() => {
+          if (!saveError && currentDecision) handleDecision(currentDecision);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !saveError && currentDecision) {
+            handleDecision(currentDecision);
+          }
+        }}
         placeholder="Add notes..."
         className="w-full px-2.5 py-1.5 rounded bg-surface-50 border border-border text-xs text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-brand/40"
       />

--- a/web/src/pages/Results.tsx
+++ b/web/src/pages/Results.tsx
@@ -1168,6 +1168,7 @@ function RunDetailPanel({
 
       {/* Decision bar */}
       <DecisionBar
+        key={run.run_id}
         runId={run.run_id}
         currentDecision={decision}
         currentNotes={decisionNotes}


### PR DESCRIPTION
Closes #266.

## What changed

- Keep a failed decision locally instead of updating the parent optimistically.
- Display a semantic `role="alert"` error when saving fails.
- Provide a focused retry action that reuses the exact attempted decision, including clear/null.
- Disable visible decision controls while a save is active.
- Add a regression test for rejection, retry, successful parent update, and alert removal.

## Root cause

Decision-save rejections were swallowed while the UI updated as though persistence had succeeded, leaving users without feedback or a reliable retry path.

## Validation

- Independent static interface/acceptance review passed.
- `git diff --check` passed.
- The focused Vitest file could not be collected locally because this worktree has an incomplete dependency junction; GitHub CI is the dynamic frontend gate.

