### PR TITLE
feat: add montage preflight move mode

### DIFF
--- a/plans/correspondance/026-issue-278-review-fixes.html
+++ b/plans/correspondance/026-issue-278-review-fixes.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Issue 278 Review Fixes Execution Update</title>
+</head>
+<body>
+  <h1>Issue 278 Review Fixes Execution Update</h1>
+  <dl>
+    <dt>From</dt>
+    <dd>Echo - Software Engineer</dd>
+    <dt>To</dt>
+    <dd>Raven - Engineering Delivery and Loop Coordinator</dd>
+    <dt>Date</dt>
+    <dd>2026-08-13</dd>
+    <dt>Re</dt>
+    <dd>T-2026-08-13-001 / issue #278 montage preflight move-mode review fixes</dd>
+    <dt>Thread IDs</dt>
+    <dd>Raven source thread 019f375b-b0cb-7311-8fe1-5d829f5a7b3a; Echo role thread 019f375b-b21a-7af2-97fd-09b211380783</dd>
+  </dl>
+
+  <h2>Request Summary</h2>
+  <p>
+    Raven routed Boulder and Cricket pre-PR review blockers against commit
+    12fd4e6b5144b474b8f698b8f0b39bfb5c2986c0 on branch
+    codex/278-montage-preflight-move-mode. Required fixes were to prevent stale
+    move audit summaries when task cloning fails after source deletion, print
+    source path information before moving, and expose top-level apply summary
+    fields for move/copy operation auditing.
+  </p>
+
+  <h2>Execution Update</h2>
+  <p>
+    Updated montage preflight move mode so successful moves write a completed
+    post-move apply summary before any later task-clone step can fail. The clone
+    failure path now rewrites the apply summary with the current move result
+    before returning an error. Move estimates now carry and print the source
+    path. Apply summaries keep the existing nested copy_result and move_result
+    fields while adding top-level operation, move/copy flags, confirmation and
+    delete semantics, same-volume and temporary-space fields, skipped unknown
+    files, and normalized file_operations records.
+  </p>
+
+  <h2>Validation</h2>
+  <ul>
+    <li>uv run --extra dev pytest -p no:cacheprovider --no-cov tests/unit/utils/test_montage_preflight.py tests/unit/test_montage_preflight_cli.py -q</li>
+    <li>uv run --with black black src/autoclean/cli.py src/autoclean/utils/montage_preflight.py tests/unit/utils/test_montage_preflight.py tests/unit/test_montage_preflight_cli.py</li>
+    <li>uv run --extra dev ruff check --select I,F,FLY src/autoclean/cli.py src/autoclean/utils/montage_preflight.py tests/unit/utils/test_montage_preflight.py tests/unit/test_montage_preflight_cli.py</li>
+    <li>git diff --check</li>
+  </ul>
+
+  <h2>Scope Limits</h2>
+  <p>
+    No PR, merge, push, or GitHub thread resolution was performed. Size-only
+    verification remains unchanged by instruction. Changes were kept to the
+    routed issue #278 worktree and branch.
+  </p>
+
+  <h2>Conflict Status</h2>
+  <p>No conflicts or blockers encountered.</p>
+
+  <h2>Execution Decision</h2>
+  <p>
+    Proceeded with a scoped branch-local fix and regression coverage. Awaiting
+    Raven routing for any independent review, PR creation, push, or merge action.
+  </p>
+</body>
+</html>

--- a/plans/correspondance/027-issue-278-audit-byte-fix.html
+++ b/plans/correspondance/027-issue-278-audit-byte-fix.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Issue 278 Audit Byte Fix Execution Update</title>
+</head>
+<body>
+  <h1>Issue 278 Audit Byte Fix Execution Update</h1>
+  <dl>
+    <dt>From</dt>
+    <dd>Echo - Software Engineer</dd>
+    <dt>To</dt>
+    <dd>Raven - Engineering Delivery and Loop Coordinator</dd>
+    <dt>Date</dt>
+    <dd>2026-08-13</dd>
+    <dt>Re</dt>
+    <dd>T-2026-08-13-001 / PR #286 failed file-operation byte audit fix</dd>
+    <dt>Thread IDs</dt>
+    <dd>Raven source thread 019f375b-b0cb-7311-8fe1-5d829f5a7b3a; Echo role thread 019f375b-b21a-7af2-97fd-09b211380783</dd>
+  </dl>
+
+  <h2>Request Summary</h2>
+  <p>
+    Raven routed a PI-approved PR #286 review fix for branch
+    codex/278-montage-preflight-move-mode. Failed file_operations audit entries
+    could report bytes as null because copy and move error payloads omitted
+    size_bytes even though the planned file result already had that value.
+  </p>
+
+  <h2>Execution Update</h2>
+  <p>
+    Added size_bytes to copy_originals_for_plan and move_originals_for_plan
+    error payloads. Tightened focused tests so partial helper errors and
+    CLI-written failed file_operations include the expected byte count.
+  </p>
+
+  <h2>Validation</h2>
+  <ul>
+    <li>uv run --extra dev pytest -p no:cacheprovider --no-cov tests/unit/utils/test_montage_preflight.py tests/unit/test_montage_preflight_cli.py -q</li>
+    <li>UV_CACHE_DIR=/tmp/uv-cache-codex uv run --with black black src/autoclean/utils/montage_preflight.py tests/unit/utils/test_montage_preflight.py tests/unit/test_montage_preflight_cli.py</li>
+    <li>UV_CACHE_DIR=/tmp/uv-cache-codex uv run --extra dev ruff check --select I,F,FLY src/autoclean/utils/montage_preflight.py tests/unit/utils/test_montage_preflight.py tests/unit/test_montage_preflight_cli.py</li>
+    <li>git diff --check</li>
+  </ul>
+
+  <h2>Scope Limits</h2>
+  <p>
+    No merge, unrelated refactor, same-volume rename change, or checksum
+    verification change was performed.
+  </p>
+
+  <h2>Conflict Status</h2>
+  <p>No conflicts or blockers encountered.</p>
+
+  <h2>Execution Decision</h2>
+  <p>
+    Proceeded with the scoped audit payload fix and prepared the branch for
+    local commit and push to the existing PR branch.
+  </p>
+</body>
+</html>

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -63,12 +63,17 @@ from autoclean.utils.matlab_runtime import detect_matlab_engine, start_matlab_en
 from autoclean.utils.montage import load_valid_montages
 from autoclean.utils.montage_preflight import (
     MontageCopyError,
+    MontageMoveError,
+    MontageMoveResult,
     build_batch_plan,
     clone_tasks_for_mismatches,
     copy_originals_for_plan,
     estimate_copy_originals_for_plan,
+    estimate_move_originals_for_plan,
+    move_originals_for_plan,
     write_apply_summary,
     write_batch_plan_json,
+    write_planned_move_manifest,
     write_scan_csv,
 )
 from autoclean.utils.montage_validation import (
@@ -1779,15 +1784,23 @@ For detailed help on any command: autocleaneeg-pipeline <command> --help
         action="store_true",
         help="Apply explicitly requested copy/clone actions",
     )
