### PR TITLE
fix: tolerate inaccessible saved workspace config

### DIFF
--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -80,7 +80,7 @@ from autoclean.utils.template_renderer import (
     render_template,
     validate_python_identifier,
 )
-from autoclean.utils.user_config import user_config
+from autoclean.utils.user_config import safe_path_exists, user_config
 
 # Optional Neo support for extended formats (XDAT)
 try:
@@ -352,7 +352,9 @@ def _print_context(
     try:
         workspace_valid = user_config._is_workspace_valid()  # type: ignore[attr-defined]
     except Exception:
-        workspace_valid = workspace_dir.exists() and (workspace_dir / "tasks").exists()
+        workspace_valid = safe_path_exists(workspace_dir) and safe_path_exists(
+            workspace_dir / "tasks"
+        )
 
     home = str(Path.home())
     if workspace_display.startswith(home):
@@ -379,7 +381,7 @@ def _print_context(
             input_display = str(p)
             if input_display.startswith(home):
                 input_display = input_display.replace(home, "~", 1)
-            if p.exists():
+            if safe_path_exists(p):
                 if p.is_file():
                     input_type = "file"
                 elif p.is_dir():
@@ -510,10 +512,10 @@ def _print_context(
             workspace_dir = user_config.config_dir
             usage_path = (
                 workspace_dir
-                if workspace_dir.exists()
+                if safe_path_exists(workspace_dir)
                 else (
                     workspace_dir.parent
-                    if workspace_dir.parent.exists()
+                    if safe_path_exists(workspace_dir.parent)
                     else Path.home()
                 )
             )

--- a/src/autoclean/utils/task_discovery.py
+++ b/src/autoclean/utils/task_discovery.py
@@ -11,7 +11,7 @@ from autoclean.core.task import Task
 
 # Optional dependencies - may not be available in all contexts
 try:
-    from autoclean.utils.user_config import user_config
+    from autoclean.utils.user_config import safe_path_exists, user_config
 
     USER_CONFIG_AVAILABLE = True
 except ImportError:
@@ -24,6 +24,12 @@ except ImportError:
             return Path.home() / ".autoclean" / "tasks"
 
     user_config = MockUserConfig()
+
+    def safe_path_exists(path: Path) -> bool:
+        try:
+            return path.exists()
+        except OSError:
+            return False
 
 # Import logging utilities for warnings
 try:
@@ -177,15 +183,22 @@ def _discover_custom_tasks() -> (
         )
         return valid_tasks, invalid_files, skipped_files
 
+    tasks_dir = user_config.tasks_dir
+
     # Check if tasks directory exists
-    if not user_config.tasks_dir.exists():
+    if not safe_path_exists(tasks_dir):
         return valid_tasks, invalid_files, skipped_files
 
     # Scan for Python files recursively (including subdirectories)
-    for task_file in user_config.tasks_dir.rglob("*.py"):
+    try:
+        task_files = list(tasks_dir.rglob("*.py"))
+    except OSError:
+        return valid_tasks, invalid_files, skipped_files
+
+    for task_file in task_files:
         # Skip generated built-in/reference task copies stored under a reserved
         # subfolder (e.g. tasks/builtin/) so they aren't discovered as user tasks
-        relative_parts = task_file.relative_to(user_config.tasks_dir).parts
+        relative_parts = task_file.relative_to(tasks_dir).parts
         if RESERVED_TASK_DISCOVERY_DIRS.intersection(relative_parts):
             skipped_files.append(
                 SkippedTaskFile(

--- a/src/autoclean/utils/task_discovery.py
+++ b/src/autoclean/utils/task_discovery.py
@@ -31,6 +31,7 @@ except ImportError:
         except OSError:
             return False
 
+
 # Import logging utilities for warnings
 try:
     from autoclean.utils import logging  # noqa: F401

--- a/src/autoclean/utils/user_config.py
+++ b/src/autoclean/utils/user_config.py
@@ -50,6 +50,14 @@ LOGO_ICON = "🧠"
 DIVIDER = "═════════════════════════════════════════════════"
 
 
+def safe_path_exists(path: Path) -> bool:
+    """Return whether a path exists without surfacing inaccessible-mount errors."""
+    try:
+        return path.exists()
+    except OSError:
+        return False
+
+
 def _get_torch_module():
     """Load torch lazily for optional GPU detection."""
     global TORCH_AVAILABLE, _TORCH_MODULE
@@ -77,11 +85,21 @@ class UserConfigManager:
         # Get workspace directory (without auto-creating)
         self.config_dir = self._get_workspace_path()
         self.tasks_dir = self.config_dir / "tasks"
+        self.workspace_accessible = True
 
         # Always create basic directory structure to avoid confusion
         # This eliminates "workspace not configured" messages on fresh installs
-        self.config_dir.mkdir(parents=True, exist_ok=True)
-        self.tasks_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+            self.tasks_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            self.workspace_accessible = False
+            print(
+                "Warning: Saved AutoClean workspace is not accessible: "
+                f"{self.config_dir} ({exc}). "
+                "Use 'autocleaneeg-pipeline workspace set <path>' to choose a "
+                "new workspace or 'autocleaneeg-pipeline workspace unset' to clear it."
+            )
 
     def _get_workspace_path(self) -> Path:
         """Get configured workspace path or default."""
@@ -114,24 +132,38 @@ class UserConfigManager:
             Path(platformdirs.user_config_dir("autoclean", "autoclean")) / "setup.json"
         )
         return (
-            global_config.exists()
-            and self.config_dir.exists()
-            and (self.config_dir / "tasks").exists()
+            safe_path_exists(global_config)
+            and safe_path_exists(self.config_dir)
+            and safe_path_exists(self.config_dir / "tasks")
         )
 
     def get_default_output_dir(self) -> Path:
         """Get default output directory."""
         return self.config_dir / "output"
 
-    def list_custom_tasks(self) -> Dict[str, Dict[str, Any]]:
+    def list_custom_tasks(
+        self, *, raise_on_error: bool = False
+    ) -> Dict[str, Dict[str, Any]]:
         """List custom tasks by scanning tasks directory (including subdirectories)."""
         custom_tasks = {}
 
-        if not self.tasks_dir.exists():
+        try:
+            if not self.tasks_dir.exists():
+                return custom_tasks
+        except OSError:
+            if raise_on_error:
+                raise
             return custom_tasks
 
         # Scan for Python files recursively (including subdirectories)
-        for task_file in self.tasks_dir.rglob("*.py"):
+        try:
+            task_files = list(self.tasks_dir.rglob("*.py"))
+        except OSError:
+            if raise_on_error:
+                raise
+            return custom_tasks
+
+        for task_file in task_files:
             if task_file.name.startswith("_"):
                 continue
 
@@ -195,10 +227,13 @@ class UserConfigManager:
             return None
 
         if ensure_exists:
+            if not getattr(self, "workspace_accessible", True):
+                return active_task
+
             try:
-                custom_tasks = self.list_custom_tasks()
-            except Exception:
-                custom_tasks = {}
+                custom_tasks = self.list_custom_tasks(raise_on_error=True)
+            except OSError:
+                return active_task
 
             if active_task not in custom_tasks:
                 # Clear out stale configuration so future calls reflect reality.

--- a/src/autoclean/utils/user_config.py
+++ b/src/autoclean/utils/user_config.py
@@ -98,7 +98,8 @@ class UserConfigManager:
                 "Warning: Saved AutoClean workspace is not accessible: "
                 f"{self.config_dir} ({exc}). "
                 "Use 'autocleaneeg-pipeline workspace set <path>' to choose a "
-                "new workspace or 'autocleaneeg-pipeline workspace unset' to clear it."
+                "new workspace or 'autocleaneeg-pipeline workspace unset' to clear it.",
+                file=sys.stderr,
             )
 
     def _get_workspace_path(self) -> Path:

--- a/tests/unit/test_task_discovery.py
+++ b/tests/unit/test_task_discovery.py
@@ -33,6 +33,65 @@ def test_safe_discover_tasks(monkeypatch):
     assert isinstance(invalid_files, list)
 
 
+def test_safe_discover_tasks_tolerates_inaccessible_tasks_dir_exists(
+    monkeypatch,
+):
+    """Task discovery should not crash when a saved tasks dir is inaccessible."""
+    inaccessible = Path("/Volumes/srv2/autoclean/tasks")
+    monkeypatch.setattr(
+        "autoclean.utils.user_config.user_config.tasks_dir",
+        inaccessible,
+    )
+
+    original_exists = Path.exists
+
+    def raise_for_inaccessible(self):
+        if self == inaccessible:
+            raise PermissionError("permission denied")
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", raise_for_inaccessible)
+
+    valid_tasks, invalid_files, skipped_files = safe_discover_tasks()
+
+    assert not any(str(inaccessible) in task.source for task in valid_tasks)
+    assert not any(str(inaccessible) in entry.source for entry in invalid_files)
+    assert not any(str(inaccessible) in entry.source for entry in skipped_files)
+
+
+def test_safe_discover_tasks_tolerates_inaccessible_tasks_dir_scan(
+    monkeypatch,
+):
+    """Task discovery should not crash when recursive scanning fails."""
+    inaccessible = Path("/Volumes/srv2/autoclean/tasks")
+    monkeypatch.setattr(
+        "autoclean.utils.user_config.user_config.tasks_dir",
+        inaccessible,
+    )
+
+    original_exists = Path.exists
+    original_rglob = Path.rglob
+
+    def exists_for_inaccessible(self):
+        if self == inaccessible:
+            return True
+        return original_exists(self)
+
+    def rglob_for_inaccessible(self, pattern):
+        if self == inaccessible:
+            raise PermissionError("permission denied")
+        return original_rglob(self, pattern)
+
+    monkeypatch.setattr(Path, "exists", exists_for_inaccessible)
+    monkeypatch.setattr(Path, "rglob", rglob_for_inaccessible)
+
+    valid_tasks, invalid_files, skipped_files = safe_discover_tasks()
+
+    assert not any(str(inaccessible) in task.source for task in valid_tasks)
+    assert not any(str(inaccessible) in entry.source for entry in invalid_files)
+    assert not any(str(inaccessible) in entry.source for entry in skipped_files)
+
+
 def test_discovered_task_structure():
     """Test that DiscoveredTask has the expected structure."""
     task = DiscoveredTask(

--- a/tests/unit/test_user_config_workspace_access.py
+++ b/tests/unit/test_user_config_workspace_access.py
@@ -4,9 +4,7 @@ from autoclean.utils import user_config as user_config_module
 from autoclean.utils.user_config import UserConfigManager, safe_path_exists
 
 
-def test_init_does_not_crash_when_saved_workspace_is_inaccessible(
-    monkeypatch, capsys
-):
+def test_init_does_not_crash_when_saved_workspace_is_inaccessible(monkeypatch, capsys):
     inaccessible = Path("/Volumes/srv2/autoclean")
 
     monkeypatch.setattr(

--- a/tests/unit/test_user_config_workspace_access.py
+++ b/tests/unit/test_user_config_workspace_access.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+from autoclean.utils import user_config as user_config_module
+from autoclean.utils.user_config import UserConfigManager, safe_path_exists
+
+
+def test_init_does_not_crash_when_saved_workspace_is_inaccessible(
+    monkeypatch, capsys
+):
+    inaccessible = Path("/Volumes/srv2/autoclean")
+
+    monkeypatch.setattr(
+        UserConfigManager,
+        "_get_workspace_path",
+        lambda self: inaccessible,
+    )
+
+    def raise_for_inaccessible(self, *args, **kwargs):
+        if self == inaccessible or self == inaccessible / "tasks":
+            raise PermissionError("permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", raise_for_inaccessible)
+
+    manager = UserConfigManager()
+
+    assert manager.config_dir == inaccessible
+    assert manager.tasks_dir == inaccessible / "tasks"
+    assert manager.workspace_accessible is False
+    assert "workspace set <path>" in capsys.readouterr().out
+
+
+def test_safe_path_exists_returns_false_for_permission_errors(monkeypatch):
+    inaccessible = Path("/Volumes/srv2")
+
+    def raise_for_inaccessible(self):
+        if self == inaccessible:
+            raise PermissionError("permission denied")
+        return True
+
+    monkeypatch.setattr(Path, "exists", raise_for_inaccessible)
+
+    assert safe_path_exists(inaccessible) is False
+    assert safe_path_exists(Path("/tmp")) is True
+
+
+def test_is_workspace_valid_returns_false_for_inaccessible_workspace(
+    monkeypatch, tmp_path
+):
+    config_root = tmp_path / "config"
+    config_root.mkdir()
+    setup_json = config_root / "setup.json"
+    setup_json.write_text("{}", encoding="utf-8")
+    inaccessible = Path("/Volumes/srv2/autoclean")
+
+    manager = UserConfigManager.__new__(UserConfigManager)
+    manager.config_dir = inaccessible
+    manager.tasks_dir = inaccessible / "tasks"
+
+    monkeypatch.setattr(
+        user_config_module.platformdirs,
+        "user_config_dir",
+        lambda *args: str(config_root),
+    )
+
+    original_exists = Path.exists
+
+    def raise_for_inaccessible(self):
+        if self == inaccessible or self == inaccessible / "tasks":
+            raise PermissionError("permission denied")
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", raise_for_inaccessible)
+
+    assert manager._is_workspace_valid() is False
+
+
+def test_list_custom_tasks_returns_empty_for_inaccessible_tasks_dir(monkeypatch):
+    inaccessible = Path("/Volumes/srv2/autoclean/tasks")
+
+    manager = UserConfigManager.__new__(UserConfigManager)
+    manager.config_dir = inaccessible.parent
+    manager.tasks_dir = inaccessible
+
+    def raise_for_inaccessible(self):
+        if self == inaccessible:
+            raise PermissionError("permission denied")
+        return True
+
+    monkeypatch.setattr(Path, "exists", raise_for_inaccessible)
+
+    assert manager.list_custom_tasks() == {}
+
+
+def test_get_active_task_preserves_task_when_tasks_dir_is_inaccessible(
+    monkeypatch, tmp_path
+):
+    config_root = tmp_path / "config"
+    config_root.mkdir()
+    setup_json = config_root / "setup.json"
+    setup_json.write_text('{"active_task": "MyTask"}', encoding="utf-8")
+    inaccessible = Path("/Volumes/srv2/autoclean/tasks")
+
+    manager = UserConfigManager.__new__(UserConfigManager)
+    manager.config_dir = inaccessible.parent
+    manager.tasks_dir = inaccessible
+    manager.workspace_accessible = True
+
+    monkeypatch.setattr(
+        user_config_module.platformdirs,
+        "user_config_dir",
+        lambda *args: str(config_root),
+    )
+
+    def raise_for_inaccessible(self):
+        if self == inaccessible:
+            raise PermissionError("permission denied")
+        return True
+
+    monkeypatch.setattr(Path, "exists", raise_for_inaccessible)
+    monkeypatch.setattr(
+        manager,
+        "set_active_task",
+        lambda task_name=None: (_ for _ in ()).throw(
+            AssertionError("active task should not be cleared")
+        ),
+    )
+
+    assert manager.get_active_task() == "MyTask"
+    assert setup_json.read_text(encoding="utf-8") == '{"active_task": "MyTask"}'

--- a/tests/unit/test_user_config_workspace_access.py
+++ b/tests/unit/test_user_config_workspace_access.py
@@ -26,7 +26,9 @@ def test_init_does_not_crash_when_saved_workspace_is_inaccessible(
     assert manager.config_dir == inaccessible
     assert manager.tasks_dir == inaccessible / "tasks"
     assert manager.workspace_accessible is False
-    assert "workspace set <path>" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "workspace set <path>" in captured.err
 
 
 def test_safe_path_exists_returns_false_for_permission_errors(monkeypatch):


### PR DESCRIPTION
## Summary
- keep CLI startup from crashing when a persisted workspace points at an inaccessible network path
- preserve stale workspace/task/input config so users can recover with workspace/input commands instead of silently losing settings
- add regression tests for inaccessible workspace paths and active task preservation

Closes #272

## Tests
- HOME=/tmp/autoclean-home-codex MPLCONFIGDIR=/tmp/mpl-codex MNE_DONTWRITE_HOME=true MNE_HOME=/tmp/mne-codex python -B -m pytest -p no:cacheprovider --no-cov tests/unit/test_user_config_workspace_access.py -q
- UV_CACHE_DIR=/tmp/uv-cache-codex uvx ruff check --select I,F,FLY src/autoclean/utils/user_config.py tests/unit/test_user_config_workspace_access.py
- git diff --check