### PR TITLE
feat: add CLI montage preflight

### DIFF
--- a/docs/command_reference.rst
+++ b/docs/command_reference.rst
@@ -461,6 +461,37 @@ Montage Commands
 
       autocleaneeg-pipeline montage test
 
+``autocleaneeg-pipeline montage preflight --input /path/to/input --task /path/to/Task.py --output /path/to/workspace``
+   Scan an EEG file or folder for supported HydroCel 128/129 montage layouts
+   before batch processing. The command writes
+   ``autoclean_montage_scan.csv`` and
+   ``autoclean_montage_batch_plan.json`` and defaults to review-only behavior.
+   Use ``--apply --copy-originals`` and/or ``--clone-tasks`` for explicitly
+   approved copy and task-clone actions.
+
+   Example:
+
+   .. code-block:: bash
+
+      autocleaneeg-pipeline montage preflight \
+        --input /path/to/input_mixed_hydrocel \
+        --task /path/to/workspace/tasks/RestingState_Basic_128.py \
+        --output /path/to/workspace
+
+   Apply example:
+
+   .. code-block:: bash
+
+      autocleaneeg-pipeline montage preflight \
+        --input /path/to/input_mixed_hydrocel \
+        --task /path/to/workspace/tasks/RestingState_Basic_128.py \
+        --output /path/to/workspace \
+        --apply \
+        --copy-originals \
+        --split-output-root /path/to/workspace/montage_preflight_split_inputs \
+        --clone-tasks \
+        --task-output-dir /path/to/workspace/tasks/montage_preflight
+
 Block Commands
 --------------
 

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -61,6 +61,14 @@ from autoclean.utils.file_system import update_status_marker
 from autoclean.utils.logging import has_logged_errors, message
 from autoclean.utils.matlab_runtime import detect_matlab_engine, start_matlab_engine
 from autoclean.utils.montage import load_valid_montages
+from autoclean.utils.montage_preflight import (
+    build_batch_plan,
+    clone_tasks_for_mismatches,
+    copy_originals_for_plan,
+    write_apply_summary,
+    write_batch_plan_json,
+    write_scan_csv,
+)
 from autoclean.utils.montage_validation import (
     analyze_channels,
     create_3d_plot,
@@ -75,6 +83,11 @@ from autoclean.utils.task_discovery import (
     get_task_by_name,
     get_task_overrides,
     safe_discover_tasks,
+)
+from autoclean.utils.task_montage import (
+    extract_montage_value,
+    locate_montage_block,
+    replace_montage_value,
 )
 from autoclean.utils.template_renderer import (
     render_template,
@@ -1727,6 +1740,71 @@ For detailed help on any command: autocleaneeg-pipeline <command> --help
         add_help=False,
     )
     attach_rich_help(montage_test_parser)
+
+    montage_preflight_parser = montage_subparsers.add_parser(
+        "preflight",
+        help="Scan inputs for HydroCel montage mismatches before batch processing",
+        add_help=False,
+    )
+    attach_rich_help(montage_preflight_parser)
+    montage_preflight_parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="EEG file or folder to scan",
+    )
+    montage_preflight_parser.add_argument(
+        "--task",
+        required=True,
+        type=Path,
+        help="Python task file whose montage config is expected",
+    )
+    montage_preflight_parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Directory for scan CSV, batch-plan JSON, and apply summary",
+    )
+    montage_preflight_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Review only; write scan artifacts without copying or cloning",
+    )
+    montage_preflight_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply explicitly requested copy/clone actions",
+    )
+    montage_preflight_parser.add_argument(
+        "--copy-originals",
+        action="store_true",
+        help="Copy actionable inputs into montage-specific folders",
+    )
+    montage_preflight_parser.add_argument(
+        "--split-output-root",
+        type=Path,
+        help="Destination root for copied montage-specific input folders",
+    )
+    montage_preflight_parser.add_argument(
+        "--clone-tasks",
+        action="store_true",
+        help="Clone the selected task for detected mismatch montages",
+    )
+    montage_preflight_parser.add_argument(
+        "--task-output-dir",
+        type=Path,
+        help="Destination directory for cloned task files",
+    )
+    montage_preflight_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for apply actions",
+    )
+    montage_preflight_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting generated copy/clone destinations",
+    )
 
     # Blocks management commands
     blocks_parser = subparsers.add_parser(
@@ -4171,6 +4249,8 @@ def cmd_montage(args) -> int:
         return cmd_montage_set(args)
     if action == "test":
         return cmd_montage_test(args)
+    if action == "preflight":
+        return cmd_montage_preflight(args)
 
     message("error", f"Unknown montage action: {action}")
     return 1
@@ -4217,6 +4297,135 @@ def cmd_montage_list(args) -> int:
     )
 
     return 0
