### PR TITLE
fix: default component classifier to iclabel

### DIFF
--- a/src/autoclean/data/builtins/tasks/auditory/ASSR_40Hz.py
+++ b/src/autoclean/data/builtins/tasks/auditory/ASSR_40Hz.py
@@ -38,7 +38,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": [
                 "muscle",

--- a/src/autoclean/data/builtins/tasks/auditory/MMN_Standard.py
+++ b/src/autoclean/data/builtins/tasks/auditory/MMN_Standard.py
@@ -35,7 +35,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": [
                 "muscle",

--- a/src/autoclean/data/builtins/tasks/resting/RestingEyesClosed.py
+++ b/src/autoclean/data/builtins/tasks/resting/RestingEyesClosed.py
@@ -38,7 +38,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": [
                 "muscle",

--- a/src/autoclean/data/builtins/tasks/resting/RestingEyesOpen.py
+++ b/src/autoclean/data/builtins/tasks/resting/RestingEyesOpen.py
@@ -38,7 +38,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": [
                 "muscle",

--- a/src/autoclean/tasks/RestingState_Basic.py
+++ b/src/autoclean/tasks/RestingState_Basic.py
@@ -45,7 +45,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": ["muscle", "heart", "eog", "ch_noise", "line_noise"],
             "ic_rejection_threshold": 0.3,

--- a/src/autoclean/tasks/RestingState_BasicWavelet.py
+++ b/src/autoclean/tasks/RestingState_BasicWavelet.py
@@ -55,7 +55,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": ["muscle", "heart", "eog", "ch_noise", "line_noise"],
             "ic_rejection_threshold": 0.3,

--- a/src/autoclean/tasks/RestingState_Basic_128.py
+++ b/src/autoclean/tasks/RestingState_Basic_128.py
@@ -38,7 +38,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": ["muscle", "heart", "eog", "ch_noise", "line_noise"],
             "ic_rejection_threshold": 0.3,

--- a/src/autoclean/tasks/pending_approval/RestingState_Basic.py
+++ b/src/autoclean/tasks/pending_approval/RestingState_Basic.py
@@ -44,7 +44,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "icvision",
+        "method": "iclabel",
         "value": {
             "ic_flags_to_reject": ["muscle", "heart", "eog", "ch_noise", "line_noise"],
             "ic_rejection_threshold": 0.3,

--- a/src/autoclean/templates/reprocess_with_overrides.jinja
+++ b/src/autoclean/templates/reprocess_with_overrides.jinja
@@ -54,7 +54,7 @@ config = {
     },
     "component_rejection": {
         "enabled": True,
-        "method": "{{ ica_classification_method|default('icvision') }}",
+        "method": "{{ ica_classification_method|default('iclabel') }}",
         "value": {
             "ic_flags_to_reject": {{ ic_flags_to_reject|default('["muscle", "heart", "eog", "ch_noise", "line_noise"]') }},
             "ic_rejection_threshold": {{ ic_rejection_threshold|default(0.3) }},

--- a/tests/unit/test_ica_classifier_defaults.py
+++ b/tests/unit/test_ica_classifier_defaults.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from autoclean.data.builtins.tasks.auditory.ASSR_40Hz import config as assr_config
+from autoclean.data.builtins.tasks.auditory.MMN_Standard import config as mmn_config
+from autoclean.data.builtins.tasks.resting.RestingEyesClosed import (
+    config as resting_closed_config,
+)
+from autoclean.data.builtins.tasks.resting.RestingEyesOpen import (
+    config as resting_open_config,
+)
+from autoclean.tasks.RestingState_Basic import config as resting_basic_config
+from autoclean.tasks.RestingState_Basic_128 import config as resting_basic_128_config
+from autoclean.tasks.RestingState_BasicWavelet import (
+    config as resting_basic_wavelet_config,
+)
+from autoclean.templates.custom_task_template import config as custom_template_config
+from autoclean.utils.template_renderer import render_template
+
+
+def _reprocess_context(**overrides):
+    context = {
+        "timestamp": "2026-08-12T00:00:00",
+        "original_file": "sub-01.raw",
+        "fix_type": "ica",
+        "class_name": "ReprocessTask",
+        "bad_channels": [],
+        "rejected_ica": [],
+    }
+    context.update(overrides)
+    return context
+
+
+def test_resting_task_configs_default_component_classifier_to_iclabel() -> None:
+    configs = [
+        resting_basic_config,
+        resting_basic_128_config,
+        resting_basic_wavelet_config,
+        resting_open_config,
+        resting_closed_config,
+    ]
+
+    assert {
+        config["component_rejection"]["method"] for config in configs
+    } == {"iclabel"}
+
+
+def test_auditory_task_configs_default_component_classifier_to_iclabel() -> None:
+    configs = [assr_config, mmn_config]
+
+    assert {
+        config["component_rejection"]["method"] for config in configs
+    } == {"iclabel"}
+
+
+def test_custom_task_template_defaults_component_classifier_to_iclabel() -> None:
+    assert custom_template_config["component_rejection"]["method"] == "iclabel"
+
+
+def test_reprocess_template_defaults_component_classifier_to_iclabel() -> None:
+    template = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "autoclean"
+        / "templates"
+        / "reprocess_with_overrides.jinja"
+    )
+
+    rendered = render_template(template, _reprocess_context())
+
+    assert '"method": "iclabel"' in rendered
+    assert "classify_ica_components(method=\"iclabel\"" in rendered
+
+
+def test_reprocess_template_preserves_explicit_icvision_override() -> None:
+    template = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "autoclean"
+        / "templates"
+        / "reprocess_with_overrides.jinja"
+    )
+
+    rendered = render_template(
+        template,
+        _reprocess_context(ica_classification_method="icvision"),
+    )
+
+    assert '"method": "icvision"' in rendered
+    assert "classify_ica_components(method=\"icvision\"" in rendered
+
+
+def test_ica_fitting_method_defaults_are_unchanged() -> None:
+    assert resting_basic_config["ICA"]["value"]["method"] == "infomax"
+    assert custom_template_config["ICA"]["value"]["method"] == "fastica"

--- a/tests/unit/test_ica_classifier_defaults.py
+++ b/tests/unit/test_ica_classifier_defaults.py
@@ -39,21 +39,36 @@ def test_resting_task_configs_default_component_classifier_to_iclabel() -> None:
         resting_closed_config,
     ]
 
