### PR TITLE
feat: add ASSR analysis profiles

### DIFF
--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -324,6 +324,21 @@ def _epoch_descriptor() -> dict:
     }
 
 
+def _assr_analysis_descriptor() -> dict:
+    return {
+        "enabled": "bool",
+        "value": {
+            "profile": "'assr_epochs'|null",
+            "baseline": "list|tuple|null",
+            "time_windows": "dict|null",
+            "freq_bands": "dict|null",
+            "combined_bands": "dict|null",
+            "exclude_channel_types": "list|tuple|null",
+            "save_tfr": "bool",
+        },
+    }
+
+
 def _bad_channel_log_descriptor() -> dict:
     return {
         "enabled": "bool",
@@ -573,6 +588,18 @@ def _build_task_settings_schema() -> Schema:
                     Optional("group_by"): "event_id",
                 },
             },
+            Optional("assr_analysis"): {
+                "enabled": bool,
+                "value": {
+                    Optional("profile"): Or("assr_epochs", None),
+                    Optional("baseline"): Or(list, tuple, None),
+                    Optional("time_windows"): Or(dict, None),
+                    Optional("freq_bands"): Or(dict, None),
+                    Optional("combined_bands"): Or(dict, None),
+                    Optional("exclude_channel_types"): Or(list, tuple, None),
+                    Optional("save_tfr"): bool,
+                },
+            },
             # Source Localization
             Optional("apply_source_localization"): {
                 "enabled": bool,
@@ -716,6 +743,7 @@ def export_task_schema_layout() -> dict:
                     "group_by": "'event_id'",
                 },
             },
+            "assr_analysis": _assr_analysis_descriptor(),
             "apply_source_localization": _source_localization_descriptor(),
             "apply_source_psd": _source_psd_descriptor(),
             "apply_sensor_psd": _sensor_psd_descriptor(),

--- a/src/autoclean/data/builtins/tasks/auditory/ASSR_40Hz.py
+++ b/src/autoclean/data/builtins/tasks/auditory/ASSR_40Hz.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from autoclean.calc.assr_analysis import analyze_assr
 from autoclean.core.task import Task
 
 config = {
@@ -58,6 +61,10 @@ config = {
             "volt_threshold": {"eeg": 0.0002},
         },
     },
+    "assr_analysis": {
+        "enabled": False,
+        "value": {"profile": "assr_epochs"},
+    },
     "ai_reporting": False,
 }
 
@@ -89,8 +96,36 @@ class ASSR_40Hz(Task):
         self.create_eventid_epochs()
         self.detect_outlier_epochs()
         self.gfp_clean_epochs()
+        self.run_assr_analysis()
 
         self.generate_reports()
+
+    def run_assr_analysis(self) -> None:
+        """Run optional ASSR analysis on the cleaned epochs."""
+        if (
+            getattr(self, "settings", None) is not None
+            and "assr_analysis" not in self.settings
+        ):
+            return
+        is_enabled, step_config = self._check_step_enabled("assr_analysis")
+        if not is_enabled:
+            return
+        if self.epochs is None:
+            raise RuntimeError("ASSR analysis requires cleaned epochs")
+
+        analysis_config = dict((step_config or {}).get("value") or {})
+        analysis_profile = analysis_config.pop("profile", None)
+        input_file = self.config.get("unprocessed_file")
+        file_basename = Path(input_file).stem if input_file else None
+
+        analyze_assr(
+            output_dir=self._resolve_report_path("assr"),
+            save_results=True,
+            epochs=self.epochs,
+            file_basename=file_basename,
+            analysis_profile=analysis_profile,
+            analysis_config=analysis_config,
+        )
 
     def generate_reports(self) -> None:
         if self.raw is None or self.original_raw is None:

--- a/tests/config/test_assr_schema.py
+++ b/tests/config/test_assr_schema.py
@@ -36,9 +36,7 @@ def test_schema_accepts_assr_analysis_overrides() -> None:
         ("save_tfr", "yes"),
     ],
 )
