### PR TITLE
fix: clarify Quarto requirement for serve docs

### DIFF
--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -5921,7 +5921,7 @@ def cmd_wizard(args) -> int:
                 break
 
         # Step 3 — Montage selection
-        (_, _, active_task, active_task_path, current_montage, _) = (
+        _, _, active_task, active_task_path, current_montage, _ = (
             _wizard_collect_state()
         )
 
@@ -6044,7 +6044,7 @@ def cmd_wizard(args) -> int:
                 )
 
         # Step 4 — Input source
-        (*_, _, current_input) = _wizard_collect_state()
+        *_, _, current_input = _wizard_collect_state()
 
         display.header(
             "Step 4 • Input",
@@ -12255,13 +12255,16 @@ def _quarto_missing_message() -> str:
     elif sys.platform.startswith("win"):
         install_hint = "winget install --id Posit.Quarto"
     else:
-        install_hint = "Install a Linux package from https://quarto.org/docs/get-started/"
+        install_hint = (
+            "Install a Linux package from https://quarto.org/docs/get-started/"
+        )
 
     return (
         "Quarto CLI is required for `autocleaneeg-pipeline serve docs`, "
         "which previews the internal plans documentation site, but Quarto was not "
         "found on PATH. Normal Serve startup (`serve`, `serve up`) and processing "
-        "do not install Quarto through `uv tool install autocleaneeg-pipeline`. "
+        "do not require Quarto. Quarto is not a Python dependency and is not "
+        "installed by `uv tool install autocleaneeg-pipeline`. "
         "Install Quarto from https://quarto.org/docs/get-started/ or run: "
         f"{install_hint}. Then restart `autocleaneeg-pipeline serve docs`."
     )

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -12222,10 +12222,10 @@ def cmd_serve_docs(args) -> int:
 
         result = subprocess.run(["quarto", "--version"], capture_output=True, text=True)
         if result.returncode != 0:
-            message("error", "Quarto not found. Please install quarto CLI.")
+            message("error", _quarto_missing_message())
             return 1
     except FileNotFoundError:
-        message("error", "Quarto not found. Please install quarto CLI.")
+        message("error", _quarto_missing_message())
         return 1
 
     # Run quarto preview
@@ -12245,6 +12245,26 @@ def cmd_serve_docs(args) -> int:
     except Exception as e:
         message("error", f"Failed to serve: {e}")
         return 1
+
+
+def _quarto_missing_message() -> str:
+    """Return actionable guidance for missing Quarto CLI."""
+
+    if sys.platform == "darwin":
+        install_hint = "brew install --cask quarto"
+    elif sys.platform.startswith("win"):
+        install_hint = "winget install --id Posit.Quarto"
+    else:
+        install_hint = "Install a Linux package from https://quarto.org/docs/get-started/"
+
+    return (
+        "Quarto CLI is required for `autocleaneeg-pipeline serve docs`, "
+        "which previews the internal plans documentation site, but Quarto was not "
+        "found on PATH. Normal Serve startup (`serve`, `serve up`) and processing "
+        "do not install Quarto through `uv tool install autocleaneeg-pipeline`. "
+        "Install Quarto from https://quarto.org/docs/get-started/ or run: "
+        f"{install_hint}. Then restart `autocleaneeg-pipeline serve docs`."
+    )
 
 
 def cmd_auth(args) -> int:

--- a/tests/unit/test_quarto_serve_docs.py
+++ b/tests/unit/test_quarto_serve_docs.py
@@ -11,11 +11,15 @@ def test_quarto_missing_message_explains_scope_and_macos_install(monkeypatch) ->
 
     assert "`autocleaneeg-pipeline serve docs`" in guidance
     assert "`serve`, `serve up`" in guidance
+    assert "do not require Quarto" in guidance
     assert "uv tool install autocleaneeg-pipeline" in guidance
+    assert "not installed by" in guidance
     assert "brew install --cask quarto" in guidance
 
 
-def test_serve_docs_missing_quarto_uses_actionable_message(tmp_path, monkeypatch) -> None:
+def test_serve_docs_missing_quarto_uses_actionable_message(
+    tmp_path, monkeypatch
+) -> None:
     (tmp_path / "plans").mkdir()
     monkeypatch.chdir(tmp_path)
 

--- a/tests/unit/test_quarto_serve_docs.py
+++ b/tests/unit/test_quarto_serve_docs.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from autoclean.cli import _quarto_missing_message, cmd_serve_docs
+
+
+def test_quarto_missing_message_explains_scope_and_macos_install(monkeypatch) -> None:
+    monkeypatch.setattr("autoclean.cli.sys.platform", "darwin")
+
+    guidance = _quarto_missing_message()
+
+    assert "`autocleaneeg-pipeline serve docs`" in guidance
+    assert "`serve`, `serve up`" in guidance
+    assert "uv tool install autocleaneeg-pipeline" in guidance
+    assert "brew install --cask quarto" in guidance
+
+
+def test_serve_docs_missing_quarto_uses_actionable_message(tmp_path, monkeypatch) -> None:
+    (tmp_path / "plans").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("autoclean.cli.subprocess.run", side_effect=FileNotFoundError),
+        patch("autoclean.cli.message") as mock_message,
+    ):
+        result = cmd_serve_docs(SimpleNamespace(port=4321, host="127.0.0.1"))
+
+    assert result == 1
+    error_message = mock_message.call_args.args[1]
+    assert "Quarto CLI is required" in error_message
+    assert "serve docs" in error_message
+    assert "serve up" in error_message
+
+
+def test_serve_docs_nonzero_quarto_version_uses_actionable_message(
+    tmp_path, monkeypatch
+) -> None:
+    (tmp_path / "plans").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch(
+            "autoclean.cli.subprocess.run",
+            return_value=SimpleNamespace(returncode=1),
+        ),
+        patch("autoclean.cli.message") as mock_message,
+    ):
+        result = cmd_serve_docs(SimpleNamespace(port=4321, host="127.0.0.1"))
+
+    assert result == 1
+    error_message = mock_message.call_args.args[1]
+    assert "Quarto CLI is required" in error_message
+    assert "serve docs" in error_message
+    assert "serve up" in error_message


### PR DESCRIPTION
## Summary
- scope the Quarto missing/error guidance specifically to `autocleaneeg-pipeline serve docs`
- clarify that normal Serve startup commands do not require Quarto or get it from `uv tool install autocleaneeg-pipeline`
- add tests for missing Quarto and nonzero `quarto --version` behavior

Closes #273

## Validation
- `pytest -p no:cacheprovider --no-cov tests/unit/test_quarto_serve_docs.py -q` -> 3 passed
- `uvx ruff check --select I,F,FLY src/autoclean/cli.py tests/unit/test_quarto_serve_docs.py` -> passed
- `git diff --check` -> passed

## Review
- Boulder code review: PASS after adding the nonzero Quarto test coverage requested during review