### PR TITLE
fix: validate custom task template config

### DIFF
--- a/src/autoclean/configkit/schema.py
+++ b/src/autoclean/configkit/schema.py
@@ -30,6 +30,8 @@ except Exception:  # pragma: no cover - optional dep
 THRESHOLD_MODES = ("soft", "hard")
 COMP_REJ_METHODS = ("iclabel", "icvision", "hybrid")
 ICA_METHODS = ("fastica", "infomax", "picard")
+BAD_CHANNEL_PRESETS = ("auto", "low_density", "mid_density", "high_density", "legacy")
+BAD_CHANNEL_CLEANING_METHODS = ("interpolate", "drop")
 IC_FLAGS = (
     "brain",
     "muscle",
@@ -238,6 +240,32 @@ def _component_rejection_descriptor() -> dict:
     }
 
 
+def _bad_channel_detection_descriptor() -> dict:
+    threshold = "number"
+    return {
+        "enabled": "bool",
+        "value": {
+            "preset": "'auto'|'low_density'|'mid_density'|'high_density'|'legacy'",
+            "cleaning_method": "'interpolate'|'drop'|None",
+            "channel_count_bins": {
+                "<bin_name>": {
+                    "min_channels": "integer>=0",
+                    "max_channels": "integer>=0",
+                    "correlation_thresh": threshold,
+                    "deviation_thresh": threshold,
+                    "ransac_sample_prop": threshold,
+                    "ransac_corr_thresh": threshold,
+                    "ransac_frac_bad": threshold,
+                    "ransac_channel_wise": "bool",
+                    "ransac_enabled": "bool",
+                    "cleaning_method": "'interpolate'|'drop'|None",
+                    "max_bad_fraction": threshold,
+                }
+            },
+        },
+    }
+
+
 def _is_non_negative_number(value: object) -> bool:
     try:
         return float(value) >= 0
@@ -391,6 +419,34 @@ def _build_task_settings_schema() -> Schema:
         list,
         None,
     )
+    bad_channel_threshold = Or(int, float)
+    bad_channel_cleaning_method = Or(*BAD_CHANNEL_CLEANING_METHODS, None)
+    bad_channel_bin_schema = {
+        Optional("min_channels"): And(int, _is_non_negative_int),
+        Optional("max_channels"): And(int, _is_non_negative_int),
+        Optional("correlation_thresh"): bad_channel_threshold,
+        Optional("deviation_thresh"): bad_channel_threshold,
+        Optional("ransac_sample_prop"): bad_channel_threshold,
+        Optional("ransac_corr_thresh"): bad_channel_threshold,
+        Optional("ransac_frac_bad"): bad_channel_threshold,
+        Optional("ransac_channel_wise"): bool,
+        Optional("ransac_enabled"): bool,
+        Optional("cleaning_method"): bad_channel_cleaning_method,
+        Optional("max_bad_fraction"): bad_channel_threshold,
+    }
+    bad_channel_detection_value_schema = {
+        Optional("preset"): Or(*BAD_CHANNEL_PRESETS),
+        Optional("cleaning_method"): bad_channel_cleaning_method,
+        Optional("channel_count_bins"): Or({str: bad_channel_bin_schema}, None),
+        Optional("correlation_thresh"): bad_channel_threshold,
+        Optional("deviation_thresh"): bad_channel_threshold,
+        Optional("ransac_sample_prop"): bad_channel_threshold,
+        Optional("ransac_corr_thresh"): bad_channel_threshold,
+        Optional("ransac_frac_bad"): bad_channel_threshold,
+        Optional("ransac_channel_wise"): bool,
+        Optional("ransac_enabled"): bool,
+        Optional("max_bad_fraction"): bad_channel_threshold,
+    }
     matlab_step_value = {
         "kind": Or(*MATLAB_ENTRYPOINT_KINDS),
         "entrypoint": And(str, len),
@@ -495,6 +551,10 @@ def _build_task_settings_schema() -> Schema:
                     Optional("mode"): Or("tag", "skip"),
                     Optional("strict"): bool,
                 },