-def test_schema_rejects_invalid_assr_analysis_values(
-    key: str, value: object
-) -> None:
+def test_schema_rejects_invalid_assr_analysis_values(key: str, value: object) -> None:
     task_config = deepcopy(assr_config)
     task_config["assr_analysis"] = {
         "enabled": True,

--- a/tests/config/test_assr_schema.py
+++ b/tests/config/test_assr_schema.py
@@ -1,0 +1,53 @@
+"""ASSR task configuration schema tests."""
+
+from copy import deepcopy
+
+import pytest
+from schema import SchemaError
+
+from autoclean.configkit.schema import validate_task_module_config
+from autoclean.data.builtins.tasks.auditory.ASSR_40Hz import config as assr_config
+
+
+def test_schema_accepts_assr_analysis_overrides() -> None:
+    task_config = deepcopy(assr_config)
+    task_config["assr_analysis"] = {
+        "enabled": True,
+        "value": {
+            "profile": "assr_epochs",
+            "baseline": (-0.2, 0.0),
+            "time_windows": {"response": [0.0, 0.5]},
+            "freq_bands": {"assr": [39.0, 41.0]},
+            "combined_bands": {"broad_assr": [[30.0, 45.0], [65.0, 80.0]]},
+            "exclude_channel_types": ("eog",),
+            "save_tfr": True,
+        },
+    }
+
+    validated = validate_task_module_config(task_config)
+
+    assert validated["assr_analysis"] == task_config["assr_analysis"]
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("profile", "unknown_profile"),
+        ("save_tfr", "yes"),
+    ],
+)
+def test_schema_rejects_invalid_assr_analysis_values(
+    key: str, value: object
+) -> None:
+    task_config = deepcopy(assr_config)
+    task_config["assr_analysis"] = {
+        "enabled": True,
+        "value": {
+            "profile": "assr_epochs",
+            "save_tfr": False,
+            key: value,
+        },
+    }
+
+    with pytest.raises(SchemaError):
+        validate_task_module_config(task_config)

--- a/tests/unit/tasks/test_assr_task_analysis.py
+++ b/tests/unit/tasks/test_assr_task_analysis.py
@@ -1,0 +1,93 @@
+"""Focused tests for optional analysis in the built-in ASSR task."""
+
+from pathlib import Path
+
+import pytest
+
+from autoclean.data.builtins.tasks.auditory import ASSR_40Hz as assr_module
+
+
+def _task(tmp_path: Path, settings: dict) -> assr_module.ASSR_40Hz:
+    task = assr_module.ASSR_40Hz.__new__(assr_module.ASSR_40Hz)
+    task.settings = settings
+    task.config = {"unprocessed_file": tmp_path / "subject_01.set"}
+    task.epochs = object()
+    task._resolve_report_path = lambda key: tmp_path / "reports" / key
+    return task
+
+
+def test_run_assr_analysis_forwards_profile_overrides_and_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task = _task(
+        tmp_path,
+        {
+            "assr_analysis": {
+                "enabled": True,
+                "value": {
+                    "profile": "assr_epochs",
+                    "baseline": [-0.2, 0.0],
+                    "save_tfr": True,
+                },
+            }
+        },
+    )
+    epochs = task.epochs
+    captured: dict[str, object] = {}
+
+    def fake_analyze_assr(**kwargs) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(assr_module, "analyze_assr", fake_analyze_assr)
+
+    task.run_assr_analysis()
+
+    assert captured == {
+        "output_dir": tmp_path / "reports" / "assr",
+        "save_results": True,
+        "epochs": epochs,
+        "file_basename": "subject_01",
+        "analysis_profile": "assr_epochs",
+        "analysis_config": {
+            "baseline": [-0.2, 0.0],
+            "save_tfr": True,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {},
+        {
+            "assr_analysis": {
+                "enabled": False,
+                "value": {"profile": "assr_epochs"},
+            }
+        },
+    ],
+)
+def test_run_assr_analysis_skips_absent_or_disabled_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    settings: dict,
+) -> None:
+    task = _task(tmp_path, settings)
+
+    def fail_if_called(**kwargs) -> None:
+        raise AssertionError("disabled ASSR analysis must not run")
+
+    monkeypatch.setattr(assr_module, "analyze_assr", fail_if_called)
+
+    task.run_assr_analysis()
+
+
+def test_run_assr_analysis_requires_epochs_when_enabled(tmp_path: Path) -> None:
+    task = _task(
+        tmp_path,
+        {"assr_analysis": {"enabled": True, "value": {}}},
+    )
+    task.epochs = None
+
+    with pytest.raises(RuntimeError, match="requires cleaned epochs"):
+        task.run_assr_analysis()


### PR DESCRIPTION
Closes #220.

## What changed

- Add the exact `assr_analysis` schema and exported configuration.
- Ship a disabled-by-default `ASSR_40Hz` profile.
- Wire task execution to the existing ASSR analyzer after cleaned epochs are available.
- Forward configured profile and overrides.
- Skip cleanly when the block is absent or disabled, and fail clearly when required epochs are missing.

## Why

The ASSR analysis implementation existed but was not reachable through the task configuration and execution path.

## Validation

- Ruff passed on all changed Python files.
- Schema acceptance/rejection tests: 3 passed.
- Task forwarding, skip, and missing-epochs tests: 4 passed.