+
+
+def cmd_montage_preflight(args) -> int:
+    """Run montage preflight scan and optional apply steps."""
+
+    console = get_console(args)
+    input_path = Path(args.input)
+    task_path = Path(args.task)
+    output_dir = Path(args.output)
+
+    if not input_path.exists():
+        message("error", f"Input path does not exist: {input_path}")
+        return 1
+    if not task_path.is_file():
+        message("error", f"Task file does not exist: {task_path}")
+        return 1
+    if args.apply and args.dry_run:
+        message("error", "Use either --dry-run or --apply, not both.")
+        return 1
+
+    try:
+        plan = build_batch_plan(
+            input_path=input_path,
+            task_path=task_path,
+            output_dir=output_dir,
+        )
+        csv_path = write_scan_csv(plan, output_dir)
+        plan_path = write_batch_plan_json(plan, output_dir)
+    except Exception as exc:  # pylint: disable=broad-except
+        message("error", f"Montage preflight failed: {exc}")
+        return 1
+
+    _print_montage_preflight_summary(console, plan, csv_path, plan_path)
+
+    if not args.apply:
+        console.print("[muted]Dry run only. No files copied and no tasks cloned.[/muted]")
+        return 0
+
+    copy_result = None
+    cloned_tasks = []
+
+    if args.copy_originals:
+        if args.split_output_root is None:
+            message("error", "--copy-originals requires --split-output-root")
+            return 1
+        if not args.yes and not _confirm_preflight_action(
+            args,
+            "Copy actionable input files into montage-specific folders?",
+        ):
+            message("info", "Copy step skipped.")
+        else:
+            try:
+                copy_result = copy_originals_for_plan(
+                    plan,
+                    split_output_root=Path(args.split_output_root),
+                    overwrite=args.overwrite,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                message("error", f"Copy step failed: {exc}")
+                return 1
+
+    if args.clone_tasks:
+        if args.task_output_dir is None:
+            message("error", "--clone-tasks requires --task-output-dir")
+            return 1
+        if not args.yes and not _confirm_preflight_action(
+            args,
+            "Clone task files for detected mismatch montages?",
+        ):
+            message("info", "Task clone step skipped.")
+        else:
+            try:
+                cloned_tasks = clone_tasks_for_mismatches(
+                    plan=plan,
+                    task_output_dir=Path(args.task_output_dir),
+                    overwrite=args.overwrite,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                message("error", f"Task clone step failed: {exc}")
+                return 1
+
+    summary_path = write_apply_summary(
+        output_dir=output_dir,
+        copy_result=copy_result,
+        cloned_tasks=cloned_tasks,
+    )
+    message("success", f"✓ Montage preflight apply summary written: {summary_path}")
+    return 0
+
+
+def _print_montage_preflight_summary(console, plan, csv_path: Path, plan_path: Path):
+    """Render a compact montage preflight summary."""
+
+    console.print()
+    console.print("[title]Montage Preflight[/title]")
+    console.print(f"Expected montage: [accent]{plan.expected_montage}[/accent]")
+    console.print(f"Files scanned: [accent]{len(plan.files)}[/accent]")
+    console.print()
+
+    table = Table(show_header=True, header_style="header", box=None, padding=(0, 1))
+    table.add_column("Detected", style="accent")
+    table.add_column("Status")
+    table.add_column("Files", justify="right")
+    table.add_column("Examples", style="muted")
+    for group in plan.groups:
+        table.add_row(
+            group.detected_montage,
+            group.status,
+            str(group.file_count),
+            ", ".join(group.examples),
+        )
+    console.print(table)
+    console.print()
+    console.print(f"Scan CSV: [info]{csv_path}[/info]")
+    console.print(f"Batch plan: [info]{plan_path}[/info]")
+    if plan.unknown_files:
+        console.print(
+            f"[warning]{len(plan.unknown_files)} unknown/unsupported file(s) were not routed.[/warning]"
+        )
+
+
+def _confirm_preflight_action(args, prompt: str) -> bool:
+    try:
+        from rich.prompt import Confirm
+
+        return Confirm.ask(prompt, default=False)
+    except Exception:
+        response = input(f"{prompt} [y/N] ").strip().lower()
+        return response in {"y", "yes"}
 
 
 def cmd_montage_set(args) -> int:
@@ -4844,83 +5053,22 @@ def _prompt_for_montage(args, montages, current_value):
 def _locate_montage_block(text: str):
     """Find the montage configuration block in a task file."""
 
-    match = re.search(r"[\"']montage[\"']\s*:\s*\{", text)
-    if not match:
+    block = locate_montage_block(text)
+    if block is None:
         return None, None, None
-
-    brace_start = text.find("{", match.start())
-    if brace_start == -1:
-        return None, None, None
-
-    depth = 0
-    in_string: Optional[str] = None
-    escape = False
-
-    for idx in range(brace_start, len(text)):
-        char = text[idx]
-        if in_string:
-            if escape:
-                escape = False
-            elif char == "\\":
-                escape = True
-            elif char == in_string:
-                in_string = None
-        else:
-            if char in {'"', "'"}:
-                in_string = char
-            elif char == "{":
-                depth += 1
-            elif char == "}":
-                depth -= 1
-                if depth == 0:
-                    block_end = idx + 1
-                    block_start = match.start()
-                    return text[block_start:block_end], block_start, block_end
-
-    return None, None, None
+    return block.text, block.start, block.end
 
 
 def _extract_montage_value(block_text: str) -> Optional[str]:
     """Extract the montage value from the montage block."""
 
-    value_match = re.search(
-        r"([\"\']value[\"\']\s*:\s*)(?P<quote>[\"\'])(?P<val>.*?)(?P=quote)",
-        block_text,
-        re.DOTALL,
-    )
-    if value_match:
-        return value_match.group("val")
-
-    none_match = re.search(r"[\"\']value[\"\']\s*:\s*None", block_text)
-    if none_match:
-        return None
-
-    return None
+    return extract_montage_value(block_text)
 
 
 def _replace_montage_value(block_text: str, new_value: str) -> Optional[str]:
     """Return a montage block with the value replaced."""
 
-    string_match = re.search(
-        r"([\"\']value[\"\']\s*:\s*)(?P<quote>[\"\'])(?P<val>.*?)(?P=quote)",
-        block_text,
-        re.DOTALL,
-    )
-    if string_match:
-        prefix = block_text[: string_match.start()]
-        suffix = block_text[string_match.end() :]
-        quote = string_match.group("quote")
-        replacement = f"{string_match.group(1)}{quote}{new_value}{quote}"
-        return prefix + replacement + suffix
-
-    none_match = re.search(r"([\"\']value[\"\']\s*:\s*)None", block_text)
-    if none_match:
-        prefix = block_text[: none_match.start()]
-        suffix = block_text[none_match.end() :]
-        replacement = f'{none_match.group(1)}"{new_value}"'
-        return prefix + replacement + suffix
-
-    return None
+    return replace_montage_value(block_text, new_value)
 
 
 def cmd_review(args) -> int:

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -66,6 +66,7 @@ from autoclean.utils.montage_preflight import (
     build_batch_plan,
     clone_tasks_for_mismatches,
     copy_originals_for_plan,
+    estimate_copy_originals_for_plan,
     write_apply_summary,
     write_batch_plan_json,
     write_scan_csv,
@@ -4352,6 +4353,15 @@ def cmd_montage_preflight(args) -> int:
         if args.split_output_root is None:
             message("error", "--copy-originals requires --split-output-root")
             return 1
+        try:
+            copy_estimate = estimate_copy_originals_for_plan(
+                plan,
+                split_output_root=Path(args.split_output_root),
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            message("error", f"Copy estimate failed: {exc}")
+            return 1
+        _print_montage_copy_estimate(console, copy_estimate)
         if not args.yes and not _confirm_preflight_action(
             args,
             "Copy actionable input files into montage-specific folders?",
@@ -4438,6 +4448,30 @@ def _print_montage_preflight_summary(console, plan, csv_path: Path, plan_path: P
         console.print(
             f"[warning]{len(plan.unknown_files)} unknown/unsupported file(s) were not routed.[/warning]"
         )
+
+
+def _print_montage_copy_estimate(console, copy_estimate) -> None:
+    """Render copy-originals size and free-space estimate before confirmation."""
+
+    console.print()
+    console.print("[header]Copy Originals Estimate[/header]")
+    console.print(f"Destination: [info]{copy_estimate.split_output_root}[/info]")
+    console.print(
+        "Actionable files: "
+        f"[accent]{copy_estimate.actionable_file_count}[/accent]"
+        f" ([muted]{copy_estimate.skipped_file_count} skipped/unknown[/muted])"
+    )
+    console.print(
+        "Required space: " f"[accent]{copy_estimate.required_bytes:,} bytes[/accent]"
+    )
+    console.print(
+        "Available space: "
+        f"[accent]{copy_estimate.free_bytes_before:,} bytes[/accent]"
+    )
+    console.print(
+        "Estimated free after copy: "
+        f"[accent]{copy_estimate.free_bytes_after_estimate:,} bytes[/accent]"
+    )
 
 
 def _confirm_preflight_action(args, prompt: str) -> bool:

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -4332,7 +4332,9 @@ def cmd_montage_preflight(args) -> int:
     _print_montage_preflight_summary(console, plan, csv_path, plan_path)
 
     if not args.apply:
-        console.print("[muted]Dry run only. No files copied and no tasks cloned.[/muted]")
+        console.print(
+            "[muted]Dry run only. No files copied and no tasks cloned.[/muted]"
+        )
         return 0
 
     copy_result = None
@@ -6069,7 +6071,7 @@ def cmd_wizard(args) -> int:
                 break
 
         # Step 3 — Montage selection
-        (_, _, active_task, active_task_path, current_montage, _) = (
+        _, _, active_task, active_task_path, current_montage, _ = (
             _wizard_collect_state()
         )
 
@@ -6192,7 +6194,7 @@ def cmd_wizard(args) -> int:
                 )
 
         # Step 4 — Input source
-        (*_, _, current_input) = _wizard_collect_state()
+        *_, _, current_input = _wizard_collect_state()
 
         display.header(
             "Step 4 • Input",

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -62,6 +62,7 @@ from autoclean.utils.logging import has_logged_errors, message
 from autoclean.utils.matlab_runtime import detect_matlab_engine, start_matlab_engine
 from autoclean.utils.montage import load_valid_montages
 from autoclean.utils.montage_preflight import (
+    MontageCopyError,
     build_batch_plan,
     clone_tasks_for_mismatches,
     copy_originals_for_plan,
@@ -1768,7 +1769,7 @@ For detailed help on any command: autocleaneeg-pipeline <command> --help
     montage_preflight_parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Review only; write scan artifacts without copying or cloning",
+        help="Explicitly select the default review-only mode; cannot be combined with --apply",
     )
     montage_preflight_parser.add_argument(
         "--apply",
@@ -4316,6 +4317,13 @@ def cmd_montage_preflight(args) -> int:
     if args.apply and args.dry_run:
         message("error", "Use either --dry-run or --apply, not both.")
         return 1
+    if not args.apply and (args.copy_originals or args.clone_tasks):
+        message(
+            "error",
+            "--copy-originals and --clone-tasks require --apply; "
+            "rerun with --apply or omit apply-only flags for dry-run review.",
+        )
+        return 1
 
     try:
         plan = build_batch_plan(
@@ -4356,6 +4364,18 @@ def cmd_montage_preflight(args) -> int:
                     split_output_root=Path(args.split_output_root),
                     overwrite=args.overwrite,
                 )
+            except MontageCopyError as exc:
+                summary_path = write_apply_summary(
+                    output_dir=output_dir,
+                    copy_result=exc.partial_result,
+                    cloned_tasks=cloned_tasks,
+                )
+                message("error", f"Copy step failed: {exc}")
+                message(
+                    "error",
+                    f"Partial copy summary written: {summary_path}",
+                )
+                return 1
             except Exception as exc:  # pylint: disable=broad-except
                 message("error", f"Copy step failed: {exc}")
                 return 1

--- a/src/autoclean/utils/montage_preflight.py
+++ b/src/autoclean/utils/montage_preflight.py
@@ -97,6 +97,18 @@ class MontageCopyResult:
     errors: list[dict] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class MontageCopyEstimate:
+    """Pre-confirmation size and free-space estimate for copy-originals."""
+
+    split_output_root: str
+    actionable_file_count: int
+    skipped_file_count: int
+    required_bytes: int
+    free_bytes_before: int
+    free_bytes_after_estimate: int
+
+
 class MontageCopyError(RuntimeError):
     """Raised when copy-originals fails after recording partial progress."""
 
@@ -328,11 +340,14 @@ def copy_originals_for_plan(
 ) -> MontageCopyResult:
     """Copy actionable original inputs into montage-specific folders."""
 
+    estimate = estimate_copy_originals_for_plan(
+        plan,
+        split_output_root=split_output_root,
+    )
     actionable = [result for result in plan.files if result.is_actionable]
-    required_bytes = sum(result.size_bytes for result in actionable)
-    disk_usage_path = _nearest_existing_path(split_output_root.parent)
-    free_before = shutil.disk_usage(disk_usage_path).free
-    free_after = free_before - required_bytes
+    required_bytes = estimate.required_bytes
+    free_before = estimate.free_bytes_before
+    free_after = estimate.free_bytes_after_estimate
     if required_bytes > free_before:
         raise RuntimeError(
             "Insufficient free space for montage preflight copy: "
@@ -401,6 +416,27 @@ def copy_originals_for_plan(
         required_bytes=required_bytes,
         free_bytes_before=free_before,
         free_bytes_after_estimate=free_after,
+    )
+
+
+def estimate_copy_originals_for_plan(
+    plan: MontageBatchPlan,
+    *,
+    split_output_root: Path,
+) -> MontageCopyEstimate:
+    """Estimate copy-originals size and destination free space without copying."""
+
+    actionable = [result for result in plan.files if result.is_actionable]
+    required_bytes = sum(result.size_bytes for result in actionable)
+    disk_usage_path = _nearest_existing_path(split_output_root.parent)
+    free_before = shutil.disk_usage(disk_usage_path).free
+    return MontageCopyEstimate(
+        split_output_root=str(split_output_root),
+        actionable_file_count=len(actionable),
+        skipped_file_count=len(plan.unknown_files),
+        required_bytes=required_bytes,
+        free_bytes_before=free_before,
+        free_bytes_after_estimate=free_before - required_bytes,
     )
 
 

--- a/src/autoclean/utils/montage_preflight.py
+++ b/src/autoclean/utils/montage_preflight.py
@@ -12,7 +12,7 @@ from typing import Callable
 
 import mne
 
-from autoclean.io.import_ import get_format_from_extension
+from autoclean.io.import_ import discover_plugins, get_format_from_extension
 from autoclean.utils.task_montage import (
     read_task_montage,
     replace_task_class_name,
@@ -93,6 +93,16 @@ class MontageCopyResult:
     required_bytes: int
     free_bytes_before: int
     free_bytes_after_estimate: int
+    completed: bool = True
+    errors: list[dict] = field(default_factory=list)
+
+
+class MontageCopyError(RuntimeError):
+    """Raised when copy-originals fails after recording partial progress."""
+
+    def __init__(self, message: str, partial_result: MontageCopyResult) -> None:
+        super().__init__(message)
+        self.partial_result = partial_result
 
 
 @dataclass(frozen=True)
@@ -119,11 +129,17 @@ def discover_eeg_inputs(input_path: Path) -> list[Path]:
         raise FileNotFoundError(f"Input path does not exist: {input_path}")
 
     inputs: list[Path] = []
-    for child in input_path.rglob("*"):
-        if child.is_dir() and child.suffix.lower() == ".mff":
-            inputs.append(child)
-        elif child.is_file() and get_format_from_extension(child.suffix):
-            inputs.append(child)
+    pending = [input_path]
+    while pending:
+        current = pending.pop()
+        children = sorted(current.iterdir())
+        for child in children:
+            if child.is_dir() and child.suffix.lower() == ".mff":
+                inputs.append(child)
+            elif child.is_dir():
+                pending.append(child)
+            elif child.is_file() and get_format_from_extension(child.suffix):
+                inputs.append(child)
 
     return sorted(inputs)
 
@@ -234,6 +250,7 @@ def build_batch_plan(
 ) -> MontageBatchPlan:
     """Scan inputs and build a dry-run montage batch plan."""
 
+    discover_plugins()
     expected_montage = read_task_montage(task_path)
     if input_path.is_dir() and input_path.suffix.lower() == ".mff":
         input_root = input_path.parent
@@ -313,7 +330,8 @@ def copy_originals_for_plan(
 
     actionable = [result for result in plan.files if result.is_actionable]
     required_bytes = sum(result.size_bytes for result in actionable)
-    free_before = shutil.disk_usage(split_output_root.parent).free
+    disk_usage_path = _nearest_existing_path(split_output_root.parent)
+    free_before = shutil.disk_usage(disk_usage_path).free
     free_after = free_before - required_bytes
     if required_bytes > free_before:
         raise RuntimeError(
@@ -321,23 +339,51 @@ def copy_originals_for_plan(
             f"need {required_bytes} bytes, available {free_before} bytes"
         )
 
-    copied: list[dict] = []
-    skipped = list(plan.unknown_files)
-    for result in actionable:
-        destination = (
-            split_output_root / str(result.detected_montage) / result.relative_path
+    copy_targets = [
+        (
+            result,
+            split_output_root / str(result.detected_montage) / result.relative_path,
         )
+        for result in actionable
+    ]
+    for _result, destination in copy_targets:
         if destination.exists() and not overwrite:
             raise FileExistsError(
                 f"Refusing to overwrite existing destination: {destination}"
             )
 
+    copied: list[dict] = []
+    skipped = list(plan.unknown_files)
+    for result, destination in copy_targets:
         destination.parent.mkdir(parents=True, exist_ok=True)
         source = Path(result.path)
-        if source.is_dir():
-            shutil.copytree(source, destination, dirs_exist_ok=overwrite)
-        else:
-            shutil.copy2(source, destination)
+        try:
+            if source.is_dir():
+                shutil.copytree(source, destination, dirs_exist_ok=overwrite)
+            else:
+                shutil.copy2(source, destination)
+        except Exception as exc:
+            partial_result = MontageCopyResult(
+                split_output_root=str(split_output_root),
+                copied_files=copied,
+                skipped_files=skipped,
+                required_bytes=required_bytes,
+                free_bytes_before=free_before,
+                free_bytes_after_estimate=free_after,
+                completed=False,
+                errors=[
+                    {
+                        "source": result.path,
+                        "destination": str(destination),
+                        "error": str(exc),
+                    }
+                ],
+            )
+            raise MontageCopyError(
+                "Copy failed after "
+                f"{len(copied)} file(s): {result.path} -> {destination}: {exc}",
+                partial_result,
+            ) from exc
 
         copied.append(
             {
@@ -500,6 +546,18 @@ def _path_size(path: Path) -> int:
     if path.is_dir():
         return sum(child.stat().st_size for child in path.rglob("*") if child.is_file())
     return path.stat().st_size if path.exists() else 0
+
+
+def _nearest_existing_path(path: Path) -> Path:
+    current = path
+    while not current.exists():
+        parent = current.parent
+        if parent == current:
+            raise FileNotFoundError(
+                f"No existing parent directory for copy destination: {path}"
+            )
+        current = parent
+    return current
 
 
 def _first_task_class_name(source: str) -> str:

--- a/src/autoclean/utils/montage_preflight.py
+++ b/src/autoclean/utils/montage_preflight.py
@@ -1,0 +1,522 @@
+"""Montage preflight scanning, planning, and apply helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+import shutil
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Callable
+
+import mne
+
+from autoclean.io.import_ import get_format_from_extension
+from autoclean.utils.task_montage import (
+    read_task_montage,
+    replace_task_class_name,
+    update_task_montage_source,
+)
+
+SUPPORTED_HYDROCEL_MONTAGES = {"GSN-HydroCel-128", "GSN-HydroCel-129"}
+
+
+@dataclass(frozen=True)
+class MontagePreflightFileResult:
+    """Preflight result for one input path."""
+
+    path: str
+    relative_path: str
+    format_id: str | None
+    expected_montage: str | None
+    detected_montage: str | None
+    status: str
+    eeg_channel_count: int | None = None
+    e129_present: bool = False
+    reason: str = ""
+    size_bytes: int = 0
+
+    @property
+    def is_actionable(self) -> bool:
+        """Return True when this file can be routed automatically."""
+
+        return self.detected_montage in SUPPORTED_HYDROCEL_MONTAGES
+
+
+@dataclass(frozen=True)
+class MontagePreflightGroup:
+    """Grouped preflight results by status and detected montage."""
+
+    detected_montage: str
+    status: str
+    file_count: int
+    total_size_bytes: int
+    examples: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MontageBatchPlan:
+    """Dry-run batch plan emitted by montage preflight."""
+
+    input_path: str
+    task_path: str
+    expected_montage: str | None
+    output_dir: str
+    groups: list[MontagePreflightGroup]
+    files: list[MontagePreflightFileResult]
+    unknown_files: list[str]
+    actionable_files: list[str]
+
+    def to_json_dict(self) -> dict:
+        """Return a JSON-serializable representation."""
+
+        return {
+            "input_path": self.input_path,
+            "task_path": self.task_path,
+            "expected_montage": self.expected_montage,
+            "output_dir": self.output_dir,
+            "groups": [asdict(group) for group in self.groups],
+            "files": [asdict(result) for result in self.files],
+            "unknown_files": self.unknown_files,
+            "actionable_files": self.actionable_files,
+        }
+
+
+@dataclass(frozen=True)
+class MontageCopyResult:
+    """Summary of a copy-originals apply step."""
+
+    split_output_root: str
+    copied_files: list[dict]
+    skipped_files: list[str]
+    required_bytes: int
+    free_bytes_before: int
+    free_bytes_after_estimate: int
+
+
+@dataclass(frozen=True)
+class MontageTaskCloneResult:
+    """Summary of one cloned task file."""
+
+    source_task: str
+    cloned_task: str
+    source_montage: str | None
+    cloned_montage: str
+    class_name: str
+
+
+def discover_eeg_inputs(input_path: Path) -> list[Path]:
+    """Return supported file inputs under a file or directory."""
+
+    if input_path.is_file():
+        return [input_path]
+
+    if input_path.is_dir() and input_path.suffix.lower() == ".mff":
+        return [input_path]
+
+    if not input_path.is_dir():
+        raise FileNotFoundError(f"Input path does not exist: {input_path}")
+
+    inputs: list[Path] = []
+    for child in input_path.rglob("*"):
+        if child.is_dir() and child.suffix.lower() == ".mff":
+            inputs.append(child)
+        elif child.is_file() and get_format_from_extension(child.suffix):
+            inputs.append(child)
+
+    return sorted(inputs)
+
+
+def detect_hydrocel_montage(raw) -> tuple[str | None, int | None, bool, str]:
+    """Classify HydroCel 128/129 layouts without changing channels."""
+
+    ch_names = list(getattr(raw, "ch_names", []))
+    try:
+        ch_types = raw.get_channel_types()
+    except Exception:
+        ch_types = ["eeg" if re.fullmatch(r"E\d+", name) else "misc" for name in ch_names]
+
+    eeg_names = [
+        name for name, ch_type in zip(ch_names, ch_types, strict=False) if ch_type == "eeg"
+    ]
+    if not eeg_names and ch_names:
+        eeg_names = [name for name in ch_names if re.fullmatch(r"E\d+", name)]
+
+    eeg_count = len(eeg_names)
+    e129_present = "E129" in eeg_names
+
+    if eeg_count == 128 and not e129_present:
+        return "GSN-HydroCel-128", eeg_count, e129_present, ""
+    if eeg_count == 129 and e129_present:
+        return "GSN-HydroCel-129", eeg_count, e129_present, ""
+
+    return (
+        None,
+        eeg_count,
+        e129_present,
+        "Unsupported or ambiguous HydroCel channel layout",
+    )
+
+
+def scan_file(
+    file_path: Path,
+    *,
+    input_root: Path,
+    expected_montage: str | None,
+    raw_loader: Callable[[Path], object] | None = None,
+) -> MontagePreflightFileResult:
+    """Scan one EEG file with header-only loading when possible."""
+
+    format_id = get_format_from_extension(file_path.suffix)
+    relative_path = _relative_to_input(file_path, input_root)
+    size_bytes = _path_size(file_path)
+
+    if format_id is None:
+        return MontagePreflightFileResult(
+            path=str(file_path),
+            relative_path=relative_path,
+            format_id=None,
+            expected_montage=expected_montage,
+            detected_montage=None,
+            status="unsupported",
+            reason="Unsupported file extension",
+            size_bytes=size_bytes,
+        )
+
+    loader = raw_loader or _read_raw_header
+    try:
+        raw = loader(file_path)
+        detected, eeg_count, e129_present, reason = detect_hydrocel_montage(raw)
+    except Exception as exc:
+        return MontagePreflightFileResult(
+            path=str(file_path),
+            relative_path=relative_path,
+            format_id=format_id,
+            expected_montage=expected_montage,
+            detected_montage=None,
+            status="unknown",
+            reason=f"Could not read EEG header: {exc}",
+            size_bytes=size_bytes,
+        )
+
+    if detected is None:
+        status = "unknown"
+    elif detected == expected_montage:
+        status = "match"
+    else:
+        status = "mismatch"
+
+    return MontagePreflightFileResult(
+        path=str(file_path),
+        relative_path=relative_path,
+        format_id=format_id,
+        expected_montage=expected_montage,
+        detected_montage=detected,
+        status=status,
+        eeg_channel_count=eeg_count,
+        e129_present=e129_present,
+        reason=reason,
+        size_bytes=size_bytes,
+    )
+
+
+def build_batch_plan(
+    *,
+    input_path: Path,
+    task_path: Path,
+    output_dir: Path,
+    raw_loader: Callable[[Path], object] | None = None,
+) -> MontageBatchPlan:
+    """Scan inputs and build a dry-run montage batch plan."""
+
+    expected_montage = read_task_montage(task_path)
+    if input_path.is_dir() and input_path.suffix.lower() == ".mff":
+        input_root = input_path.parent
+    else:
+        input_root = input_path if input_path.is_dir() else input_path.parent
+    files = [
+        scan_file(
+            path,
+            input_root=input_root,
+            expected_montage=expected_montage,
+            raw_loader=raw_loader,
+        )
+        for path in discover_eeg_inputs(input_path)
+    ]
+
+    groups = _group_results(files)
+    unknown_files = [
+        result.path
+        for result in files
+        if result.status in {"unknown", "unsupported"} or not result.is_actionable
+    ]
+    actionable_files = [result.path for result in files if result.is_actionable]
+
+    return MontageBatchPlan(
+        input_path=str(input_path),
+        task_path=str(task_path),
+        expected_montage=expected_montage,
+        output_dir=str(output_dir),
+        groups=groups,
+        files=files,
+        unknown_files=unknown_files,
+        actionable_files=actionable_files,
+    )
+
+
+def write_scan_csv(plan: MontageBatchPlan, output_dir: Path) -> Path:
+    """Write autoclean_montage_scan.csv."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "autoclean_montage_scan.csv"
+    fields = [
+        "path",
+        "relative_path",
+        "format_id",
+        "expected_montage",
+        "detected_montage",
+        "status",
+        "eeg_channel_count",
+        "e129_present",
+        "reason",
+        "size_bytes",
+    ]
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for result in plan.files:
+            writer.writerow(asdict(result))
+    return csv_path
+
+
+def write_batch_plan_json(plan: MontageBatchPlan, output_dir: Path) -> Path:
+    """Write autoclean_montage_batch_plan.json."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "autoclean_montage_batch_plan.json"
+    path.write_text(json.dumps(plan.to_json_dict(), indent=2), encoding="utf-8")
+    return path
+
+
+def copy_originals_for_plan(
+    plan: MontageBatchPlan,
+    *,
+    split_output_root: Path,
+    overwrite: bool = False,
+) -> MontageCopyResult:
+    """Copy actionable original inputs into montage-specific folders."""
+
+    actionable = [result for result in plan.files if result.is_actionable]
+    required_bytes = sum(result.size_bytes for result in actionable)
+    free_before = shutil.disk_usage(split_output_root.parent).free
+    free_after = free_before - required_bytes
+    if required_bytes > free_before:
+        raise RuntimeError(
+            "Insufficient free space for montage preflight copy: "
+            f"need {required_bytes} bytes, available {free_before} bytes"
+        )
+
+    copied: list[dict] = []
+    skipped = list(plan.unknown_files)
+    for result in actionable:
+        destination = split_output_root / str(result.detected_montage) / result.relative_path
+        if destination.exists() and not overwrite:
+            raise FileExistsError(f"Refusing to overwrite existing destination: {destination}")
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        source = Path(result.path)
+        if source.is_dir():
+            shutil.copytree(source, destination, dirs_exist_ok=overwrite)
+        else:
+            shutil.copy2(source, destination)
+
+        copied.append(
+            {
+                "source": result.path,
+                "destination": str(destination),
+                "detected_montage": result.detected_montage,
+                "size_bytes": result.size_bytes,
+            }
+        )
+
+    return MontageCopyResult(
+        split_output_root=str(split_output_root),
+        copied_files=copied,
+        skipped_files=skipped,
+        required_bytes=required_bytes,
+        free_bytes_before=free_before,
+        free_bytes_after_estimate=free_after,
+    )
+
+
+def write_apply_summary(
+    *,
+    output_dir: Path,
+    copy_result: MontageCopyResult | None = None,
+    cloned_tasks: list[MontageTaskCloneResult] | None = None,
+) -> Path:
+    """Write autoclean_montage_apply_summary.json."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / "autoclean_montage_apply_summary.json"
+    summary = {
+        "copy_result": asdict(copy_result) if copy_result else None,
+        "cloned_tasks": [asdict(task) for task in (cloned_tasks or [])],
+    }
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary_path
+
+
+def clone_task_for_montage(
+    *,
+    source_task_path: Path,
+    task_output_dir: Path,
+    target_montage: str,
+    class_name: str | None = None,
+    file_stem: str | None = None,
+    overwrite: bool = False,
+) -> MontageTaskCloneResult:
+    """Clone a task, changing only its montage value and class/file identity."""
+
+    source = source_task_path.read_text(encoding="utf-8")
+    source_montage = read_task_montage(source_task_path)
+    old_class = _first_task_class_name(source)
+    class_name = class_name or f"{old_class}_{_safe_identifier_suffix(target_montage)}"
+    file_stem = file_stem or class_name
+    destination = task_output_dir / f"{file_stem}.py"
+
+    if destination.exists() and not overwrite:
+        raise FileExistsError(f"Refusing to overwrite existing task clone: {destination}")
+
+    updated = update_task_montage_source(source, target_montage)
+    updated = replace_task_class_name(updated, old_class, class_name)
+    updated = _add_clone_provenance_comment(
+        updated,
+        source_task_path.name,
+        source_montage,
+        target_montage,
+    )
+
+    task_output_dir.mkdir(parents=True, exist_ok=True)
+    destination.write_text(updated, encoding="utf-8")
+
+    return MontageTaskCloneResult(
+        source_task=str(source_task_path),
+        cloned_task=str(destination),
+        source_montage=source_montage,
+        cloned_montage=target_montage,
+        class_name=class_name,
+    )
+
+
+def clone_tasks_for_mismatches(
+    *,
+    plan: MontageBatchPlan,
+    task_output_dir: Path,
+    overwrite: bool = False,
+) -> list[MontageTaskCloneResult]:
+    """Clone one task per detected montage that differs from the source task."""
+
+    targets = sorted(
+        {
+            result.detected_montage
+            for result in plan.files
+            if result.detected_montage
+            and result.detected_montage != plan.expected_montage
+            and result.is_actionable
+        }
+    )
+    return [
+        clone_task_for_montage(
+            source_task_path=Path(plan.task_path),
+            task_output_dir=task_output_dir,
+            target_montage=target,
+            overwrite=overwrite,
+        )
+        for target in targets
+    ]
+
+
+def _read_raw_header(file_path: Path):
+    suffix = file_path.suffix.lower()
+    if suffix == ".set":
+        return mne.io.read_raw_eeglab(str(file_path), preload=False, verbose=False)
+    if suffix == ".edf":
+        return mne.io.read_raw_edf(str(file_path), preload=False, verbose=False)
+    if suffix == ".bdf":
+        return mne.io.read_raw_bdf(str(file_path), preload=False, verbose=False)
+    if suffix == ".fif":
+        return mne.io.read_raw_fif(str(file_path), preload=False, verbose=False)
+    if suffix == ".vhdr":
+        return mne.io.read_raw_brainvision(str(file_path), preload=False, verbose=False)
+    if suffix == ".cnt":
+        return mne.io.read_raw_cnt(str(file_path), preload=False, verbose=False)
+    if suffix in {".mff", ".raw"}:
+        return mne.io.read_raw_egi(str(file_path), preload=False, verbose=False)
+    raise ValueError(f"Unsupported file format: {file_path.suffix}")
+
+
+def _group_results(
+    results: list[MontagePreflightFileResult],
+) -> list[MontagePreflightGroup]:
+    grouped: dict[tuple[str, str], list[MontagePreflightFileResult]] = {}
+    for result in results:
+        detected = result.detected_montage or "unknown"
+        grouped.setdefault((detected, result.status), []).append(result)
+
+    groups = []
+    for (detected, status), items in sorted(grouped.items()):
+        groups.append(
+            MontagePreflightGroup(
+                detected_montage=detected,
+                status=status,
+                file_count=len(items),
+                total_size_bytes=sum(item.size_bytes for item in items),
+                examples=[item.relative_path for item in items[:5]],
+            )
+        )
+    return groups
+
+
+def _relative_to_input(file_path: Path, input_root: Path) -> str:
+    try:
+        return str(file_path.relative_to(input_root))
+    except ValueError:
+        return file_path.name
+
+
+def _path_size(path: Path) -> int:
+    if path.is_dir():
+        return sum(child.stat().st_size for child in path.rglob("*") if child.is_file())
+    return path.stat().st_size if path.exists() else 0
+
+
+def _first_task_class_name(source: str) -> str:
+    match = re.search(r"^\s*class\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", source, re.MULTILINE)
+    if not match:
+        raise ValueError("Could not find a Python task class declaration")
+    return match.group(1)
+
+
+def _safe_identifier_suffix(value: str) -> str:
+    suffix = re.sub(r"[^0-9A-Za-z]+", "_", value).strip("_")
+    if suffix and suffix[0].isdigit():
+        suffix = f"Montage_{suffix}"
+    return suffix or "Montage"
+
+
+def _add_clone_provenance_comment(
+    source: str,
+    source_task_name: str,
+    source_montage: str | None,
+    target_montage: str,
+) -> str:
+    comment = (
+        "# Montage preflight clone note:\n"
+        f"# This task was derived from {source_task_name}, which expected {source_montage}.\n"
+        "# At creation, the only intended behavioral change was updating the "
+        f"montage value to \"{target_montage}\".\n"
+        "# Review this task before processing if any other settings should differ.\n\n"
+    )
+    return comment + source

--- a/src/autoclean/utils/montage_preflight.py
+++ b/src/autoclean/utils/montage_preflight.py
@@ -135,10 +135,14 @@ def detect_hydrocel_montage(raw) -> tuple[str | None, int | None, bool, str]:
     try:
         ch_types = raw.get_channel_types()
     except Exception:
-        ch_types = ["eeg" if re.fullmatch(r"E\d+", name) else "misc" for name in ch_names]
+        ch_types = [
+            "eeg" if re.fullmatch(r"E\d+", name) else "misc" for name in ch_names
+        ]
 
     eeg_names = [
-        name for name, ch_type in zip(ch_names, ch_types, strict=False) if ch_type == "eeg"
+        name
+        for name, ch_type in zip(ch_names, ch_types, strict=False)
+        if ch_type == "eeg"
     ]
     if not eeg_names and ch_names:
         eeg_names = [name for name in ch_names if re.fullmatch(r"E\d+", name)]
@@ -320,9 +324,13 @@ def copy_originals_for_plan(
     copied: list[dict] = []
     skipped = list(plan.unknown_files)
     for result in actionable:
-        destination = split_output_root / str(result.detected_montage) / result.relative_path
+        destination = (
+            split_output_root / str(result.detected_montage) / result.relative_path
+        )
         if destination.exists() and not overwrite:
-            raise FileExistsError(f"Refusing to overwrite existing destination: {destination}")
+            raise FileExistsError(
+                f"Refusing to overwrite existing destination: {destination}"
+            )
 
         destination.parent.mkdir(parents=True, exist_ok=True)
         source = Path(result.path)
@@ -387,7 +395,9 @@ def clone_task_for_montage(
     destination = task_output_dir / f"{file_stem}.py"
 
     if destination.exists() and not overwrite:
-        raise FileExistsError(f"Refusing to overwrite existing task clone: {destination}")
+        raise FileExistsError(
+            f"Refusing to overwrite existing task clone: {destination}"
+        )
 
     updated = update_task_montage_source(source, target_montage)
     updated = replace_task_class_name(updated, old_class, class_name)
@@ -493,7 +503,9 @@ def _path_size(path: Path) -> int:
 
 
 def _first_task_class_name(source: str) -> str:
-    match = re.search(r"^\s*class\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", source, re.MULTILINE)
+    match = re.search(
+        r"^\s*class\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", source, re.MULTILINE
+    )
     if not match:
         raise ValueError("Could not find a Python task class declaration")
     return match.group(1)
@@ -516,7 +528,7 @@ def _add_clone_provenance_comment(
         "# Montage preflight clone note:\n"
         f"# This task was derived from {source_task_name}, which expected {source_montage}.\n"
         "# At creation, the only intended behavioral change was updating the "
-        f"montage value to \"{target_montage}\".\n"
+        f'montage value to "{target_montage}".\n'
         "# Review this task before processing if any other settings should differ.\n\n"
     )
     return comment + source

--- a/src/autoclean/utils/task_montage.py
+++ b/src/autoclean/utils/task_montage.py
@@ -48,7 +48,9 @@ def locate_montage_block(text: str) -> MontageBlock | None:
             elif char == "}":
                 depth -= 1
                 if depth == 0:
-                    return MontageBlock(text[match.start() : index + 1], match.start(), index + 1)
+                    return MontageBlock(
+                        text[match.start() : index + 1], match.start(), index + 1
+                    )
 
     return None
 
@@ -126,7 +128,9 @@ def update_task_montage_file(task_path: Path, new_value: str) -> None:
     """Rewrite a task file, changing only its montage value."""
 
     source = task_path.read_text(encoding="utf-8")
-    task_path.write_text(update_task_montage_source(source, new_value), encoding="utf-8")
+    task_path.write_text(
+        update_task_montage_source(source, new_value), encoding="utf-8"
+    )
 
 
 def replace_task_class_name(source: str, old_name: str, new_name: str) -> str:

--- a/src/autoclean/utils/task_montage.py
+++ b/src/autoclean/utils/task_montage.py
@@ -1,0 +1,139 @@
+"""Helpers for reading and updating task-file montage settings."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MontageBlock:
+    """Located montage config block within a task file."""
+
+    text: str
+    start: int
+    end: int
+
+
+def locate_montage_block(text: str) -> MontageBlock | None:
+    """Find the montage configuration block in Python task source."""
+
+    match = re.search(r"[\"']montage[\"']\s*:\s*\{", text)
+    if not match:
+        return None
+
+    brace_start = text.find("{", match.start())
+    if brace_start == -1:
+        return None
+
+    depth = 0
+    in_string: str | None = None
+    escape = False
+
+    for index in range(brace_start, len(text)):
+        char = text[index]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == in_string:
+                in_string = None
+        else:
+            if char in {'"', "'"}:
+                in_string = char
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return MontageBlock(text[match.start() : index + 1], match.start(), index + 1)
+
+    return None
+
+
+def extract_montage_value(block_text: str) -> str | None:
+    """Extract the montage value from a montage block."""
+
+    value_match = re.search(
+        r"([\"\']value[\"\']\s*:\s*)(?P<quote>[\"\'])(?P<val>.*?)(?P=quote)",
+        block_text,
+        re.DOTALL,
+    )
+    if value_match:
+        return value_match.group("val")
+
+    none_match = re.search(r"[\"\']value[\"\']\s*:\s*None", block_text)
+    if none_match:
+        return None
+
+    return None
+
+
+def replace_montage_value(block_text: str, new_value: str) -> str | None:
+    """Return a montage block with only the value replaced."""
+
+    string_match = re.search(
+        r"([\"\']value[\"\']\s*)(:\s*)(?P<quote>[\"\'])(?P<val>.*?)(?P=quote)",
+        block_text,
+        re.DOTALL,
+    )
+    if string_match:
+        prefix = block_text[: string_match.start()]
+        suffix = block_text[string_match.end() :]
+        quote = string_match.group("quote")
+        replacement = (
+            f"{string_match.group(1)}{string_match.group(2)}{quote}{new_value}{quote}"
+        )
+        return prefix + replacement + suffix
+
+    none_match = re.search(r"([\"\']value[\"\']\s*:\s*)None", block_text)
+    if none_match:
+        prefix = block_text[: none_match.start()]
+        suffix = block_text[none_match.end() :]
+        replacement = f'{none_match.group(1)}"{new_value}"'
+        return prefix + replacement + suffix
+
+    return None
+
+
+def read_task_montage(task_path: Path) -> str | None:
+    """Read the configured montage value from a Python task file."""
+
+    source = task_path.read_text(encoding="utf-8")
+    block = locate_montage_block(source)
+    if block is None:
+        return None
+    return extract_montage_value(block.text)
+
+
+def update_task_montage_source(source: str, new_value: str) -> str:
+    """Return task source with only config['montage']['value'] changed."""
+
+    block = locate_montage_block(source)
+    if block is None:
+        raise ValueError("Task does not define an editable montage block")
+
+    updated_block = replace_montage_value(block.text, new_value)
+    if updated_block is None:
+        raise ValueError("Task montage block does not define an editable value")
+
+    return source[: block.start] + updated_block + source[block.end :]
+
+
+def update_task_montage_file(task_path: Path, new_value: str) -> None:
+    """Rewrite a task file, changing only its montage value."""
+
+    source = task_path.read_text(encoding="utf-8")
+    task_path.write_text(update_task_montage_source(source, new_value), encoding="utf-8")
+
+
+def replace_task_class_name(source: str, old_name: str, new_name: str) -> str:
+    """Rename a task class declaration without touching unrelated identifiers."""
+
+    pattern = re.compile(rf"(^\s*class\s+){re.escape(old_name)}(\s*\()", re.MULTILINE)
+    updated, count = pattern.subn(rf"\1{new_name}\2", source, count=1)
+    if count != 1:
+        raise ValueError(f"Could not find class declaration for {old_name}")
+    return updated

--- a/tests/unit/test_montage_preflight_cli.py
+++ b/tests/unit/test_montage_preflight_cli.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from autoclean.cli import cmd_montage_preflight, create_parser
+from autoclean.utils.montage_preflight import (
+    MontageBatchPlan,
+    MontagePreflightFileResult,
+    MontagePreflightGroup,
+)
+
+
+def test_montage_preflight_parser_defaults() -> None:
+    parser = create_parser()
+    args = parser.parse_args(
+        [
+            "montage",
+            "preflight",
+            "--input",
+            "/tmp/input",
+            "--task",
+            "/tmp/task.py",
+            "--output",
+            "/tmp/output",
+        ]
+    )
+
+    assert args.command == "montage"
+    assert args.montage_action == "preflight"
+    assert args.apply is False
+    assert args.copy_originals is False
+    assert args.clone_tasks is False
+
+
+def test_cmd_montage_preflight_writes_dry_run_artifacts(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[
+            MontagePreflightGroup(
+                detected_montage="GSN-HydroCel-128",
+                status="match",
+                file_count=1,
+                total_size_bytes=3,
+                examples=["sub-01.raw"],
+            )
+        ],
+        files=[
+            MontagePreflightFileResult(
+                path=str(input_file),
+                relative_path="sub-01.raw",
+                format_id="EGI_RAW",
+                expected_montage="GSN-HydroCel-128",
+                detected_montage="GSN-HydroCel-128",
+                status="match",
+                eeg_channel_count=128,
+                e129_present=False,
+                size_bytes=3,
+            )
+        ],
+        unknown_files=[],
+        actionable_files=[str(input_file)],
+    )
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=False,
+        copy_originals=False,
+        split_output_root=None,
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=False,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 0
+    assert (output_dir / "autoclean_montage_scan.csv").is_file()
+    assert (output_dir / "autoclean_montage_batch_plan.json").is_file()
+    assert not (output_dir / "autoclean_montage_apply_summary.json").exists()
+
+
+def test_cmd_montage_preflight_apply_clone_uses_keyword_plan(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    task_output_dir = tmp_path / "tasks"
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[],
+        files=[],
+        unknown_files=[],
+        actionable_files=[],
+    )
+    calls = {}
+
+    def fake_clone_tasks_for_mismatches(**kwargs):
+        calls.update(kwargs)
+        return []
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        "autoclean.cli.clone_tasks_for_mismatches",
+        fake_clone_tasks_for_mismatches,
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=True,
+        copy_originals=False,
+        split_output_root=None,
+        clone_tasks=True,
+        task_output_dir=task_output_dir,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 0
+    assert calls["plan"] is plan
+    assert calls["task_output_dir"] == task_output_dir
+    assert (output_dir / "autoclean_montage_apply_summary.json").is_file()

--- a/tests/unit/test_montage_preflight_cli.py
+++ b/tests/unit/test_montage_preflight_cli.py
@@ -6,6 +6,7 @@ from autoclean.cli import cmd_montage_preflight, create_parser
 from autoclean.utils.montage_preflight import (
     MontageBatchPlan,
     MontageCopyError,
+    MontageCopyEstimate,
     MontageCopyResult,
     MontagePreflightFileResult,
     MontagePreflightGroup,
@@ -222,6 +223,91 @@ def test_cmd_montage_preflight_apply_copy_uses_split_output_root(
     assert calls["plan"] is plan
     assert calls["split_output_root"] == split_output_root
     assert (output_dir / "autoclean_montage_apply_summary.json").is_file()
+
+
+def test_cmd_montage_preflight_prints_copy_estimate_before_copy(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    split_output_root = tmp_path / "split"
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[],
+        files=[],
+        unknown_files=[],
+        actionable_files=[],
+    )
+    calls = {}
+
+    def fake_estimate_copy_originals_for_plan(plan_arg, **kwargs):
+        calls["estimate_seen_copy"] = "copy" in calls
+        calls["estimate_plan"] = plan_arg
+        calls["estimate_kwargs"] = kwargs
+        return MontageCopyEstimate(
+            split_output_root=str(split_output_root),
+            actionable_file_count=2,
+            skipped_file_count=1,
+            required_bytes=256,
+            free_bytes_before=1024,
+            free_bytes_after_estimate=768,
+        )
+
+    def fake_copy_originals_for_plan(plan_arg, **kwargs):
+        calls["copy"] = True
+        return MontageCopyResult(
+            split_output_root=str(split_output_root),
+            copied_files=[],
+            skipped_files=[],
+            required_bytes=256,
+            free_bytes_before=1024,
+            free_bytes_after_estimate=768,
+        )
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        "autoclean.cli.estimate_copy_originals_for_plan",
+        fake_estimate_copy_originals_for_plan,
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.copy_originals_for_plan",
+        fake_copy_originals_for_plan,
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=True,
+        copy_originals=True,
+        split_output_root=split_output_root,
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 0
+    assert calls["estimate_seen_copy"] is False
+    assert calls["estimate_plan"] is plan
+    assert calls["estimate_kwargs"]["split_output_root"] == split_output_root
+    assert calls["copy"] is True
+    output = capsys.readouterr().out
+    assert "Copy Originals Estimate" in output
+    assert str(split_output_root) in output
+    assert "Required space" in output
+    assert "256 bytes" in output
+    assert "Available space" in output
+    assert "1,024 bytes" in output
 
 
 def test_cmd_montage_preflight_copy_failure_writes_partial_summary(

--- a/tests/unit/test_montage_preflight_cli.py
+++ b/tests/unit/test_montage_preflight_cli.py
@@ -32,9 +32,7 @@ def test_montage_preflight_parser_defaults() -> None:
     assert args.clone_tasks is False
 
 
-def test_cmd_montage_preflight_writes_dry_run_artifacts(
-    monkeypatch, tmp_path
-) -> None:
+def test_cmd_montage_preflight_writes_dry_run_artifacts(monkeypatch, tmp_path) -> None:
     input_file = tmp_path / "sub-01.raw"
     input_file.write_text("raw", encoding="utf-8")
     task_file = tmp_path / "Task.py"

--- a/tests/unit/test_montage_preflight_cli.py
+++ b/tests/unit/test_montage_preflight_cli.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 from autoclean.cli import cmd_montage_preflight, create_parser
 from autoclean.utils.montage_preflight import (
     MontageBatchPlan,
+    MontageCopyError,
+    MontageCopyResult,
     MontagePreflightFileResult,
     MontagePreflightGroup,
 )
@@ -91,6 +93,205 @@ def test_cmd_montage_preflight_writes_dry_run_artifacts(monkeypatch, tmp_path) -
     assert (output_dir / "autoclean_montage_scan.csv").is_file()
     assert (output_dir / "autoclean_montage_batch_plan.json").is_file()
     assert not (output_dir / "autoclean_montage_apply_summary.json").exists()
+
+
+def test_cmd_montage_preflight_rejects_apply_flags_without_apply(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    messages = []
+
+    monkeypatch.setattr(
+        "autoclean.cli.build_batch_plan",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("build should not run")),
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.message",
+        lambda _level, text: messages.append(text),
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=tmp_path / "out",
+        dry_run=False,
+        apply=False,
+        copy_originals=True,
+        split_output_root=tmp_path / "split",
+        clone_tasks=True,
+        task_output_dir=tmp_path / "tasks",
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 1
+    assert any("require --apply" in text for text in messages)
+
+
+def test_cmd_montage_preflight_rejects_apply_and_dry_run(monkeypatch, tmp_path) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "autoclean.cli.build_batch_plan",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("build should not run")),
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=tmp_path / "out",
+        dry_run=True,
+        apply=True,
+        copy_originals=False,
+        split_output_root=None,
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 1
+
+
+def test_cmd_montage_preflight_apply_copy_uses_split_output_root(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    split_output_root = tmp_path / "split"
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[],
+        files=[],
+        unknown_files=[],
+        actionable_files=[],
+    )
+    calls = {}
+
+    def fake_copy_originals_for_plan(plan_arg, **kwargs):
+        calls["plan"] = plan_arg
+        calls.update(kwargs)
+        return MontageCopyResult(
+            split_output_root=str(split_output_root),
+            copied_files=[],
+            skipped_files=[],
+            required_bytes=0,
+            free_bytes_before=100,
+            free_bytes_after_estimate=100,
+        )
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        "autoclean.cli.copy_originals_for_plan",
+        fake_copy_originals_for_plan,
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=True,
+        copy_originals=True,
+        split_output_root=split_output_root,
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 0
+    assert calls["plan"] is plan
+    assert calls["split_output_root"] == split_output_root
+    assert (output_dir / "autoclean_montage_apply_summary.json").is_file()
+
+
+def test_cmd_montage_preflight_copy_failure_writes_partial_summary(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    split_output_root = tmp_path / "split"
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[],
+        files=[],
+        unknown_files=[],
+        actionable_files=[],
+    )
+    partial_result = MontageCopyResult(
+        split_output_root=str(split_output_root),
+        copied_files=[
+            {
+                "source": str(input_file),
+                "destination": str(
+                    split_output_root / "GSN-HydroCel-128" / "sub-01.raw"
+                ),
+                "detected_montage": "GSN-HydroCel-128",
+                "size_bytes": 3,
+            }
+        ],
+        skipped_files=[],
+        required_bytes=6,
+        free_bytes_before=100,
+        free_bytes_after_estimate=94,
+        completed=False,
+        errors=[{"source": "sub-02.raw", "destination": "dest", "error": "blocked"}],
+    )
+
+    def fake_copy_originals_for_plan(*_args, **_kwargs):
+        raise MontageCopyError("blocked", partial_result)
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        "autoclean.cli.copy_originals_for_plan",
+        fake_copy_originals_for_plan,
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=True,
+        copy_originals=True,
+        split_output_root=split_output_root,
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 1
+    summary = output_dir / "autoclean_montage_apply_summary.json"
+    assert summary.is_file()
+    assert '"completed": false' in summary.read_text(encoding="utf-8")
 
 
 def test_cmd_montage_preflight_apply_clone_uses_keyword_plan(

--- a/tests/unit/utils/test_montage_preflight.py
+++ b/tests/unit/utils/test_montage_preflight.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from autoclean.utils.montage_preflight import (
+    MontageCopyError,
     build_batch_plan,
     clone_tasks_for_mismatches,
     copy_originals_for_plan,
@@ -105,6 +106,58 @@ def test_build_batch_plan_groups_matching_mixed_and_unknown_files(
     assert str(input_dir / "notes.txt") not in plan.actionable_files
 
 
+def test_build_batch_plan_discovers_plugin_registered_edf(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_dir = tmp_path / "input"
+    edf_file = _touch(input_dir / "sub-01.edf")
+    task = _task_file(tmp_path)
+    discovery_calls = []
+
+    def fake_discover_plugins() -> None:
+        from autoclean.io.import_ import register_format
+
+        discovery_calls.append(True)
+        register_format("edf", "EDF_FORMAT")
+
+    monkeypatch.setattr(
+        "autoclean.utils.montage_preflight.discover_plugins",
+        fake_discover_plugins,
+    )
+
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+
+    assert discovery_calls
+    assert [Path(result.path) for result in plan.files] == [edf_file]
+    assert plan.files[0].format_id == "EDF_FORMAT"
+
+
+def test_mff_package_internals_are_not_scanned(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    mff_dir = input_dir / "sub-01.mff"
+    _touch(mff_dir / "signal.raw")
+    task = _task_file(tmp_path)
+
+    def loader(path: Path) -> FakeRaw:
+        assert path == mff_dir
+        return FakeRaw([f"E{i}" for i in range(1, 129)])
+
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=loader,
+    )
+
+    assert [Path(result.path) for result in plan.files] == [mff_dir]
+    assert plan.files[0].relative_path == "sub-01.mff"
+
+
 def test_write_scan_csv_and_batch_plan_json(tmp_path: Path) -> None:
     input_file = _touch(tmp_path / "input" / "sub-01.raw")
     task = _task_file(tmp_path)
@@ -152,6 +205,28 @@ def test_copy_originals_preserves_source_and_skips_unknown(tmp_path: Path) -> No
     assert result.required_bytes >= len("alpha")
 
 
+def test_copy_originals_allows_missing_destination_parent(tmp_path: Path) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw", "alpha")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+
+    result = copy_originals_for_plan(
+        plan,
+        split_output_root=tmp_path / "missing-parent" / "split",
+    )
+
+    copied_path = (
+        tmp_path / "missing-parent" / "split" / "GSN-HydroCel-128" / "sub-01.raw"
+    )
+    assert copied_path.read_text(encoding="utf-8") == "alpha"
+    assert result.completed is True
+
+
 def test_copy_originals_blocks_existing_destinations(tmp_path: Path) -> None:
     input_file = _touch(tmp_path / "input" / "sub-01.raw")
     task = _task_file(tmp_path)
@@ -165,6 +240,45 @@ def test_copy_originals_blocks_existing_destinations(tmp_path: Path) -> None:
 
     with pytest.raises(FileExistsError):
         copy_originals_for_plan(plan, split_output_root=tmp_path / "split")
+
+
+def test_copy_originals_reports_partial_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_dir = tmp_path / "input"
+    file_a = _touch(input_dir / "a.raw", "alpha")
+    file_b = _touch(input_dir / "b.raw", "beta")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+
+    def fake_copy2(source: Path, destination: Path):
+        if Path(source) == file_b:
+            raise PermissionError("blocked")
+        Path(destination).write_text(Path(source).read_text(encoding="utf-8"))
+
+    monkeypatch.setattr(
+        "autoclean.utils.montage_preflight.shutil.copy2",
+        fake_copy2,
+    )
+
+    with pytest.raises(MontageCopyError) as exc_info:
+        copy_originals_for_plan(plan, split_output_root=tmp_path / "split")
+
+    partial = exc_info.value.partial_result
+    assert partial.completed is False
+    assert partial.copied_files[0]["source"] == str(file_a)
+    assert partial.errors == [
+        {
+            "source": str(file_b),
+            "destination": str(tmp_path / "split" / "GSN-HydroCel-128" / "b.raw"),
+            "error": "blocked",
+        }
+    ]
 
 
 def test_direct_mff_input_copy_preserves_package_name(tmp_path: Path) -> None:

--- a/tests/unit/utils/test_montage_preflight.py
+++ b/tests/unit/utils/test_montage_preflight.py
@@ -11,6 +11,7 @@ from autoclean.utils.montage_preflight import (
     clone_tasks_for_mismatches,
     copy_originals_for_plan,
     detect_hydrocel_montage,
+    estimate_copy_originals_for_plan,
     write_batch_plan_json,
     write_scan_csv,
 )
@@ -203,6 +204,45 @@ def test_copy_originals_preserves_source_and_skips_unknown(tmp_path: Path) -> No
     assert file_128.read_text(encoding="utf-8") == "alpha"
     assert str(file_unknown) in result.skipped_files
     assert result.required_bytes >= len("alpha")
+
+
+def test_estimate_copy_originals_reports_size_and_free_space(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_dir = tmp_path / "input"
+    file_128 = _touch(input_dir / "sub-01.raw", "alpha")
+    file_unknown = _touch(input_dir / "sub-02.raw", "beta")
+    task = _task_file(tmp_path)
+
+    def loader(path: Path) -> FakeRaw:
+        if path == file_128:
+            return FakeRaw([f"E{i}" for i in range(1, 129)])
+        if path == file_unknown:
+            return FakeRaw([f"E{i}" for i in range(1, 128)])
+        raise AssertionError(f"unexpected path {path}")
+
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=loader,
+    )
+    monkeypatch.setattr(
+        "autoclean.utils.montage_preflight.shutil.disk_usage",
+        lambda _path: type("DiskUsage", (), {"free": 1_000})(),
+    )
+
+    estimate = estimate_copy_originals_for_plan(
+        plan,
+        split_output_root=tmp_path / "missing-parent" / "split",
+    )
+
+    assert estimate.split_output_root == str(tmp_path / "missing-parent" / "split")
+    assert estimate.actionable_file_count == 1
+    assert estimate.skipped_file_count == 1
+    assert estimate.required_bytes == file_128.stat().st_size
+    assert estimate.free_bytes_before == 1_000
+    assert estimate.free_bytes_after_estimate == 1_000 - file_128.stat().st_size
 
 
 def test_copy_originals_allows_missing_destination_parent(tmp_path: Path) -> None:

--- a/tests/unit/utils/test_montage_preflight.py
+++ b/tests/unit/utils/test_montage_preflight.py
@@ -27,7 +27,7 @@ class FakeRaw:
 def _task_file(tmp_path: Path, montage: str = "GSN-HydroCel-128") -> Path:
     path = tmp_path / "RestingState_Basic_128.py"
     path.write_text(
-        f'''from autoclean.core.task import Task
+        f"""from autoclean.core.task import Task
 
 config = {{
     "schema_version": "2025.09",
@@ -37,7 +37,7 @@ config = {{
 class RestingStateBasic128(Task):
     def run(self):
         pass
-''',
+""",
         encoding="utf-8",
     )
     return path
@@ -58,14 +58,18 @@ def test_detect_hydrocel_128_and_129_without_dropping_e129() -> None:
 
 
 def test_detect_hydrocel_ambiguous_layout_is_unknown() -> None:
-    detected = detect_hydrocel_montage(FakeRaw([f"E{i}" for i in range(1, 128)] + ["E129"]))
+    detected = detect_hydrocel_montage(
+        FakeRaw([f"E{i}" for i in range(1, 128)] + ["E129"])
+    )
 
     assert detected[0] is None
     assert detected[1] == 128
     assert detected[2] is True
 
 
-def test_build_batch_plan_groups_matching_mixed_and_unknown_files(tmp_path: Path) -> None:
+def test_build_batch_plan_groups_matching_mixed_and_unknown_files(
+    tmp_path: Path,
+) -> None:
     input_dir = tmp_path / "input"
     file_128 = _touch(input_dir / "sub-01.raw")
     file_129 = _touch(input_dir / "sub-02.raw")
@@ -89,7 +93,9 @@ def test_build_batch_plan_groups_matching_mixed_and_unknown_files(tmp_path: Path
         raw_loader=loader,
     )
 
-    statuses = {(item.relative_path, item.detected_montage, item.status) for item in plan.files}
+    statuses = {
+        (item.relative_path, item.detected_montage, item.status) for item in plan.files
+    }
     assert ("sub-01.raw", "GSN-HydroCel-128", "match") in statuses
     assert ("sub-02.raw", "GSN-HydroCel-129", "mismatch") in statuses
     assert ("sub-03.raw", None, "unknown") in statuses
@@ -180,7 +186,9 @@ def test_direct_mff_input_copy_preserves_package_name(tmp_path: Path) -> None:
     assert result.copied_files[0]["destination"] == str(copied_package)
 
 
-def test_task_clone_changes_montage_class_name_and_adds_provenance(tmp_path: Path) -> None:
+def test_task_clone_changes_montage_class_name_and_adds_provenance(
+    tmp_path: Path,
+) -> None:
     input_dir = tmp_path / "input"
     _touch(input_dir / "sub-01.raw")
     task = _task_file(tmp_path)

--- a/tests/unit/utils/test_montage_preflight.py
+++ b/tests/unit/utils/test_montage_preflight.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoclean.utils.montage_preflight import (
+    build_batch_plan,
+    clone_tasks_for_mismatches,
+    copy_originals_for_plan,
+    detect_hydrocel_montage,
+    write_batch_plan_json,
+    write_scan_csv,
+)
+
+
+class FakeRaw:
+    def __init__(self, ch_names: list[str], ch_types: list[str] | None = None) -> None:
+        self.ch_names = ch_names
+        self._ch_types = ch_types or ["eeg"] * len(ch_names)
+
+    def get_channel_types(self) -> list[str]:
+        return self._ch_types
+
+
+def _task_file(tmp_path: Path, montage: str = "GSN-HydroCel-128") -> Path:
+    path = tmp_path / "RestingState_Basic_128.py"
+    path.write_text(
+        f'''from autoclean.core.task import Task
+
+config = {{
+    "schema_version": "2025.09",
+    "montage": {{"enabled": True, "value": "{montage}"}},
+}}
+
+class RestingStateBasic128(Task):
+    def run(self):
+        pass
+''',
+        encoding="utf-8",
+    )
+    return path
+
+
+def _touch(path: Path, content: str = "data") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_detect_hydrocel_128_and_129_without_dropping_e129() -> None:
+    detected_128 = detect_hydrocel_montage(FakeRaw([f"E{i}" for i in range(1, 129)]))
+    detected_129 = detect_hydrocel_montage(FakeRaw([f"E{i}" for i in range(1, 130)]))
+
+    assert detected_128 == ("GSN-HydroCel-128", 128, False, "")
+    assert detected_129 == ("GSN-HydroCel-129", 129, True, "")
+
+
+def test_detect_hydrocel_ambiguous_layout_is_unknown() -> None:
+    detected = detect_hydrocel_montage(FakeRaw([f"E{i}" for i in range(1, 128)] + ["E129"]))
+
+    assert detected[0] is None
+    assert detected[1] == 128
+    assert detected[2] is True
+
+
+def test_build_batch_plan_groups_matching_mixed_and_unknown_files(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    file_128 = _touch(input_dir / "sub-01.raw")
+    file_129 = _touch(input_dir / "sub-02.raw")
+    file_unknown = _touch(input_dir / "sub-03.raw")
+    _touch(input_dir / "notes.txt")
+    task = _task_file(tmp_path)
+
+    def loader(path: Path) -> FakeRaw:
+        if path == file_128:
+            return FakeRaw([f"E{i}" for i in range(1, 129)])
+        if path == file_129:
+            return FakeRaw([f"E{i}" for i in range(1, 130)])
+        if path == file_unknown:
+            return FakeRaw([f"E{i}" for i in range(1, 128)])
+        raise AssertionError(f"unexpected path {path}")
+
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=loader,
+    )
+
+    statuses = {(item.relative_path, item.detected_montage, item.status) for item in plan.files}
+    assert ("sub-01.raw", "GSN-HydroCel-128", "match") in statuses
+    assert ("sub-02.raw", "GSN-HydroCel-129", "mismatch") in statuses
+    assert ("sub-03.raw", None, "unknown") in statuses
+    assert str(file_unknown) in plan.unknown_files
+    assert str(file_128) in plan.actionable_files
+    assert str(file_129) in plan.actionable_files
+    assert str(input_dir / "notes.txt") not in plan.actionable_files
+
+
+def test_write_scan_csv_and_batch_plan_json(tmp_path: Path) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+
+    csv_path = write_scan_csv(plan, tmp_path / "out")
+    json_path = write_batch_plan_json(plan, tmp_path / "out")
+
+    assert "e129_present" in csv_path.read_text(encoding="utf-8")
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["expected_montage"] == "GSN-HydroCel-128"
+    assert payload["files"][0]["detected_montage"] == "GSN-HydroCel-128"
+
+
+def test_copy_originals_preserves_source_and_skips_unknown(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    file_128 = _touch(input_dir / "sub-01.raw", "alpha")
+    file_unknown = _touch(input_dir / "sub-02.raw", "beta")
+    task = _task_file(tmp_path)
+
+    def loader(path: Path) -> FakeRaw:
+        if path == file_128:
+            return FakeRaw([f"E{i}" for i in range(1, 129)])
+        if path == file_unknown:
+            return FakeRaw([f"E{i}" for i in range(1, 128)])
+        raise AssertionError(f"unexpected path {path}")
+
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=loader,
+    )
+    result = copy_originals_for_plan(plan, split_output_root=tmp_path / "split")
+
+    copied_path = tmp_path / "split" / "GSN-HydroCel-128" / "sub-01.raw"
+    assert copied_path.read_text(encoding="utf-8") == "alpha"
+    assert file_128.read_text(encoding="utf-8") == "alpha"
+    assert str(file_unknown) in result.skipped_files
+    assert result.required_bytes >= len("alpha")
+
+
+def test_copy_originals_blocks_existing_destinations(tmp_path: Path) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+    _touch(tmp_path / "split" / "GSN-HydroCel-128" / "sub-01.raw", "exists")
+
+    with pytest.raises(FileExistsError):
+        copy_originals_for_plan(plan, split_output_root=tmp_path / "split")
+
+
+def test_direct_mff_input_copy_preserves_package_name(tmp_path: Path) -> None:
+    mff_dir = tmp_path / "sub-01.mff"
+    _touch(mff_dir / "signal1.bin", "alpha")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=mff_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+
+    result = copy_originals_for_plan(plan, split_output_root=tmp_path / "split")
+
+    copied_package = tmp_path / "split" / "GSN-HydroCel-128" / "sub-01.mff"
+    assert copied_package.is_dir()
+    assert (copied_package / "signal1.bin").read_text(encoding="utf-8") == "alpha"
+    assert result.copied_files[0]["destination"] == str(copied_package)
+
+
+def test_task_clone_changes_montage_class_name_and_adds_provenance(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    _touch(input_dir / "sub-01.raw")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 130)]),
+    )
+
+    clones = clone_tasks_for_mismatches(plan=plan, task_output_dir=tmp_path / "tasks")
+
+    assert len(clones) == 1
+    clone_text = Path(clones[0].cloned_task).read_text(encoding="utf-8")
+    assert "Montage preflight clone note" in clone_text
+    assert '"value": "GSN-HydroCel-129"' in clone_text
+    assert "class RestingStateBasic128_GSN_HydroCel_129(Task):" in clone_text
+    assert '"schema_version": "2025.09"' in clone_text

--- a/tests/unit/utils/test_task_montage.py
+++ b/tests/unit/utils/test_task_montage.py
@@ -1,0 +1,47 @@
+from autoclean.utils.task_montage import (
+    extract_montage_value,
+    locate_montage_block,
+    update_task_montage_source,
+)
+
+
+def test_update_task_montage_source_changes_only_value() -> None:
+    source = '''config = {
+    "dataset_name": "Demo",
+    "montage": {"enabled": True, "value": "GSN-HydroCel-128"},
+    "filtering": {"enabled": True, "value": {"l_freq": 1}},
+}
+'''
+
+    updated = update_task_montage_source(source, "GSN-HydroCel-129")
+
+    assert '"value": "GSN-HydroCel-129"' in updated
+    assert '"dataset_name": "Demo"' in updated
+    assert '"filtering": {"enabled": True, "value": {"l_freq": 1}}' in updated
+
+
+def test_locate_montage_block_handles_nested_formatting() -> None:
+    source = '''config = {
+    "montage": {
+        "enabled": True,
+        "value": "GSN-HydroCel-128",
+        "metadata": {"note": "literal } brace"},
+    },
+}
+'''
+
+    block = locate_montage_block(source)
+
+    assert block is not None
+    assert extract_montage_value(block.text) == "GSN-HydroCel-128"
+
+
+def test_update_task_montage_source_replaces_none_value() -> None:
+    source = '''config = {
+    "montage": {"enabled": False, "value": None},
+}
+'''
+
+    updated = update_task_montage_source(source, "GSN-HydroCel-129")
+
+    assert '"value": "GSN-HydroCel-129"' in updated

--- a/tests/unit/utils/test_task_montage.py
+++ b/tests/unit/utils/test_task_montage.py
@@ -6,12 +6,12 @@ from autoclean.utils.task_montage import (
 
 
 def test_update_task_montage_source_changes_only_value() -> None:
-    source = '''config = {
+    source = """config = {
     "dataset_name": "Demo",
     "montage": {"enabled": True, "value": "GSN-HydroCel-128"},
     "filtering": {"enabled": True, "value": {"l_freq": 1}},
 }
-'''
+"""
 
     updated = update_task_montage_source(source, "GSN-HydroCel-129")
 
@@ -21,14 +21,14 @@ def test_update_task_montage_source_changes_only_value() -> None:
 
 
 def test_locate_montage_block_handles_nested_formatting() -> None:
-    source = '''config = {
+    source = """config = {
     "montage": {
         "enabled": True,
         "value": "GSN-HydroCel-128",
         "metadata": {"note": "literal } brace"},
     },
 }
-'''
+"""
 
     block = locate_montage_block(source)
 
@@ -37,10 +37,10 @@ def test_locate_montage_block_handles_nested_formatting() -> None:
 
 
 def test_update_task_montage_source_replaces_none_value() -> None:
-    source = '''config = {
+    source = """config = {
     "montage": {"enabled": False, "value": None},
 }
-'''
+"""
 
     updated = update_task_montage_source(source, "GSN-HydroCel-129")
 


### PR DESCRIPTION
## Summary
- add a dry-run-first `montage preflight` command that scans one file or input folder and writes scan CSV plus batch-plan JSON artifacts
- detect supported HydroCel 128/129 layouts without dropping or coercing E129, while keeping unknown/unsupported inputs out of automatic routing
- add explicit apply-mode copy protections, apply summary output, and task cloning that changes only the cloned task montage value with provenance

Closes #276

## Validation
- `pytest -p no:cacheprovider --no-cov tests/unit/utils/test_task_montage.py tests/unit/utils/test_montage_preflight.py tests/unit/test_montage_preflight_cli.py -q` -> 14 passed
- `uvx ruff check --select I,F,FLY src/autoclean/cli.py src/autoclean/utils/montage_preflight.py src/autoclean/utils/task_montage.py tests/unit/test_montage_preflight_cli.py tests/unit/utils/test_montage_preflight.py tests/unit/utils/test_task_montage.py` -> passed
- `git diff --check` -> passed

## Review
- Atlas integration-contract review: PASS for use by #277/#278 follow-up work
- Boulder code review: PASS after fixes for CLI clone invocation and direct .mff package copy behavior