+            },
+            Optional("bad_channel_detection"): {
+                "enabled": bool,
+                "value": bad_channel_detection_value_schema,
             },
             "eog_step": {**step_bool, "value": eog_value_schema},
             "trim_step": {**step_bool, "value": Or(int, float)},
@@ -776,6 +836,7 @@ def export_task_schema_layout() -> dict:
             "filtering": _filtering_descriptor(),
             "drop_outerlayer": {"enabled": "bool", "value": "list|None"},
             "bad_channel_log": _bad_channel_log_descriptor(),
+            "bad_channel_detection": _bad_channel_detection_descriptor(),
             "exclusion_list": _exclusion_list_descriptor(),
             "eog_step": {
                 "enabled": "bool",

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -70,6 +70,7 @@ from tqdm import tqdm
 from ulid import ULID
 
 from autoclean.configkit.schema import (
+    SchemaError,
     format_task_config_error,
     validate_task_module_config,
 )
@@ -1495,7 +1496,9 @@ class Pipeline:
         if hasattr(module, "config") and isinstance(module.config, dict):
             try:
                 task_config = validate_task_module_config(module.config)
-            except Exception as exc:
+            except SchemaError as exc:
+                if module_name in sys.modules:
+                    del sys.modules[module_name]
                 message_text = format_task_config_error(
                     exc,
                     getattr(exc, "task_config", module.config),

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -97,9 +97,11 @@ from autoclean.utils.config import hash_and_encode_yaml, load_user_config
 from autoclean.utils.database import (
     create_isolated_database,
     get_run_record,
-    set_database_path,
 )
 from autoclean.utils.database import manage_database_conditionally as manage_database
+from autoclean.utils.database import (
+    set_database_path,
+)
 from autoclean.utils.exclusion_list import ExclusionListResult, evaluate_exclusion_list
 from autoclean.utils.file_system import (
     STATUS_DIR_NAME,

--- a/src/autoclean/core/pipeline.py
+++ b/src/autoclean/core/pipeline.py
@@ -69,6 +69,11 @@ import mne
 from tqdm import tqdm
 from ulid import ULID
 
+from autoclean.configkit.schema import (
+    format_task_config_error,
+    validate_task_module_config,
+)
+
 # IMPORT TASKS HERE
 from autoclean.core.task import Task
 from autoclean.io.export import copy_final_files, save_epochs_to_set, save_raw_to_set
@@ -88,9 +93,12 @@ from autoclean.utils.auth import (
 )
 from autoclean.utils.block_errors import BlockDependencyError
 from autoclean.utils.config import hash_and_encode_yaml, load_user_config
-from autoclean.utils.database import create_isolated_database, get_run_record
+from autoclean.utils.database import (
+    create_isolated_database,
+    get_run_record,
+    set_database_path,
+)
 from autoclean.utils.database import manage_database_conditionally as manage_database
-from autoclean.utils.database import set_database_path
 from autoclean.utils.exclusion_list import ExclusionListResult, evaluate_exclusion_list
 from autoclean.utils.file_system import (
     STATUS_DIR_NAME,
@@ -1485,7 +1493,16 @@ class Pipeline:
         # Extract config dict from module if available
         task_config = {}
         if hasattr(module, "config") and isinstance(module.config, dict):
-            task_config = module.config
+            try:
+                task_config = validate_task_module_config(module.config)
+            except Exception as exc:
+                message_text = format_task_config_error(
+                    exc,
+                    getattr(exc, "task_config", module.config),
+                    task_name=task_classes[0].__name__,
+                    task_file=str(task_file_path),
+                )
+                raise ValueError(message_text) from exc
 
         return task_classes[0], task_config
 

--- a/src/autoclean/templates/custom_task_template.jinja
+++ b/src/autoclean/templates/custom_task_template.jinja
@@ -30,12 +30,9 @@ config = {
     #   With dataset_name: "Experiment1_07-03-2025"
     #   Without dataset_name: "{{ class_name }}"
     "dataset_name": "Experiment1",  # Uncomment and modify for your dataset
-    # Optional: Specify default input file or directory for this task
-    # This will be used when no input is provided via CLI or API
-    # Examples:
-    #   "input_path": "/path/to/my/data.raw",           # Single file
-    #   "input_path": "/path/to/data/directory/",       # Directory
-    "input_path": "/path/to/my/data/",  # Uncomment and modify for your data
+    # Input files/directories are selected at run time, not in task config:
+    #   autocleaneeg-pipeline input set /path/to/data
+    #   autocleaneeg-pipeline process --input /path/to/data
     # Optional: keep flagged files in standard output directories
     # "move_flagged_files": False,
     "resample_step": {"enabled": True, "value": 250},  # Resample to 250 Hz
@@ -77,46 +74,6 @@ config = {
             "psd_fmax": 45.0,  # Optional PSD ceiling for wavelet QA plots
             "bandpass": [1.0, 30.0],  # Optional pre-filter band (set to None to skip)
             "filter_kwargs": None,  # Extra args forwarded to MNE filtering
-        },
-    },
-    "bad_channel_detection": {
-        "enabled": True,
-        "value": {
-            # "auto" picks thresholds from channel_count_bins below based on
-            # EEG channel count. Other options: "low_density", "mid_density",
-            # "high_density" (force a bin regardless of channel count), or
-            # "legacy" (fixed pre-2025.09 defaults, for reproducibility).
-            "preset": "auto",
-            "cleaning_method": "interpolate",  # 'interpolate', 'drop', or None
-            "channel_count_bins": {
-                "low_density": {
-                    "max_channels": 32,
-                    # Lower = more aggressive. Suggested low-density default: 0.20
-                    "correlation_thresh": 0.20,
-                    # Lower = more aggressive. Suggested low-density default: 4.0
-                    "deviation_thresh": 4.0,
-                    # RANSAC has few neighboring channels to work with below
-                    # ~32 channels and can be unstable; off by default.
-                    "ransac_enabled": False,
-                    # Lower = stricter file flagging. Suggested default: 0.10
-                    "max_bad_fraction": 0.10,
-                },
-                "mid_density": {
-                    "min_channels": 33,
-                    "max_channels": 64,
-                    "correlation_thresh": 0.30,  # Lower = more aggressive
-                    "deviation_thresh": 3.0,  # Lower = more aggressive
-                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
-                    "max_bad_fraction": 0.15,  # Lower = stricter file flagging
-                },
-                "high_density": {
-                    "min_channels": 65,
-                    "correlation_thresh": 0.35,  # Lower = more aggressive
-                    "deviation_thresh": 2.5,  # Lower = more aggressive
-                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
-                    "max_bad_fraction": 0.20,  # Lower = stricter file flagging
-                },
-            },
         },
     },
     "reference_step": {

--- a/src/autoclean/templates/custom_task_template.jinja
+++ b/src/autoclean/templates/custom_task_template.jinja
@@ -76,6 +76,46 @@ config = {
             "filter_kwargs": None,  # Extra args forwarded to MNE filtering
         },
     },
+    "bad_channel_detection": {
+        "enabled": True,
+        "value": {
+            # "auto" picks thresholds from channel_count_bins below based on
+            # EEG channel count. Other options: "low_density", "mid_density",
+            # "high_density" (force a bin regardless of channel count), or
+            # "legacy" (fixed pre-2025.09 defaults, for reproducibility).
+            "preset": "auto",
+            "cleaning_method": "interpolate",  # 'interpolate', 'drop', or None
+            "channel_count_bins": {
+                "low_density": {
+                    "max_channels": 32,
+                    # Lower = more aggressive. Suggested low-density default: 0.20
+                    "correlation_thresh": 0.20,
+                    # Lower = more aggressive. Suggested low-density default: 4.0
+                    "deviation_thresh": 4.0,
+                    # RANSAC has few neighboring channels to work with below
+                    # ~32 channels and can be unstable; off by default.
+                    "ransac_enabled": False,
+                    # Lower = stricter file flagging. Suggested default: 0.10
+                    "max_bad_fraction": 0.10,
+                },
+                "mid_density": {
+                    "min_channels": 33,
+                    "max_channels": 64,
+                    "correlation_thresh": 0.30,  # Lower = more aggressive
+                    "deviation_thresh": 3.0,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.15,  # Lower = stricter file flagging
+                },
+                "high_density": {
+                    "min_channels": 65,
+                    "correlation_thresh": 0.35,  # Lower = more aggressive
+                    "deviation_thresh": 2.5,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.20,  # Lower = stricter file flagging
+                },
+            },
+        },
+    },
     "reference_step": {
         "enabled": True,
         "value": "average",  # Reference type: 'average', specific channels, or None

--- a/src/autoclean/templates/custom_task_template.py
+++ b/src/autoclean/templates/custom_task_template.py
@@ -76,6 +76,46 @@ config = {
             "filter_kwargs": None,  # Extra args forwarded to MNE filtering
         },
     },
+    "bad_channel_detection": {
+        "enabled": True,
+        "value": {
+            # "auto" picks thresholds from channel_count_bins below based on
+            # EEG channel count. Other options: "low_density", "mid_density",
+            # "high_density" (force a bin regardless of channel count), or
+            # "legacy" (fixed pre-2025.09 defaults, for reproducibility).
+            "preset": "auto",
+            "cleaning_method": "interpolate",  # 'interpolate', 'drop', or None
+            "channel_count_bins": {
+                "low_density": {
+                    "max_channels": 32,
+                    # Lower = more aggressive. Suggested low-density default: 0.20
+                    "correlation_thresh": 0.20,
+                    # Lower = more aggressive. Suggested low-density default: 4.0
+                    "deviation_thresh": 4.0,
+                    # RANSAC has few neighboring channels to work with below
+                    # ~32 channels and can be unstable; off by default.
+                    "ransac_enabled": False,
+                    # Lower = stricter file flagging. Suggested default: 0.10
+                    "max_bad_fraction": 0.10,
+                },
+                "mid_density": {
+                    "min_channels": 33,
+                    "max_channels": 64,
+                    "correlation_thresh": 0.30,  # Lower = more aggressive
+                    "deviation_thresh": 3.0,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.15,  # Lower = stricter file flagging
+                },
+                "high_density": {
+                    "min_channels": 65,
+                    "correlation_thresh": 0.35,  # Lower = more aggressive
+                    "deviation_thresh": 2.5,  # Lower = more aggressive
+                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
+                    "max_bad_fraction": 0.20,  # Lower = stricter file flagging
+                },
+            },
+        },
+    },
     "reference_step": {
         "enabled": True,
         "value": "average",  # Reference type: 'average', specific channels, or None

--- a/src/autoclean/templates/custom_task_template.py
+++ b/src/autoclean/templates/custom_task_template.py
@@ -30,12 +30,9 @@ config = {
     #   With dataset_name: "Experiment1_07-03-2025"
     #   Without dataset_name: "CustomTask"
     "dataset_name": "Experiment1",  # Uncomment and modify for your dataset
-    # Optional: Specify default input file or directory for this task
-    # This will be used when no input is provided via CLI or API
-    # Examples:
-    #   "input_path": "/path/to/my/data.raw",           # Single file
-    #   "input_path": "/path/to/data/directory/",       # Directory
-    "input_path": "/path/to/my/data/",  # Uncomment and modify for your data
+    # Input files/directories are selected at run time, not in task config:
+    #   autocleaneeg-pipeline input set /path/to/data
+    #   autocleaneeg-pipeline process --input /path/to/data
     # Optional: keep flagged files in standard output directories
     # "move_flagged_files": False,
     "resample_step": {"enabled": True, "value": 250},  # Resample to 250 Hz
@@ -77,46 +74,6 @@ config = {
             "psd_fmax": 45.0,  # Optional PSD ceiling for wavelet QA plots
             "bandpass": [1.0, 30.0],  # Optional pre-filter band (set to None to skip)
             "filter_kwargs": None,  # Extra args forwarded to MNE filtering
-        },
-    },
-    "bad_channel_detection": {
-        "enabled": True,
-        "value": {
-            # "auto" picks thresholds from channel_count_bins below based on
-            # EEG channel count. Other options: "low_density", "mid_density",
-            # "high_density" (force a bin regardless of channel count), or
-            # "legacy" (fixed pre-2025.09 defaults, for reproducibility).
-            "preset": "auto",
-            "cleaning_method": "interpolate",  # 'interpolate', 'drop', or None
-            "channel_count_bins": {
-                "low_density": {
-                    "max_channels": 32,
-                    # Lower = more aggressive. Suggested low-density default: 0.20
-                    "correlation_thresh": 0.20,
-                    # Lower = more aggressive. Suggested low-density default: 4.0
-                    "deviation_thresh": 4.0,
-                    # RANSAC has few neighboring channels to work with below
-                    # ~32 channels and can be unstable; off by default.
-                    "ransac_enabled": False,
-                    # Lower = stricter file flagging. Suggested default: 0.10
-                    "max_bad_fraction": 0.10,
-                },
-                "mid_density": {
-                    "min_channels": 33,
-                    "max_channels": 64,
-                    "correlation_thresh": 0.30,  # Lower = more aggressive
-                    "deviation_thresh": 3.0,  # Lower = more aggressive
-                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
-                    "max_bad_fraction": 0.15,  # Lower = stricter file flagging
-                },
-                "high_density": {
-                    "min_channels": 65,
-                    "correlation_thresh": 0.35,  # Lower = more aggressive
-                    "deviation_thresh": 2.5,  # Lower = more aggressive
-                    "ransac_corr_thresh": 0.65,  # Higher = more aggressive
-                    "max_bad_fraction": 0.20,  # Lower = stricter file flagging
-                },
-            },
         },
     },
     "reference_step": {

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -1,5 +1,6 @@
 """Unit tests for the Pipeline class."""
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -214,17 +215,21 @@ class BadTask(Task):
 
         pipeline = Pipeline(output_dir=str(tmp_path / "output"))
 
-        with patch(
-            "autoclean.core.pipeline.user_config.get_custom_task_path",
-            return_value=task_file,
-        ), pytest.raises(
-            ValueError,
-            match="Task config validation failed for BadTask",
-        ) as exc_info:
+        with (
+            patch(
+                "autoclean.core.pipeline.user_config.get_custom_task_path",
+                return_value=task_file,
+            ),
+            pytest.raises(
+                ValueError,
+                match="Task config validation failed for BadTask",
+            ) as exc_info,
+        ):
             pipeline._validate_task("BadTask")
 
         assert "Config path: config['input_path']" in str(exc_info.value)
         assert "Remove the extra key" in str(exc_info.value)
+        assert "user_task_bad_task" not in sys.modules
 
     @patch("autoclean.core.pipeline.manage_database")
     @patch("autoclean.core.pipeline.set_database_path")

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -193,6 +193,43 @@ class TestPipelineValidation:
     @patch("autoclean.core.pipeline.set_database_path")
     @patch("autoclean.core.pipeline.configure_logger")
     @patch("autoclean.core.pipeline.mne.set_log_level")
+    def test_validate_custom_task_rejects_invalid_schema_before_success(
+        self, mock_mne_log, mock_logger, mock_set_db, mock_manage_db, tmp_path
+    ):
+        """Custom task schema errors surface during task validation."""
+        task_file = tmp_path / "bad_task.py"
+        task_file.write_text(
+            """from autoclean.core.task import Task
+from autoclean.templates.custom_task_template import config as template_config
+
+config = dict(template_config)
+config["input_path"] = "/tmp/data"
+
+class BadTask(Task):
+    def run(self):
+        pass
+""",
+            encoding="utf-8",
+        )
+
+        pipeline = Pipeline(output_dir=str(tmp_path / "output"))
+
+        with patch(
+            "autoclean.core.pipeline.user_config.get_custom_task_path",
+            return_value=task_file,
+        ), pytest.raises(
+            ValueError,
+            match="Task config validation failed for BadTask",
+        ) as exc_info:
+            pipeline._validate_task("BadTask")
+
+        assert "Config path: config['input_path']" in str(exc_info.value)
+        assert "Remove the extra key" in str(exc_info.value)
+
+    @patch("autoclean.core.pipeline.manage_database")
+    @patch("autoclean.core.pipeline.set_database_path")
+    @patch("autoclean.core.pipeline.configure_logger")
+    @patch("autoclean.core.pipeline.mne.set_log_level")
     def test_validate_file_valid(
         self, mock_mne_log, mock_logger, mock_set_db, mock_manage_db, tmp_path
     ):

--- a/tests/unit/core/test_pipeline_python_tasks.py
+++ b/tests/unit/core/test_pipeline_python_tasks.py
@@ -40,10 +40,10 @@ class TestPipelinePythonTasks:
             task_content = """
 from typing import Any, Dict
 from autoclean.core.task import Task
+from autoclean.templates.custom_task_template import config as template_config
 
-config = {
-    'resample_step': {'enabled': True, 'value': 250}
-}
+config = dict(template_config)
+config['resample_step'] = {'enabled': True, 'value': 250}
 
 class MockTestTask(Task):
     def __init__(self, config: Dict[str, Any]):
@@ -146,6 +146,10 @@ class TestListTask(Task):
             # Add Python task
             task_content = """
 from autoclean.core.task import Task
+from autoclean.templates.custom_task_template import config as template_config
+
+config = dict(template_config)
+config['resample_step'] = {'enabled': True, 'value': 250}
 
 class PythonTask(Task):
     def run(self):
@@ -183,11 +187,14 @@ class PythonTask(Task):
             result = pipeline._validate_task("MockPythonTask")
             assert result == "MockPythonTask"
 
-    @pytest.mark.parametrize("lookup,expected", [
-        ("CamelCaseTask", "CamelCaseTask"),
-        ("camelcasetask", "camelcasetask"),
-        ("CAMELCASETASK", "CAMELCASETASK"),
-    ])
+    @pytest.mark.parametrize(
+        "lookup,expected",
+        [
+            ("CamelCaseTask", "CamelCaseTask"),
+            ("camelcasetask", "camelcasetask"),
+            ("CAMELCASETASK", "CAMELCASETASK"),
+        ],
+    )
     def test_validate_task_preserves_input_case_while_matching_case_insensitively(
         self, lookup, expected
     ):
@@ -289,7 +296,6 @@ class PythonTask(Task):
                 assert task in final_tasks
 
 
-
 @pytest.mark.skipif(
     not PIPELINE_AVAILABLE, reason="Pipeline module not available for import"
 )
@@ -325,10 +331,13 @@ class TestPipelineUtilities:
             task_with_settings = """
 from typing import Any, Dict
 from autoclean.core.task import Task
+from autoclean.templates.custom_task_template import config as template_config
 
-config = {
-    'montage': {'enabled': True, 'value': 'GSN-HydroCel-129'},
-    'filtering': {'enabled': True, 'value': {'l_freq': 1, 'h_freq': 40}}
+config = dict(template_config)
+config['montage'] = {'enabled': True, 'value': 'GSN-HydroCel-129'}
+config['filtering'] = {
+    'enabled': True,
+    'value': {'l_freq': 1, 'h_freq': 40, 'notch_freqs': None},
 }
 
 class SettingsTask(Task):

--- a/tests/unit/templates/test_custom_task_template.py
+++ b/tests/unit/templates/test_custom_task_template.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pytest
 
+from autoclean.configkit.schema import validate_task_module_config
+from autoclean.templates.custom_task_template import config as custom_template_config
 from autoclean.utils.template_renderer import (
     render_template,
     validate_python_identifier,
@@ -16,6 +18,13 @@ def test_custom_task_template_matches_python() -> None:
     rendered = render_template(jinja_template, {"class_name": "CustomTask"})
 
     assert canonical_python.read_text(encoding="utf-8") == rendered
+
+
+def test_custom_task_template_config_matches_schema() -> None:
+    validated = validate_task_module_config(custom_template_config)
+
+    assert "input_path" not in validated
+    assert validated["schema_version"] == custom_template_config["schema_version"]
 
 
 def test_render_template_missing_file(tmp_path: Path) -> None:

--- a/tests/unit/templates/test_custom_task_template.py
+++ b/tests/unit/templates/test_custom_task_template.py
@@ -11,7 +11,9 @@ from autoclean.utils.template_renderer import (
 
 
 def test_custom_task_template_matches_python() -> None:
-    templates_dir = Path(__file__).resolve().parents[3] / "src" / "autoclean" / "templates"
+    templates_dir = (
+        Path(__file__).resolve().parents[3] / "src" / "autoclean" / "templates"
+    )
     jinja_template = templates_dir / "custom_task_template.jinja"
     canonical_python = templates_dir / "custom_task_template.py"
 
@@ -24,6 +26,11 @@ def test_custom_task_template_config_matches_schema() -> None:
     validated = validate_task_module_config(custom_template_config)
 
     assert "input_path" not in validated
+    assert validated["bad_channel_detection"]["value"]["preset"] == "auto"
+    assert (
+        validated["bad_channel_detection"]["value"]["cleaning_method"] == "interpolate"
+    )
+    assert "channel_count_bins" in validated["bad_channel_detection"]["value"]
     assert validated["schema_version"] == custom_template_config["schema_version"]
 
 

--- a/tests/unit/test_python_task_files.py
+++ b/tests/unit/test_python_task_files.py
@@ -47,10 +47,13 @@ class TestPythonTaskFiles:
         task_content = """
 from typing import Any, Dict
 from autoclean.core.task import Task
+from autoclean.templates.custom_task_template import config as template_config
 
-config = {
-    'resample_step': {'enabled': True, 'value': 250},
-    'filtering': {'enabled': True, 'value': {'l_freq': 1, 'h_freq': 40}}
+config = dict(template_config)
+config['resample_step'] = {'enabled': True, 'value': 250}
+config['filtering'] = {
+    'enabled': True,
+    'value': {'l_freq': 1, 'h_freq': 40, 'notch_freqs': None},
 }
 
 class TestTask(Task):
@@ -184,10 +187,10 @@ class TestTask(Task):
             # Add a Python task
             python_task_content = """
 from autoclean.core.task import Task
+from autoclean.templates.custom_task_template import config as template_config
 
-config = {
-    'resample_step': {'enabled': True, 'value': 250}
-}
+config = dict(template_config)
+config['resample_step'] = {'enabled': True, 'value': 250}
 
 class PythonTask(Task):
     def __init__(self, config):


### PR DESCRIPTION
## Summary
- remove schema-invalid input_path from the generated custom task template and point users to runtime input selection
- validate Python task config during task loading so invalid custom tasks fail before a misleading validation success
- add focused regression coverage for template/schema validity and invalid custom task errors

Closes #274

## Tests
- HOME=/tmp/autoclean-home-codex MPLCONFIGDIR=/tmp/mpl-codex MNE_DONTWRITE_HOME=true MNE_HOME=/tmp/mne-codex python -B -m pytest -p no:cacheprovider --no-cov tests/unit/templates/test_custom_task_template.py tests/unit/core/test_pipeline.py::TestPipelineValidation::test_validate_custom_task_rejects_invalid_schema_before_success -q
- UV_CACHE_DIR=/tmp/uv-cache-codex uvx ruff check --select I,F,FLY src/autoclean/core/pipeline.py tests/unit/core/test_pipeline.py tests/unit/templates/test_custom_task_template.py src/autoclean/templates/custom_task_template.py
- git diff --check