-    montage_preflight_parser.add_argument(
+    montage_preflight_action_group = (
+        montage_preflight_parser.add_mutually_exclusive_group()
+    )
+    montage_preflight_action_group.add_argument(
         "--copy-originals",
         action="store_true",
         help="Copy actionable inputs into montage-specific folders",
     )
+    montage_preflight_action_group.add_argument(
+        "--move-originals",
+        action="store_true",
+        help="Move actionable inputs into montage-specific folders after copy verification",
+    )
     montage_preflight_parser.add_argument(
         "--split-output-root",
         type=Path,
-        help="Destination root for copied montage-specific input folders",
+        help="Destination root for copied or moved montage-specific input folders",
     )
     montage_preflight_parser.add_argument(
         "--clone-tasks",
@@ -4320,10 +4333,14 @@ def cmd_montage_preflight(args) -> int:
     if args.apply and args.dry_run:
         message("error", "Use either --dry-run or --apply, not both.")
         return 1
-    if not args.apply and (args.copy_originals or args.clone_tasks):
+    move_originals = getattr(args, "move_originals", False)
+    if args.copy_originals and move_originals:
+        message("error", "Use either --copy-originals or --move-originals, not both.")
+        return 1
+    if not args.apply and (args.copy_originals or move_originals or args.clone_tasks):
         message(
             "error",
-            "--copy-originals and --clone-tasks require --apply; "
+            "--copy-originals, --move-originals, and --clone-tasks require --apply; "
             "rerun with --apply or omit apply-only flags for dry-run review.",
         )
         return 1
@@ -4349,6 +4366,7 @@ def cmd_montage_preflight(args) -> int:
         return 0
 
     copy_result = None
+    move_result = None
     cloned_tasks = []
 
     if args.copy_originals:
@@ -4380,6 +4398,7 @@ def cmd_montage_preflight(args) -> int:
                 summary_path = write_apply_summary(
                     output_dir=output_dir,
                     copy_result=exc.partial_result,
+                    move_result=move_result,
                     cloned_tasks=cloned_tasks,
                 )
                 message("error", f"Copy step failed: {exc}")
@@ -4390,6 +4409,80 @@ def cmd_montage_preflight(args) -> int:
                 return 1
             except Exception as exc:  # pylint: disable=broad-except
                 message("error", f"Copy step failed: {exc}")
+                return 1
+
+    if move_originals:
+        if args.split_output_root is None:
+            message("error", "--move-originals requires --split-output-root")
+            return 1
+        try:
+            move_estimate = estimate_move_originals_for_plan(
+                plan,
+                split_output_root=Path(args.split_output_root),
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            message("error", f"Move estimate failed: {exc}")
+            return 1
+        _print_montage_move_estimate(console, move_estimate)
+        if not args.yes and not _confirm_preflight_action(
+            args,
+            "Move actionable input files into montage-specific folders?",
+        ):
+            message("info", "Move step skipped.")
+        else:
+            try:
+                planned_manifest = write_planned_move_manifest(
+                    plan,
+                    output_dir=output_dir,
+                    split_output_root=Path(args.split_output_root),
+                    estimate=move_estimate,
+                )
+                move_result = MontageMoveResult(
+                    split_output_root=str(args.split_output_root),
+                    planned_manifest=str(planned_manifest),
+                    moved_files=[],
+                    skipped_files=[],
+                    required_bytes=move_estimate.required_bytes,
+                    free_bytes_before=move_estimate.free_bytes_before,
+                    free_bytes_after_estimate=move_estimate.free_bytes_after_estimate,
+                    same_volume=move_estimate.same_volume,
+                    source_volume=move_estimate.source_volume,
+                    destination_volume=move_estimate.destination_volume,
+                    completed=False,
+                )
+                summary_path = write_apply_summary(
+                    output_dir=output_dir,
+                    copy_result=copy_result,
+                    move_result=move_result,
+                    cloned_tasks=cloned_tasks,
+                )
+                console.print(
+                    f"[muted]Planned move manifest: [info]{planned_manifest}[/info][/muted]"
+                )
+                console.print(
+                    f"[muted]Pre-move apply summary: [info]{summary_path}[/info][/muted]"
+                )
+                move_result = move_originals_for_plan(
+                    plan,
+                    split_output_root=Path(args.split_output_root),
+                    planned_manifest=planned_manifest,
+                    estimate=move_estimate,
+                )
+            except MontageMoveError as exc:
+                summary_path = write_apply_summary(
+                    output_dir=output_dir,
+                    copy_result=copy_result,
+                    move_result=exc.partial_result,
+                    cloned_tasks=cloned_tasks,
+                )
+                message("error", f"Move step failed: {exc}")
+                message(
+                    "error",
+                    f"Partial move summary written: {summary_path}",
+                )
+                return 1
+            except Exception as exc:  # pylint: disable=broad-except
+                message("error", f"Move step failed: {exc}")
                 return 1
 
     if args.clone_tasks:
@@ -4415,6 +4508,7 @@ def cmd_montage_preflight(args) -> int:
     summary_path = write_apply_summary(
         output_dir=output_dir,
         copy_result=copy_result,
+        move_result=move_result,
         cloned_tasks=cloned_tasks,
     )
     message("success", f"✓ Montage preflight apply summary written: {summary_path}")
@@ -4473,6 +4567,43 @@ def _print_montage_copy_estimate(console, copy_estimate) -> None:
     console.print(
         "Estimated free after copy: "
         f"[accent]{copy_estimate.free_bytes_after_estimate:,} bytes[/accent]"
+    )
+
+
+def _print_montage_move_estimate(console, move_estimate) -> None:
+    """Render move-originals warning, volume, and free-space estimate."""
+
+    console.print()
+    console.print("[header]Move Originals Estimate[/header]")
+    console.print(
+        "[warning]Move mode copies each source, verifies the destination size, "
+        "then deletes the source. It stops on the first failure.[/warning]"
+    )
+    console.print(f"Destination: [info]{move_estimate.split_output_root}[/info]")
+    console.print(f"Source volume: [info]{move_estimate.source_volume}[/info]")
+    console.print(
+        f"Destination volume: [info]{move_estimate.destination_volume}[/info]"
+    )
+    console.print(
+        "Same volume: "
+        f"[accent]{'yes' if move_estimate.same_volume else 'no'}[/accent]"
+    )
+    console.print(
+        "Actionable files: "
+        f"[accent]{move_estimate.actionable_file_count}[/accent]"
+        f" ([muted]{move_estimate.unknown_file_count} unknown[/muted])"
+    )
+    console.print(
+        "Temporary space needed before source deletion: "
+        f"[accent]{move_estimate.required_bytes:,} bytes[/accent]"
+    )
+    console.print(
+        "Available destination space: "
+        f"[accent]{move_estimate.free_bytes_before:,} bytes[/accent]"
+    )
+    console.print(
+        "Estimated free after copy-before-delete: "
+        f"[accent]{move_estimate.free_bytes_after_estimate:,} bytes[/accent]"
     )
 
 

--- a/src/autoclean/cli.py
+++ b/src/autoclean/cli.py
@@ -4468,6 +4468,15 @@ def cmd_montage_preflight(args) -> int:
                     planned_manifest=planned_manifest,
                     estimate=move_estimate,
                 )
+                summary_path = write_apply_summary(
+                    output_dir=output_dir,
+                    copy_result=copy_result,
+                    move_result=move_result,
+                    cloned_tasks=cloned_tasks,
+                )
+                console.print(
+                    f"[muted]Post-move apply summary: [info]{summary_path}[/info][/muted]"
+                )
             except MontageMoveError as exc:
                 summary_path = write_apply_summary(
                     output_dir=output_dir,
@@ -4503,6 +4512,16 @@ def cmd_montage_preflight(args) -> int:
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 message("error", f"Task clone step failed: {exc}")
+                summary_path = write_apply_summary(
+                    output_dir=output_dir,
+                    copy_result=copy_result,
+                    move_result=move_result,
+                    cloned_tasks=cloned_tasks,
+                )
+                message(
+                    "error",
+                    f"Apply summary written before clone failure: {summary_path}",
+                )
                 return 1
 
     summary_path = write_apply_summary(
@@ -4579,6 +4598,7 @@ def _print_montage_move_estimate(console, move_estimate) -> None:
         "[warning]Move mode copies each source, verifies the destination size, "
         "then deletes the source. It stops on the first failure.[/warning]"
     )
+    console.print(f"Source: [info]{move_estimate.source_path}[/info]")
     console.print(f"Destination: [info]{move_estimate.split_output_root}[/info]")
     console.print(f"Source volume: [info]{move_estimate.source_volume}[/info]")
     console.print(

--- a/src/autoclean/utils/montage_preflight.py
+++ b/src/autoclean/utils/montage_preflight.py
@@ -432,6 +432,7 @@ def copy_originals_for_plan(
                     {
                         "source": result.path,
                         "destination": str(destination),
+                        "size_bytes": result.size_bytes,
                         "error": str(exc),
                     }
                 ],
@@ -600,6 +601,7 @@ def move_originals_for_plan(
                     {
                         "source": result.path,
                         "destination": str(destination),
+                        "size_bytes": result.size_bytes,
                         "error": str(exc),
                     }
                 ],

--- a/src/autoclean/utils/montage_preflight.py
+++ b/src/autoclean/utils/montage_preflight.py
@@ -118,6 +118,47 @@ class MontageCopyError(RuntimeError):
 
 
 @dataclass(frozen=True)
+class MontageMoveResult:
+    """Summary of a move-originals apply step."""
+
+    split_output_root: str
+    planned_manifest: str
+    moved_files: list[dict]
+    skipped_files: list[str]
+    required_bytes: int
+    free_bytes_before: int
+    free_bytes_after_estimate: int
+    same_volume: bool
+    source_volume: str
+    destination_volume: str
+    completed: bool = True
+    errors: list[dict] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MontageMoveEstimate:
+    """Pre-confirmation size, volume, and free-space estimate for move-originals."""
+
+    split_output_root: str
+    actionable_file_count: int
+    unknown_file_count: int
+    required_bytes: int
+    free_bytes_before: int
+    free_bytes_after_estimate: int
+    same_volume: bool
+    source_volume: str
+    destination_volume: str
+
+
+class MontageMoveError(RuntimeError):
+    """Raised when move-originals fails after recording partial progress."""
+
+    def __init__(self, message: str, partial_result: MontageMoveResult) -> None:
+        super().__init__(message)
+        self.partial_result = partial_result
+
+
+@dataclass(frozen=True)
 class MontageTaskCloneResult:
     """Summary of one cloned task file."""
 
@@ -440,10 +481,153 @@ def estimate_copy_originals_for_plan(
     )
 
 
+def estimate_move_originals_for_plan(
+    plan: MontageBatchPlan,
+    *,
+    split_output_root: Path,
+) -> MontageMoveEstimate:
+    """Estimate move-originals size, volume, and temporary free-space needs."""
+
+    actionable = [result for result in plan.files if result.is_actionable]
+    required_bytes = sum(result.size_bytes for result in actionable)
+    source_root = _nearest_existing_path(Path(plan.input_path))
+    destination_root = _nearest_existing_path(split_output_root.parent)
+    free_before = shutil.disk_usage(destination_root).free
+    source_volume = _volume_identity(source_root)
+    destination_volume = _volume_identity(destination_root)
+    return MontageMoveEstimate(
+        split_output_root=str(split_output_root),
+        actionable_file_count=len(actionable),
+        unknown_file_count=len(plan.unknown_files),
+        required_bytes=required_bytes,
+        free_bytes_before=free_before,
+        free_bytes_after_estimate=free_before - required_bytes,
+        same_volume=source_volume == destination_volume,
+        source_volume=source_volume,
+        destination_volume=destination_volume,
+    )
+
+
+def write_planned_move_manifest(
+    plan: MontageBatchPlan,
+    *,
+    output_dir: Path,
+    split_output_root: Path,
+    estimate: MontageMoveEstimate | None = None,
+) -> Path:
+    """Write the machine-readable planned move manifest before moving files."""
+
+    estimate = estimate or estimate_move_originals_for_plan(
+        plan,
+        split_output_root=split_output_root,
+    )
+    targets = _move_targets_for_plan(plan, split_output_root=split_output_root)
+    _validate_move_plan(plan, targets=targets, estimate=estimate)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / "autoclean_montage_move_manifest.json"
+    payload = {
+        "input_path": plan.input_path,
+        "task_path": plan.task_path,
+        "split_output_root": str(split_output_root),
+        "required_bytes": estimate.required_bytes,
+        "free_bytes_before": estimate.free_bytes_before,
+        "free_bytes_after_estimate": estimate.free_bytes_after_estimate,
+        "same_volume": estimate.same_volume,
+        "source_volume": estimate.source_volume,
+        "destination_volume": estimate.destination_volume,
+        "unknown_files": plan.unknown_files,
+        "moves": [
+            {
+                "source": result.path,
+                "destination": str(destination),
+                "detected_montage": result.detected_montage,
+                "size_bytes": result.size_bytes,
+            }
+            for result, destination in targets
+        ],
+    }
+    manifest_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def move_originals_for_plan(
+    plan: MontageBatchPlan,
+    *,
+    split_output_root: Path,
+    planned_manifest: Path,
+    estimate: MontageMoveEstimate | None = None,
+) -> MontageMoveResult:
+    """Copy, verify, then delete actionable originals into montage folders."""
+
+    estimate = estimate or estimate_move_originals_for_plan(
+        plan,
+        split_output_root=split_output_root,
+    )
+    if not planned_manifest.is_file():
+        raise FileNotFoundError(f"Planned move manifest not found: {planned_manifest}")
+    targets = _move_targets_for_plan(plan, split_output_root=split_output_root)
+    _validate_move_plan(plan, targets=targets, estimate=estimate)
+
+    moved: list[dict] = []
+    skipped: list[str] = []
+    base_result = {
+        "split_output_root": str(split_output_root),
+        "planned_manifest": str(planned_manifest),
+        "skipped_files": skipped,
+        "required_bytes": estimate.required_bytes,
+        "free_bytes_before": estimate.free_bytes_before,
+        "free_bytes_after_estimate": estimate.free_bytes_after_estimate,
+        "same_volume": estimate.same_volume,
+        "source_volume": estimate.source_volume,
+        "destination_volume": estimate.destination_volume,
+    }
+
+    for result, destination in targets:
+        source = Path(result.path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            _copy_path(source, destination)
+            _verify_copied_path(destination, result.size_bytes)
+            _delete_path(source)
+        except Exception as exc:
+            partial_result = MontageMoveResult(
+                moved_files=moved,
+                completed=False,
+                errors=[
+                    {
+                        "source": result.path,
+                        "destination": str(destination),
+                        "error": str(exc),
+                    }
+                ],
+                **base_result,
+            )
+            raise MontageMoveError(
+                "Move failed after "
+                f"{len(moved)} file(s): {result.path} -> {destination}: {exc}",
+                partial_result,
+            ) from exc
+
+        moved.append(
+            {
+                "source": result.path,
+                "destination": str(destination),
+                "detected_montage": result.detected_montage,
+                "size_bytes": result.size_bytes,
+                "verified": True,
+                "deleted_source": True,
+            }
+        )
+
+    return MontageMoveResult(moved_files=moved, **base_result)
+
+
 def write_apply_summary(
     *,
     output_dir: Path,
     copy_result: MontageCopyResult | None = None,
+    move_result: MontageMoveResult | None = None,
     cloned_tasks: list[MontageTaskCloneResult] | None = None,
 ) -> Path:
     """Write autoclean_montage_apply_summary.json."""
@@ -452,6 +636,7 @@ def write_apply_summary(
     summary_path = output_dir / "autoclean_montage_apply_summary.json"
     summary = {
         "copy_result": asdict(copy_result) if copy_result else None,
+        "move_result": asdict(move_result) if move_result else None,
         "cloned_tasks": [asdict(task) for task in (cloned_tasks or [])],
     }
     summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
@@ -594,6 +779,78 @@ def _nearest_existing_path(path: Path) -> Path:
             )
         current = parent
     return current
+
+
+def _volume_identity(path: Path) -> str:
+    stat_result = path.stat()
+    return f"device:{stat_result.st_dev}"
+
+
+def _move_targets_for_plan(
+    plan: MontageBatchPlan,
+    *,
+    split_output_root: Path,
+) -> list[tuple[MontagePreflightFileResult, Path]]:
+    return [
+        (
+            result,
+            split_output_root / str(result.detected_montage) / result.relative_path,
+        )
+        for result in plan.files
+        if result.is_actionable
+    ]
+
+
+def _validate_move_plan(
+    plan: MontageBatchPlan,
+    *,
+    targets: list[tuple[MontagePreflightFileResult, Path]],
+    estimate: MontageMoveEstimate,
+) -> None:
+    if plan.unknown_files:
+        raise ValueError(
+            "Refusing to move originals while unknown or unsupported files remain: "
+            + ", ".join(plan.unknown_files)
+        )
+
+    if estimate.required_bytes > estimate.free_bytes_before:
+        raise RuntimeError(
+            "Insufficient temporary free space for montage preflight move: "
+            f"need {estimate.required_bytes} bytes, "
+            f"available {estimate.free_bytes_before} bytes"
+        )
+
+    for _result, destination in targets:
+        if destination.exists():
+            raise FileExistsError(
+                f"Refusing to overwrite existing move destination: {destination}"
+            )
+
+
+def _copy_path(source: Path, destination: Path) -> None:
+    if source.is_dir():
+        shutil.copytree(source, destination)
+    else:
+        shutil.copy2(source, destination)
+
+
+def _verify_copied_path(destination: Path, expected_size_bytes: int) -> None:
+    if not destination.exists():
+        raise FileNotFoundError(f"Move destination was not created: {destination}")
+    actual_size = _path_size(destination)
+    if actual_size != expected_size_bytes:
+        raise RuntimeError(
+            "Move destination size mismatch after copy: "
+            f"{destination} expected {expected_size_bytes} bytes, "
+            f"found {actual_size} bytes"
+        )
+
+
+def _delete_path(source: Path) -> None:
+    if source.is_dir():
+        shutil.rmtree(source)
+    else:
+        source.unlink()
 
 
 def _first_task_class_name(source: str) -> str:

--- a/src/autoclean/utils/montage_preflight.py
+++ b/src/autoclean/utils/montage_preflight.py
@@ -139,6 +139,7 @@ class MontageMoveResult:
 class MontageMoveEstimate:
     """Pre-confirmation size, volume, and free-space estimate for move-originals."""
 
+    source_path: str
     split_output_root: str
     actionable_file_count: int
     unknown_file_count: int
@@ -496,6 +497,7 @@ def estimate_move_originals_for_plan(
     source_volume = _volume_identity(source_root)
     destination_volume = _volume_identity(destination_root)
     return MontageMoveEstimate(
+        source_path=plan.input_path,
         split_output_root=str(split_output_root),
         actionable_file_count=len(actionable),
         unknown_file_count=len(plan.unknown_files),
@@ -634,13 +636,126 @@ def write_apply_summary(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     summary_path = output_dir / "autoclean_montage_apply_summary.json"
+    operation_fields = _apply_summary_operation_fields(
+        copy_result=copy_result,
+        move_result=move_result,
+    )
     summary = {
+        **operation_fields,
         "copy_result": asdict(copy_result) if copy_result else None,
         "move_result": asdict(move_result) if move_result else None,
         "cloned_tasks": [asdict(task) for task in (cloned_tasks or [])],
     }
     summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
     return summary_path
+
+
+def _apply_summary_operation_fields(
+    *,
+    copy_result: MontageCopyResult | None,
+    move_result: MontageMoveResult | None,
+) -> dict:
+    """Build top-level audit fields for apply-mode file operations."""
+
+    if move_result:
+        return {
+            "operation": "move_originals",
+            "move_originals": True,
+            "copied_originals": False,
+            "delete_after_verified_copy": True,
+            "requires_user_confirmation": True,
+            "same_volume": move_result.same_volume,
+            "temporary_space_required_bytes": move_result.required_bytes,
+            "skipped_unknown_files": move_result.skipped_files,
+            "file_operations": _move_file_operations(move_result),
+        }
+    if copy_result:
+        return {
+            "operation": "copy_originals",
+            "move_originals": False,
+            "copied_originals": True,
+            "delete_after_verified_copy": False,
+            "requires_user_confirmation": True,
+            "same_volume": None,
+            "temporary_space_required_bytes": copy_result.required_bytes,
+            "skipped_unknown_files": copy_result.skipped_files,
+            "file_operations": _copy_file_operations(copy_result),
+        }
+    return {
+        "operation": None,
+        "move_originals": False,
+        "copied_originals": False,
+        "delete_after_verified_copy": False,
+        "requires_user_confirmation": False,
+        "same_volume": None,
+        "temporary_space_required_bytes": 0,
+        "skipped_unknown_files": [],
+        "file_operations": [],
+    }
+
+
+def _move_file_operations(move_result: MontageMoveResult) -> list[dict]:
+    operations = [
+        {
+            "source": item["source"],
+            "destination": item["destination"],
+            "operation": "move",
+            "bytes": item["size_bytes"],
+            "copy_status": "completed",
+            "verification_status": "completed" if item.get("verified") else "unknown",
+            "delete_source_status": (
+                "completed" if item.get("deleted_source") else "unknown"
+            ),
+            "status": "completed",
+        }
+        for item in move_result.moved_files
+    ]
+    operations.extend(
+        {
+            "source": item.get("source"),
+            "destination": item.get("destination"),
+            "operation": "move",
+            "bytes": item.get("size_bytes"),
+            "copy_status": "unknown",
+            "verification_status": "failed",
+            "delete_source_status": "not_started",
+            "status": "failed",
+            "error": item.get("error"),
+        }
+        for item in move_result.errors
+    )
+    return operations
+
+
+def _copy_file_operations(copy_result: MontageCopyResult) -> list[dict]:
+    operations = [
+        {
+            "source": item["source"],
+            "destination": item["destination"],
+            "operation": "copy",
+            "bytes": item["size_bytes"],
+            "copy_status": "completed",
+            "verification_status": "not_applicable",
+            "delete_source_status": "not_applicable",
+            "status": "completed",
+        }
+        for item in copy_result.copied_files
+    ]
+    operations.extend(
+        {
+            "source": item.get("source"),
+            "destination": item.get("destination"),
+            "operation": "copy",
+            "bytes": item.get("size_bytes"),
+            "copy_status": "failed",
+            "verification_status": "not_applicable",
+            "delete_source_status": "not_applicable",
+            "status": "failed",
+            "error": item.get("error"),
+        }
+        for item in copy_result.errors
+    )
+    return operations
 
 
 def clone_task_for_montage(

--- a/tests/unit/test_montage_preflight_cli.py
+++ b/tests/unit/test_montage_preflight_cli.py
@@ -492,7 +492,7 @@ def test_cmd_montage_preflight_copy_failure_writes_partial_summary(
 
 
 def test_cmd_montage_preflight_apply_move_writes_summary_before_move(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, capsys
 ) -> None:
     input_file = tmp_path / "sub-01.raw"
     input_file.write_text("raw", encoding="utf-8")
@@ -542,6 +542,7 @@ def test_cmd_montage_preflight_apply_move_writes_summary_before_move(
     monkeypatch.setattr(
         "autoclean.cli.estimate_move_originals_for_plan",
         lambda *_args, **_kwargs: MontageMoveEstimate(
+            source_path=str(input_file),
             split_output_root=str(split_output_root),
             actionable_file_count=1,
             unknown_file_count=0,
@@ -580,6 +581,9 @@ def test_cmd_montage_preflight_apply_move_writes_summary_before_move(
     )
 
     assert cmd_montage_preflight(args) == 0
+    output = capsys.readouterr().out
+    assert "Source:" in output
+    assert str(input_file) in output
     assert calls["manifest_before_move"] is False
     assert calls["summary_exists_before_move"] is True
     assert calls["summary_completed_before_move"] is False
@@ -589,7 +593,134 @@ def test_cmd_montage_preflight_apply_move_writes_summary_before_move(
         )
     )
     assert final_summary["copy_result"] is None
+    assert final_summary["operation"] == "move_originals"
+    assert final_summary["move_originals"] is True
+    assert final_summary["copied_originals"] is False
+    assert final_summary["delete_after_verified_copy"] is True
+    assert final_summary["requires_user_confirmation"] is True
+    assert final_summary["same_volume"] is True
+    assert final_summary["temporary_space_required_bytes"] == 3
+    assert final_summary["skipped_unknown_files"] == []
+    assert final_summary["file_operations"] == []
     assert final_summary["move_result"]["completed"] is True
+
+
+def test_cmd_montage_preflight_move_then_clone_failure_keeps_completed_summary(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    split_output_root = tmp_path / "split"
+    task_output_dir = tmp_path / "tasks"
+    manifest = output_dir / "autoclean_montage_move_manifest.json"
+    moved_destination = split_output_root / "GSN-HydroCel-129" / input_file.name
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[],
+        files=[],
+        unknown_files=[],
+        actionable_files=[],
+    )
+
+    def fake_move_originals_for_plan(*_args, **_kwargs):
+        return MontageMoveResult(
+            split_output_root=str(split_output_root),
+            planned_manifest=str(manifest),
+            moved_files=[
+                {
+                    "source": str(input_file),
+                    "destination": str(moved_destination),
+                    "detected_montage": "GSN-HydroCel-129",
+                    "size_bytes": 3,
+                    "verified": True,
+                    "deleted_source": True,
+                }
+            ],
+            skipped_files=[],
+            required_bytes=3,
+            free_bytes_before=100,
+            free_bytes_after_estimate=97,
+            same_volume=True,
+            source_volume="device:1",
+            destination_volume="device:1",
+        )
+
+    def fake_clone_tasks_for_mismatches(**_kwargs):
+        raise RuntimeError("clone blocked")
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        "autoclean.cli.estimate_move_originals_for_plan",
+        lambda *_args, **_kwargs: MontageMoveEstimate(
+            source_path=str(input_file),
+            split_output_root=str(split_output_root),
+            actionable_file_count=1,
+            unknown_file_count=0,
+            required_bytes=3,
+            free_bytes_before=100,
+            free_bytes_after_estimate=97,
+            same_volume=True,
+            source_volume="device:1",
+            destination_volume="device:1",
+        ),
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.write_planned_move_manifest",
+        lambda *_args, **_kwargs: manifest,
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.move_originals_for_plan",
+        fake_move_originals_for_plan,
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.clone_tasks_for_mismatches",
+        fake_clone_tasks_for_mismatches,
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=True,
+        copy_originals=False,
+        move_originals=True,
+        split_output_root=split_output_root,
+        clone_tasks=True,
+        task_output_dir=task_output_dir,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 1
+    summary = json.loads(
+        (output_dir / "autoclean_montage_apply_summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert summary["move_result"]["completed"] is True
+    assert summary["cloned_tasks"] == []
+    assert summary["operation"] == "move_originals"
+    assert summary["file_operations"] == [
+        {
+            "source": str(input_file),
+            "destination": str(moved_destination),
+            "operation": "move",
+            "bytes": 3,
+            "copy_status": "completed",
+            "verification_status": "completed",
+            "delete_source_status": "completed",
+            "status": "completed",
+        }
+    ]
 
 
 def test_cmd_montage_preflight_move_failure_writes_partial_summary(
@@ -634,6 +765,7 @@ def test_cmd_montage_preflight_move_failure_writes_partial_summary(
     monkeypatch.setattr(
         "autoclean.cli.estimate_move_originals_for_plan",
         lambda *_args, **_kwargs: MontageMoveEstimate(
+            source_path=str(input_file),
             split_output_root=str(split_output_root),
             actionable_file_count=1,
             unknown_file_count=0,

--- a/tests/unit/test_montage_preflight_cli.py
+++ b/tests/unit/test_montage_preflight_cli.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
+
+import pytest
 
 from autoclean.cli import cmd_montage_preflight, create_parser
 from autoclean.utils.montage_preflight import (
@@ -8,6 +11,9 @@ from autoclean.utils.montage_preflight import (
     MontageCopyError,
     MontageCopyEstimate,
     MontageCopyResult,
+    MontageMoveError,
+    MontageMoveEstimate,
+    MontageMoveResult,
     MontagePreflightFileResult,
     MontagePreflightGroup,
 )
@@ -32,7 +38,28 @@ def test_montage_preflight_parser_defaults() -> None:
     assert args.montage_action == "preflight"
     assert args.apply is False
     assert args.copy_originals is False
+    assert args.move_originals is False
     assert args.clone_tasks is False
+
+
+def test_montage_preflight_parser_rejects_copy_and_move_originals() -> None:
+    parser = create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "montage",
+                "preflight",
+                "--input",
+                "/tmp/input",
+                "--task",
+                "/tmp/task.py",
+                "--output",
+                "/tmp/output",
+                "--copy-originals",
+                "--move-originals",
+            ]
+        )
 
 
 def test_cmd_montage_preflight_writes_dry_run_artifacts(monkeypatch, tmp_path) -> None:
@@ -81,6 +108,7 @@ def test_cmd_montage_preflight_writes_dry_run_artifacts(monkeypatch, tmp_path) -
         dry_run=False,
         apply=False,
         copy_originals=False,
+        move_originals=False,
         split_output_root=None,
         clone_tasks=False,
         task_output_dir=None,
@@ -121,6 +149,7 @@ def test_cmd_montage_preflight_rejects_apply_flags_without_apply(
         dry_run=False,
         apply=False,
         copy_originals=True,
+        move_originals=False,
         split_output_root=tmp_path / "split",
         clone_tasks=True,
         task_output_dir=tmp_path / "tasks",
@@ -132,6 +161,84 @@ def test_cmd_montage_preflight_rejects_apply_flags_without_apply(
 
     assert cmd_montage_preflight(args) == 1
     assert any("require --apply" in text for text in messages)
+
+
+def test_cmd_montage_preflight_rejects_move_without_apply(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    messages = []
+
+    monkeypatch.setattr(
+        "autoclean.cli.build_batch_plan",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("build should not run")),
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.message",
+        lambda _level, text: messages.append(text),
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=tmp_path / "out",
+        dry_run=False,
+        apply=False,
+        copy_originals=False,
+        move_originals=True,
+        split_output_root=tmp_path / "split",
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 1
+    assert any("--move-originals" in text for text in messages)
+
+
+def test_cmd_montage_preflight_rejects_copy_and_move_namespace(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    messages = []
+
+    monkeypatch.setattr(
+        "autoclean.cli.build_batch_plan",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("build should not run")),
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.message",
+        lambda _level, text: messages.append(text),
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=tmp_path / "out",
+        dry_run=False,
+        apply=True,
+        copy_originals=True,
+        move_originals=True,
+        split_output_root=tmp_path / "split",
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 1
+    assert any("not both" in text for text in messages)
 
 
 def test_cmd_montage_preflight_rejects_apply_and_dry_run(monkeypatch, tmp_path) -> None:
@@ -152,6 +259,7 @@ def test_cmd_montage_preflight_rejects_apply_and_dry_run(monkeypatch, tmp_path) 
         dry_run=True,
         apply=True,
         copy_originals=False,
+        move_originals=False,
         split_output_root=None,
         clone_tasks=False,
         task_output_dir=None,
@@ -210,6 +318,7 @@ def test_cmd_montage_preflight_apply_copy_uses_split_output_root(
         dry_run=False,
         apply=True,
         copy_originals=True,
+        move_originals=False,
         split_output_root=split_output_root,
         clone_tasks=False,
         task_output_dir=None,
@@ -287,6 +396,7 @@ def test_cmd_montage_preflight_prints_copy_estimate_before_copy(
         dry_run=False,
         apply=True,
         copy_originals=True,
+        move_originals=False,
         split_output_root=split_output_root,
         clone_tasks=False,
         task_output_dir=None,
@@ -365,6 +475,7 @@ def test_cmd_montage_preflight_copy_failure_writes_partial_summary(
         dry_run=False,
         apply=True,
         copy_originals=True,
+        move_originals=False,
         split_output_root=split_output_root,
         clone_tasks=False,
         task_output_dir=None,
@@ -378,6 +489,196 @@ def test_cmd_montage_preflight_copy_failure_writes_partial_summary(
     summary = output_dir / "autoclean_montage_apply_summary.json"
     assert summary.is_file()
     assert '"completed": false' in summary.read_text(encoding="utf-8")
+
+
+def test_cmd_montage_preflight_apply_move_writes_summary_before_move(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    split_output_root = tmp_path / "split"
+    manifest = output_dir / "autoclean_montage_move_manifest.json"
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[],
+        files=[],
+        unknown_files=[],
+        actionable_files=[],
+    )
+    calls = {}
+
+    def fake_write_manifest(*_args, **_kwargs):
+        calls["manifest_before_move"] = "move" in calls
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text("{}", encoding="utf-8")
+        return manifest
+
+    def fake_move_originals_for_plan(plan_arg, **kwargs):
+        calls["move"] = True
+        summary = output_dir / "autoclean_montage_apply_summary.json"
+        calls["summary_exists_before_move"] = summary.is_file()
+        payload = json.loads(summary.read_text(encoding="utf-8"))
+        calls["summary_completed_before_move"] = payload["move_result"]["completed"]
+        return MontageMoveResult(
+            split_output_root=str(split_output_root),
+            planned_manifest=str(manifest),
+            moved_files=[],
+            skipped_files=[],
+            required_bytes=3,
+            free_bytes_before=100,
+            free_bytes_after_estimate=97,
+            same_volume=True,
+            source_volume="device:1",
+            destination_volume="device:1",
+        )
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        "autoclean.cli.estimate_move_originals_for_plan",
+        lambda *_args, **_kwargs: MontageMoveEstimate(
+            split_output_root=str(split_output_root),
+            actionable_file_count=1,
+            unknown_file_count=0,
+            required_bytes=3,
+            free_bytes_before=100,
+            free_bytes_after_estimate=97,
+            same_volume=True,
+            source_volume="device:1",
+            destination_volume="device:1",
+        ),
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.write_planned_move_manifest",
+        fake_write_manifest,
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.move_originals_for_plan",
+        fake_move_originals_for_plan,
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=True,
+        copy_originals=False,
+        move_originals=True,
+        split_output_root=split_output_root,
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 0
+    assert calls["manifest_before_move"] is False
+    assert calls["summary_exists_before_move"] is True
+    assert calls["summary_completed_before_move"] is False
+    final_summary = json.loads(
+        (output_dir / "autoclean_montage_apply_summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert final_summary["copy_result"] is None
+    assert final_summary["move_result"]["completed"] is True
+
+
+def test_cmd_montage_preflight_move_failure_writes_partial_summary(
+    monkeypatch, tmp_path
+) -> None:
+    input_file = tmp_path / "sub-01.raw"
+    input_file.write_text("raw", encoding="utf-8")
+    task_file = tmp_path / "Task.py"
+    task_file.write_text("config = {}", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    split_output_root = tmp_path / "split"
+    manifest = output_dir / "autoclean_montage_move_manifest.json"
+    plan = MontageBatchPlan(
+        input_path=str(input_file),
+        task_path=str(task_file),
+        expected_montage="GSN-HydroCel-128",
+        output_dir=str(output_dir),
+        groups=[],
+        files=[],
+        unknown_files=[],
+        actionable_files=[],
+    )
+    partial_result = MontageMoveResult(
+        split_output_root=str(split_output_root),
+        planned_manifest=str(manifest),
+        moved_files=[],
+        skipped_files=[],
+        required_bytes=3,
+        free_bytes_before=100,
+        free_bytes_after_estimate=97,
+        same_volume=True,
+        source_volume="device:1",
+        destination_volume="device:1",
+        completed=False,
+        errors=[{"source": str(input_file), "destination": "dest", "error": "bad"}],
+    )
+
+    def fake_move_originals_for_plan(*_args, **_kwargs):
+        raise MontageMoveError("bad", partial_result)
+
+    monkeypatch.setattr("autoclean.cli.build_batch_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        "autoclean.cli.estimate_move_originals_for_plan",
+        lambda *_args, **_kwargs: MontageMoveEstimate(
+            split_output_root=str(split_output_root),
+            actionable_file_count=1,
+            unknown_file_count=0,
+            required_bytes=3,
+            free_bytes_before=100,
+            free_bytes_after_estimate=97,
+            same_volume=True,
+            source_volume="device:1",
+            destination_volume="device:1",
+        ),
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.write_planned_move_manifest",
+        lambda *_args, **_kwargs: manifest,
+    )
+    monkeypatch.setattr(
+        "autoclean.cli.move_originals_for_plan",
+        fake_move_originals_for_plan,
+    )
+
+    args = SimpleNamespace(
+        input=input_file,
+        task=task_file,
+        output=output_dir,
+        dry_run=False,
+        apply=True,
+        copy_originals=False,
+        move_originals=True,
+        split_output_root=split_output_root,
+        clone_tasks=False,
+        task_output_dir=None,
+        yes=True,
+        overwrite=False,
+        no_color=True,
+        quiet=True,
+    )
+
+    assert cmd_montage_preflight(args) == 1
+    summary = json.loads(
+        (output_dir / "autoclean_montage_apply_summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert summary["move_result"]["completed"] is False
+    assert summary["move_result"]["errors"][0]["error"] == "bad"
 
 
 def test_cmd_montage_preflight_apply_clone_uses_keyword_plan(
@@ -418,6 +719,7 @@ def test_cmd_montage_preflight_apply_clone_uses_keyword_plan(
         dry_run=False,
         apply=True,
         copy_originals=False,
+        move_originals=False,
         split_output_root=None,
         clone_tasks=True,
         task_output_dir=task_output_dir,

--- a/tests/unit/test_montage_preflight_cli.py
+++ b/tests/unit/test_montage_preflight_cli.py
@@ -456,7 +456,14 @@ def test_cmd_montage_preflight_copy_failure_writes_partial_summary(
         free_bytes_before=100,
         free_bytes_after_estimate=94,
         completed=False,
-        errors=[{"source": "sub-02.raw", "destination": "dest", "error": "blocked"}],
+        errors=[
+            {
+                "source": "sub-02.raw",
+                "destination": "dest",
+                "size_bytes": 3,
+                "error": "blocked",
+            }
+        ],
     )
 
     def fake_copy_originals_for_plan(*_args, **_kwargs):
@@ -488,7 +495,10 @@ def test_cmd_montage_preflight_copy_failure_writes_partial_summary(
     assert cmd_montage_preflight(args) == 1
     summary = output_dir / "autoclean_montage_apply_summary.json"
     assert summary.is_file()
-    assert '"completed": false' in summary.read_text(encoding="utf-8")
+    payload = json.loads(summary.read_text(encoding="utf-8"))
+    assert payload["copy_result"]["completed"] is False
+    assert payload["file_operations"][-1]["status"] == "failed"
+    assert payload["file_operations"][-1]["bytes"] == 3
 
 
 def test_cmd_montage_preflight_apply_move_writes_summary_before_move(
@@ -755,7 +765,14 @@ def test_cmd_montage_preflight_move_failure_writes_partial_summary(
         source_volume="device:1",
         destination_volume="device:1",
         completed=False,
-        errors=[{"source": str(input_file), "destination": "dest", "error": "bad"}],
+        errors=[
+            {
+                "source": str(input_file),
+                "destination": "dest",
+                "size_bytes": 3,
+                "error": "bad",
+            }
+        ],
     )
 
     def fake_move_originals_for_plan(*_args, **_kwargs):
@@ -811,6 +828,8 @@ def test_cmd_montage_preflight_move_failure_writes_partial_summary(
     )
     assert summary["move_result"]["completed"] is False
     assert summary["move_result"]["errors"][0]["error"] == "bad"
+    assert summary["file_operations"][0]["status"] == "failed"
+    assert summary["file_operations"][0]["bytes"] == 3
 
 
 def test_cmd_montage_preflight_apply_clone_uses_keyword_plan(

--- a/tests/unit/utils/test_montage_preflight.py
+++ b/tests/unit/utils/test_montage_preflight.py
@@ -320,6 +320,7 @@ def test_copy_originals_reports_partial_failure(
         {
             "source": str(file_b),
             "destination": str(tmp_path / "split" / "GSN-HydroCel-128" / "b.raw"),
+            "size_bytes": 4,
             "error": "blocked",
         }
     ]
@@ -509,6 +510,7 @@ def test_move_originals_preserves_source_on_verification_failure(
 
     assert input_file.read_text(encoding="utf-8") == "alpha"
     assert exc_info.value.partial_result.completed is False
+    assert exc_info.value.partial_result.errors[0]["size_bytes"] == 5
     assert "size mismatch" in exc_info.value.partial_result.errors[0]["error"]
 
 

--- a/tests/unit/utils/test_montage_preflight.py
+++ b/tests/unit/utils/test_montage_preflight.py
@@ -7,12 +7,16 @@ import pytest
 
 from autoclean.utils.montage_preflight import (
     MontageCopyError,
+    MontageMoveError,
     build_batch_plan,
     clone_tasks_for_mismatches,
     copy_originals_for_plan,
     detect_hydrocel_montage,
     estimate_copy_originals_for_plan,
+    estimate_move_originals_for_plan,
+    move_originals_for_plan,
     write_batch_plan_json,
+    write_planned_move_manifest,
     write_scan_csv,
 )
 
@@ -338,6 +342,254 @@ def test_direct_mff_input_copy_preserves_package_name(tmp_path: Path) -> None:
     assert copied_package.is_dir()
     assert (copied_package / "signal1.bin").read_text(encoding="utf-8") == "alpha"
     assert result.copied_files[0]["destination"] == str(copied_package)
+
+
+def test_move_originals_refuses_unknown_files(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    file_128 = _touch(input_dir / "sub-01.raw", "alpha")
+    file_unknown = _touch(input_dir / "sub-02.raw", "beta")
+    task = _task_file(tmp_path)
+
+    def loader(path: Path) -> FakeRaw:
+        if path == file_128:
+            return FakeRaw([f"E{i}" for i in range(1, 129)])
+        if path == file_unknown:
+            return FakeRaw([f"E{i}" for i in range(1, 128)])
+        raise AssertionError(f"unexpected path {path}")
+
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=loader,
+    )
+
+    with pytest.raises(ValueError, match="unknown or unsupported"):
+        write_planned_move_manifest(
+            plan,
+            output_dir=tmp_path / "out",
+            split_output_root=tmp_path / "split",
+        )
+
+    assert file_128.exists()
+    assert file_unknown.exists()
+    assert not (tmp_path / "out" / "autoclean_montage_move_manifest.json").exists()
+
+
+def test_move_originals_blocks_existing_destinations(tmp_path: Path) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw", "alpha")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+    _touch(tmp_path / "split" / "GSN-HydroCel-128" / "sub-01.raw", "exists")
+
+    with pytest.raises(FileExistsError, match="overwrite"):
+        write_planned_move_manifest(
+            plan,
+            output_dir=tmp_path / "out",
+            split_output_root=tmp_path / "split",
+        )
+
+    assert input_file.read_text(encoding="utf-8") == "alpha"
+
+
+def test_move_originals_writes_manifest_before_copy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw", "alpha")
+    task = _task_file(tmp_path)
+    output_dir = tmp_path / "out"
+    split_root = tmp_path / "split"
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=output_dir,
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+    manifest = write_planned_move_manifest(
+        plan,
+        output_dir=output_dir,
+        split_output_root=split_root,
+    )
+    calls = []
+
+    def fake_copy2(source: Path, destination: Path):
+        assert manifest.is_file()
+        calls.append((source, destination))
+        Path(destination).write_text(Path(source).read_text(encoding="utf-8"))
+
+    monkeypatch.setattr("autoclean.utils.montage_preflight.shutil.copy2", fake_copy2)
+
+    result = move_originals_for_plan(
+        plan,
+        split_output_root=split_root,
+        planned_manifest=manifest,
+    )
+
+    assert calls
+    assert result.planned_manifest == str(manifest)
+    assert result.completed is True
+
+
+def test_move_originals_verifies_before_delete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw", "alpha")
+    task = _task_file(tmp_path)
+    split_root = tmp_path / "split"
+    destination = split_root / "GSN-HydroCel-128" / "sub-01.raw"
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+    manifest = write_planned_move_manifest(
+        plan,
+        output_dir=tmp_path / "out",
+        split_output_root=split_root,
+    )
+    expected_size = input_file.stat().st_size
+    original_unlink = Path.unlink
+    delete_checks = []
+
+    def checked_unlink(self, *args, **kwargs):
+        if self == input_file:
+            delete_checks.append(destination.stat().st_size)
+            assert destination.exists()
+            assert destination.stat().st_size == expected_size
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", checked_unlink)
+
+    move_originals_for_plan(
+        plan,
+        split_output_root=split_root,
+        planned_manifest=manifest,
+    )
+
+    assert delete_checks == [expected_size]
+    assert not input_file.exists()
+    assert destination.read_text(encoding="utf-8") == "alpha"
+
+
+def test_move_originals_preserves_source_on_verification_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw", "alpha")
+    task = _task_file(tmp_path)
+    split_root = tmp_path / "split"
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+    manifest = write_planned_move_manifest(
+        plan,
+        output_dir=tmp_path / "out",
+        split_output_root=split_root,
+    )
+
+    def fake_copy2(_source: Path, destination: Path):
+        Path(destination).write_text("truncated", encoding="utf-8")
+
+    monkeypatch.setattr("autoclean.utils.montage_preflight.shutil.copy2", fake_copy2)
+
+    with pytest.raises(MontageMoveError) as exc_info:
+        move_originals_for_plan(
+            plan,
+            split_output_root=split_root,
+            planned_manifest=manifest,
+        )
+
+    assert input_file.read_text(encoding="utf-8") == "alpha"
+    assert exc_info.value.partial_result.completed is False
+    assert "size mismatch" in exc_info.value.partial_result.errors[0]["error"]
+
+
+def test_move_originals_refuses_insufficient_temporary_space(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_file = _touch(tmp_path / "input" / "sub-01.raw", "alpha")
+    task = _task_file(tmp_path)
+    plan = build_batch_plan(
+        input_path=input_file,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=lambda _path: FakeRaw([f"E{i}" for i in range(1, 129)]),
+    )
+    monkeypatch.setattr(
+        "autoclean.utils.montage_preflight.shutil.disk_usage",
+        lambda _path: type("DiskUsage", (), {"free": 1})(),
+    )
+
+    estimate = estimate_move_originals_for_plan(
+        plan,
+        split_output_root=tmp_path / "split",
+    )
+
+    assert estimate.required_bytes == input_file.stat().st_size
+    with pytest.raises(RuntimeError, match="Insufficient temporary free space"):
+        write_planned_move_manifest(
+            plan,
+            output_dir=tmp_path / "out",
+            split_output_root=tmp_path / "split",
+            estimate=estimate,
+        )
+    assert input_file.exists()
+
+
+def test_move_originals_synthetic_temp_dir_move(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    file_128 = _touch(input_dir / "sub-01.raw", "alpha")
+    file_129 = _touch(input_dir / "sub-02.raw", "bravo")
+    task = _task_file(tmp_path)
+
+    def loader(path: Path) -> FakeRaw:
+        if path == file_128:
+            return FakeRaw([f"E{i}" for i in range(1, 129)])
+        if path == file_129:
+            return FakeRaw([f"E{i}" for i in range(1, 130)])
+        raise AssertionError(f"unexpected path {path}")
+
+    plan = build_batch_plan(
+        input_path=input_dir,
+        task_path=task,
+        output_dir=tmp_path / "out",
+        raw_loader=loader,
+    )
+    manifest = write_planned_move_manifest(
+        plan,
+        output_dir=tmp_path / "out",
+        split_output_root=tmp_path / "split",
+    )
+
+    result = move_originals_for_plan(
+        plan,
+        split_output_root=tmp_path / "split",
+        planned_manifest=manifest,
+    )
+
+    assert result.completed is True
+    assert len(result.moved_files) == 2
+    assert not file_128.exists()
+    assert not file_129.exists()
+    assert (tmp_path / "split" / "GSN-HydroCel-128" / "sub-01.raw").read_text(
+        encoding="utf-8"
+    ) == "alpha"
+    assert (tmp_path / "split" / "GSN-HydroCel-129" / "sub-02.raw").read_text(
+        encoding="utf-8"
+    ) == "bravo"
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert [Path(item["source"]).name for item in manifest_payload["moves"]] == [
+        "sub-01.raw",
+        "sub-02.raw",
+    ]
 
 
 def test_task_clone_changes_montage_class_name_and_adds_provenance(


### PR DESCRIPTION
## Summary

Closes #278.

Adds explicit `--move-originals` support to `autocleaneeg-pipeline montage preflight` as an apply-only, per-run action. Move mode uses copy, size verification, then source deletion, with a planned move manifest and expanded apply audit summary.

## What changed

- Added `--move-originals`, mutually exclusive with `--copy-originals`.
- Added move estimates with source/destination, same-volume status, and temporary-space impact before confirmation.
- Added `autoclean_montage_move_manifest.json` before move execution.
- Added copy-verify-delete move helper that stops on first failure and does not delete sources on verification failure.
- Extended apply summary with top-level operation audit fields and `file_operations`, while preserving existing nested result fields.
- Ensured completed move state is written before later task-clone failures can return.

## Validation

- Focused pytest: `34 passed`
- Ruff selected checks: passed
- Black check: passed
- `git diff --check`: passed
- Boulder re-review: PASS
- Cricket re-QA: PASS

Residual non-blocker: destination verification remains size-based, as scoped in the issue and review notes.