-    assert {
-        config["component_rejection"]["method"] for config in configs
-    } == {"iclabel"}
+    assert {config["component_rejection"]["method"] for config in configs} == {
+        "iclabel"
+    }
 
 
 def test_auditory_task_configs_default_component_classifier_to_iclabel() -> None:
     configs = [assr_config, mmn_config]
 
-    assert {
-        config["component_rejection"]["method"] for config in configs
-    } == {"iclabel"}
+    assert {config["component_rejection"]["method"] for config in configs} == {
+        "iclabel"
+    }
 
 
 def test_custom_task_template_defaults_component_classifier_to_iclabel() -> None:
     assert custom_template_config["component_rejection"]["method"] == "iclabel"
+
+
+def test_custom_task_jinja_template_defaults_component_classifier_to_iclabel() -> None:
+    template = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "autoclean"
+        / "templates"
+        / "custom_task_template.jinja"
+    )
+
+    template_source = template.read_text(encoding="utf-8")
+
+    assert '"method": "iclabel"' in template_source
+    assert "Classification method: 'iclabel' or 'icvision'" in template_source
 
 
 def test_reprocess_template_defaults_component_classifier_to_iclabel() -> None:
@@ -68,7 +83,7 @@ def test_reprocess_template_defaults_component_classifier_to_iclabel() -> None:
     rendered = render_template(template, _reprocess_context())
 
     assert '"method": "iclabel"' in rendered
-    assert "classify_ica_components(method=\"iclabel\"" in rendered
+    assert 'classify_ica_components(method="iclabel"' in rendered
 
 
 def test_reprocess_template_preserves_explicit_icvision_override() -> None:
@@ -86,7 +101,7 @@ def test_reprocess_template_preserves_explicit_icvision_override() -> None:
     )
 
     assert '"method": "icvision"' in rendered
-    assert "classify_ica_components(method=\"icvision\"" in rendered
+    assert 'classify_ica_components(method="icvision"' in rendered
 
 
 def test_ica_fitting_method_defaults_are_unchanged() -> None:


### PR DESCRIPTION
## Summary
- switch active task/template component-classifier defaults from `icvision` to `iclabel`
- leave ICA fitting method defaults unchanged
- keep explicit `icvision` override behavior covered for reprocess templates

Closes #279

## Validation
- `pytest -p no:cacheprovider --no-cov tests/unit/test_ica_classifier_defaults.py -q` -> 6 passed
- `uvx ruff check --select I,F,FLY src/autoclean/tasks/RestingState_Basic.py src/autoclean/tasks/RestingState_Basic_128.py src/autoclean/tasks/RestingState_BasicWavelet.py src/autoclean/tasks/pending_approval/RestingState_Basic.py src/autoclean/data/builtins/tasks/resting/RestingEyesOpen.py src/autoclean/data/builtins/tasks/resting/RestingEyesClosed.py src/autoclean/data/builtins/tasks/auditory/ASSR_40Hz.py src/autoclean/data/builtins/tasks/auditory/MMN_Standard.py tests/unit/test_ica_classifier_defaults.py` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Review
- Boulder code review: PASS; active defaults are now `iclabel`, explicit `icvision` remains supported, and ICA fitting methods remain unchanged