### PR TITLE
fix: dedupe reprocess bad channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Install Qt runtime dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libegl1
+
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
+++ b/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Correspondence 028 - Issue 288 execution update</title>
+</head>
+<body>
+  <header>
+    <h1>Correspondence 028: Issue #288 execution update</h1>
+    <dl>
+      <dt>From</dt><dd>Echo - Software Engineer</dd>
+      <dt>To</dt><dd>Raven - Engineering Delivery and Loop Coordinator</dd>
+      <dt>Date</dt><dd>2026-08-17</dd>
+      <dt>Re</dt><dd>De-duplicate bad channels in Exclude GUI reprocess tab</dd>
+      <dt>Source thread ID</dt><dd>019f42de-12c8-7681-b931-f19e15bdde8d</dd>
+      <dt>Delegation thread ID</dt><dd>01a00fb9-6e6c-7e23-a088-d7240bb721c6</dd>
+      <dt>Local work thread ID</dt><dd>T-2026-08-17-001</dd>
+      <dt>Issue</dt><dd>GitHub #288</dd>
+      <dt>Status</dt><dd>Implemented; verification blocked by local test environment</dd>
+      <dt>Record type</dt><dd>Internal draft execution update</dd>
+    </dl>
+  </header>
+
+  <section>
+    <h2>Request Summary</h2>
+    <p>PI-approved, Raven-routed implementation to preserve duplicate
+    <code>channel_removals</code> records while presenting and saving a unique,
+    stable-first-seen operational bad-channel selection in the Exclude GUI
+    reprocess path. Non-goals included schema or metadata semantic changes, UI
+    redesign, dependency changes, broad refactoring, commits, pushes, and PRs.
+    No specialist consultation was requested or performed.</p>
+  </section>
+
+  <section>
+    <h2>Execution Update</h2>
+    <p>Added a small stable-order de-duplication helper and a metadata extraction
+    helper. The preferred unified-removal path now derives a unique operational
+    list without mutating the removal records; the legacy path retains its
+    existing order and values. The widget also normalizes incoming operational
+    values before storing and displaying them. Added three focused regression
+    tests for duplicate reasons and metadata preservation, unique stable saved
+    selection, and unchanged legacy non-duplicate behavior.</p>
+    <p>Assumption: channel names are valid strings under the existing metadata
+    contract. Malformed-input handling was intentionally not broadened.</p>
+    <p><strong>QA correction:</strong> Cricket found that
+    <code>_parse_metadata_json</code> still emitted duplicate operational channel
+    names into the related-files summary path. Echo routed that parser through
+    the same metadata helper, retained its unchanged <code>channel_removals</code>
+    result for reason display, and added direct parser-boundary tests for unified
+    duplicate removals and legacy metadata. No Qt widget harness was introduced;
+    direct widget behavior remains an independent GUI verification gap.</p>
+    <p><strong>QA retest correction:</strong> Cricket noted that the direct legacy
+    parser fixture contained no duplicate and therefore would not fail against
+    the pre-fix parser. Echo changed that test fixture to
+    <code>["E3", "E1", "E3"]</code> while retaining the expected stable unique
+    result <code>["E3", "E1"]</code>. Production code was not changed in this
+    correction.</p>
+  </section>
+
+  <section>
+    <h2>Scope Limits</h2>
+    <p>Changed only <code>src/autoclean/tools/autoclean_exclude.py</code>, the new
+    directly relevant test file, and this required correspondence artifact. No
+    scientific interpretation, statistical choice, schema change, external
+    write, branch operation, commit, push, PR, or publication occurred. Full GUI
+    interaction and pytest execution were not verified because the local test
+    environment failed before collection.</p>
+  </section>
+
+  <section>
+    <h2>Evidence</h2>
+    <ul>
+      <li>Gate command (cwd <code>C:\Users\SYEX8X\Documents\autocleaneeg_pipeline</code>):
+      <code>git branch --show-current; git status --short; git rev-parse --show-toplevel; git rev-parse HEAD</code>.
+      Exit 0, 0.63s. Branch <code>codex/fix-288-dedupe-reprocess-channels</code>;
+      clean status; exact repository root; HEAD
+      <code>e095cc60debf3e0aa4bda7525f2936f7eb0bebe0</code>. Git warned that the
+      user-level ignore file was inaccessible.</li>
+      <li><code>git diff --check; git diff -- src/autoclean/tools/autoclean_exclude.py tests/unit/tools/test_autoclean_exclude.py</code>:
+      exit 0, 0.48s; no whitespace errors.</li>
+      <li>Exact pytest nodes through system Python: exit 1, 0.33s;
+      <code>No module named pytest</code>.</li>
+      <li>Single focused recovery through <code>uv run python -B -m pytest</code>
+      with the same three nodes and flags: exit 1, 0.38s; uv failed before
+      collection while initializing <code>C:\Users\SYEX8X\AppData\Local\uv\cache</code>
+      with OS error 183.</li>
+      <li>Standard-library AST parse of both Python files: exit 0, 0.91s;
+      <code>syntax-ok</code>.</li>
+      <li>Correction custody gate: exit 0, 0.64s; approved branch, exact base
+      HEAD and repository root, with only the existing maker source, tests, and
+      this correspondence artifact dirty.</li>
+      <li>Correction <code>git diff --check</code> plus standard-library AST parse:
+      exit 0, 0.53s; no whitespace errors and <code>syntax-ok</code>.</li>
+      <li>One system-Python pytest attempt for the two direct parser regression
+      nodes: exit 1, 0.29s; failed before collection because system Python 3.13
+      has no <code>pytest</code>. Per Raven's instruction, no uv retry or
+      environment mutation was attempted.</li>
+      <li>Observed working-tree state before this artifact: modified source file
+      and new <code>tests/unit/tools/</code>; no unrelated edits observed.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Conflict Status</h2>
+    <p>No conflict flagged. Cricket's acceptance finding was accepted and
+    corrected within the approved scope. Flag/Respond/Decide/Document state:
+    not applicable.</p>
+  </section>
+
+  <section>
+    <h2>Execution Decision</h2>
+    <p>Disposition: implemented within the approved boundary by Echo. Final
+    acceptance, review, and integration remain with Raven and independently
+    routed checkers. Echo does not self-approve.</p>
+  </section>
+
+  <section>
+    <h2>Verification</h2>
+    <p>Echo's maker-side static diff and syntax checks passed. Pytest was blocked
+    before collection in all permitted attempts, so dynamic test behavior and
+    direct GUI interaction remain unverified. Cricket independently found the
+    unnormalized parser path and the insufficient legacy fixture; Echo corrected
+    both, and Cricket's final read-only QA retest passed all acceptance criteria.
+    Cipher completed a bounded security and data-integrity review with no
+    findings. The Boulder found no code defects and classified the code as
+    conditionally ready subject to running the focused tests in a functioning
+    project environment.</p>
+  </section>
+
+  <section>
+    <h2>Next Actions</h2>
+    <ol>
+      <li>Run all five tests in
+      <code>tests/unit/tools/test_autoclean_exclude.py</code> in a functioning
+      project environment; stop on any failure.</li>
+      <li>Run named Black/isort check-only validation when the project tools are
+      available.</li>
+      <li>Raven should integrate the reviewed branch while preserving the
+      documented dynamic-verification gap; merge remains a PI decision.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Publication Boundary</h2>
+    <p>Internal draft. Do not publish. No patient-level data, credentials, or
+    secrets are included. Repository paths and command evidence are real, not
+    synthetic. Publication requires Raven review and the applicable PI gate.</p>
+  </section>
+</body>
+</html>

--- a/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
+++ b/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
@@ -142,9 +142,14 @@
 
   <section>
     <h2>Publication Boundary</h2>
-    <p>Internal draft. Do not publish. No patient-level data, credentials, or
-    secrets are included. Repository paths and command evidence are real, not
-    synthetic. Publication requires Raven review and the applicable PI gate.</p>
+    <p>Internal project record; not published to the public correspondence
+    archive. Draft GitHub PR
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/pull/290">#290</a>
+    was opened against <code>main</code> from
+    <code>codex/fix-288-dedupe-reprocess-channels</code> at reviewed head
+    <code>e442c3e26f910d6d394b0b6760d8478a3ce84216</code>. The PR remains draft,
+    dynamic pytest verification remains pending, and merge remains PI-gated.
+    No patient-level data, credentials, or secrets are included.</p>
   </section>
 </body>
 </html>

--- a/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
+++ b/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
@@ -55,16 +55,29 @@
     <code>["E3", "E1", "E3"]</code> while retaining the expected stable unique
     result <code>["E3", "E1"]</code>. Production code was not changed in this
     correction.</p>
+    <p><strong>PR #290 CI correction:</strong> The quality job reported that
+    <code>tests/unit/tools/test_autoclean_exclude.py</code> would be reformatted by
+    Black. The tests job stopped during collection because importing
+    <code>autoclean.tools.autoclean_exclude</code> caused PyQt6 QtPdf to fail on
+    missing <code>libEGL.so.1</code>; no assertions ran. With explicit PI
+    approval, Echo applied Black-equivalent formatting only to the test file and
+    added an Ubuntu tests-job step containing <code>apt-get update</code> and
+    installation of only <code>libegl1</code>. No speculative Qt/X11 packages,
+    test weakening, mocks, production dependency-guard changes, or helper
+    refactors were introduced.</p>
   </section>
 
   <section>
     <h2>Scope Limits</h2>
-    <p>Changed only <code>src/autoclean/tools/autoclean_exclude.py</code>, the new
-    directly relevant test file, and this required correspondence artifact. No
-    scientific interpretation, statistical choice, schema change, external
-    write, branch operation, commit, push, PR, or publication occurred. Full GUI
-    interaction and pytest execution were not verified because the local test
-    environment failed before collection.</p>
+    <p>The original bug fix changed the production exclusion module, its directly
+    relevant test file, and this required correspondence artifact. The approved CI
+    correction changes only <code>.github/workflows/ci.yml</code>, formatting in
+    <code>tests/unit/tools/test_autoclean_exclude.py</code>, and this artifact;
+    production code and test semantics are unchanged. No scientific interpretation,
+    statistical choice, schema change, merge, or public-archive publication occurred.
+    Full GUI interaction and pytest execution were not verified locally because the
+    local test environment failed before collection; GitHub Actions is the
+    authoritative Linux verification gate.</p>
   </section>
 
   <section>
@@ -97,6 +110,25 @@
       environment mutation was attempted.</li>
       <li>Observed working-tree state before this artifact: modified source file
       and new <code>tests/unit/tools/</code>; no unrelated edits observed.</li>
+      <li>PR #290 CI run:
+      <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32035975470">CI run 32035975470</a>.
+      Failed quality job:
+      <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32035975470/job/95406427166">job 95406427166</a>.
+      Failed tests job:
+      <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32035975470/job/95406427163">job 95406427163</a>.</li>
+      <li>CI-correction custody gate: exit 0, 0.69s; approved branch, clean tree,
+      exact repository root, and HEAD
+      <code>120795e67ed4e646ef5b6f3483f638d4a1abaa9b</code>.</li>
+      <li><code>gh pr checks 290 --repo cincibrainlab/autocleaneeg_pipeline</code>:
+      exit 1, 1.13s because <code>gh</code> is not installed. The connected GitHub
+      app then confirmed CI run 32035975470 and the two failed job IDs recorded
+      above; this was a read-only lookup.</li>
+      <li><code>git diff --check</code>, standard-library AST parse of the changed
+      Python test, <code>git status --short</code>, and scoped diff inspection:
+      exit 0, 0.84s; no whitespace errors, <code>syntax-ok</code>, exactly the
+      approved three files changed, and the <code>libegl1</code> step correctly
+      indented within the tests job. Black was not installed, so no installation
+      or local Black execution occurred.</li>
     </ul>
   </section>
 
@@ -124,7 +156,9 @@
     Cipher completed a bounded security and data-integrity review with no
     findings. The Boulder found no code defects and classified the code as
     conditionally ready subject to running the focused tests in a functioning
-    project environment.</p>
+    project environment. After the approved CI correction, checker state is
+    pending: Cricket has not yet verified this three-file diff, and the next CI
+    run is authoritative for Black and the Ubuntu Qt runtime dependency.</p>
   </section>
 
   <section>
@@ -135,6 +169,9 @@
       project environment; stop on any failure.</li>
       <li>Run named Black/isort check-only validation when the project tools are
       available.</li>
+      <li>Cricket should perform read-only verification of this CI correction;
+      the next GitHub CI run should confirm Black formatting and whether
+      <code>libegl1</code> is the complete concrete Ubuntu dependency fix.</li>
       <li>Raven should integrate the reviewed branch while preserving the
       documented dynamic-verification gap; merge remains a PI decision.</li>
     </ol>

--- a/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
+++ b/plans/correspondance/028-issue-288-deduplicate-reprocess-channels-execution.html
@@ -16,7 +16,7 @@
       <dt>Delegation thread ID</dt><dd>01a00fb9-6e6c-7e23-a088-d7240bb721c6</dd>
       <dt>Local work thread ID</dt><dd>T-2026-08-17-001</dd>
       <dt>Issue</dt><dd>GitHub #288</dd>
-      <dt>Status</dt><dd>Implemented; verification blocked by local test environment</dd>
+      <dt>Status</dt><dd>Implemented; independently reviewed; GitHub Actions green</dd>
       <dt>Record type</dt><dd>Internal draft execution update</dd>
     </dl>
   </header>
@@ -156,24 +156,22 @@
     Cipher completed a bounded security and data-integrity review with no
     findings. The Boulder found no code defects and classified the code as
     conditionally ready subject to running the focused tests in a functioning
-    project environment. After the approved CI correction, checker state is
-    pending: Cricket has not yet verified this three-file diff, and the next CI
-    run is authoritative for Black and the Ubuntu Qt runtime dependency.</p>
+    project environment. Cricket independently verified the three-file CI
+    correction and marked it safe to push. Authoritative GitHub Actions run
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32037406362">32037406362</a>
+    passed quality, tests, package, frontend, and docs at code head
+    <code>fe113a1136e9653b5dbc2352a9ab464d07c2ca4e</code>; companion Claude review
+    run <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32037406356">32037406356</a>
+    also passed.</p>
   </section>
 
   <section>
     <h2>Next Actions</h2>
     <ol>
-      <li>Run all five tests in
-      <code>tests/unit/tools/test_autoclean_exclude.py</code> in a functioning
-      project environment; stop on any failure.</li>
-      <li>Run named Black/isort check-only validation when the project tools are
-      available.</li>
-      <li>Cricket should perform read-only verification of this CI correction;
-      the next GitHub CI run should confirm Black formatting and whether
-      <code>libegl1</code> is the complete concrete Ubuntu dependency fix.</li>
-      <li>Raven should integrate the reviewed branch while preserving the
-      documented dynamic-verification gap; merge remains a PI decision.</li>
+      <li>The documentation-only custody commit containing this result must retain
+      green PR-head checks.</li>
+      <li>Raven performs the final mergeability/conflict audit; merge remains a PI
+      decision.</li>
     </ol>
   </section>
 
@@ -184,8 +182,8 @@
     <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/pull/290">#290</a>
     was opened against <code>main</code> from
     <code>codex/fix-288-dedupe-reprocess-channels</code> at reviewed head
-    <code>e442c3e26f910d6d394b0b6760d8478a3ce84216</code>. The PR remains draft,
-    dynamic pytest verification remains pending, and merge remains PI-gated.
+    <code>fe113a1136e9653b5dbc2352a9ab464d07c2ca4e</code>. The PR remains draft,
+    all required checks passed on that code head, and merge remains PI-gated.
     No patient-level data, credentials, or secrets are included.</p>
   </section>
 </body>

--- a/src/autoclean/tools/autoclean_exclude.py
+++ b/src/autoclean/tools/autoclean_exclude.py
@@ -217,6 +217,21 @@ def _group_channel_removals(channel_removals: List[Dict]) -> Dict[str, List[str]
     return grouped
 
 
+def _unique_channels(channels: List[str]) -> List[str]:
+    """Return channel names once each, preserving first-seen order."""
+    return list(dict.fromkeys(channels))
+
+
+def _bad_channels_from_metadata(metadata: Dict) -> List[str]:
+    """Extract the unique operational bad-channel list from run metadata."""
+    channel_removals = metadata.get("channel_removals", [])
+    if channel_removals:
+        return _unique_channels([removal["channel"] for removal in channel_removals])
+
+    legacy_bad_channels = metadata.get("step_clean_bad_channels", {}).get("bads", [])
+    return _unique_channels(legacy_bad_channels)
+
+
 def _get_removal_reason_display(reason_code: str) -> Tuple[str, str]:
     """Get human-readable label and color for a removal reason code.
 
@@ -1865,7 +1880,7 @@ class ReprocessWidget(QWidget):
         self.channel_combo.clear()
 
         # Extract data from metadata
-        bad_channels = metadata.get("bad_channels", [])
+        bad_channels = _unique_channels(metadata.get("bad_channels", []))
         rejected_ica = metadata.get("rejected_ica", [])
         valid_channels = metadata.get("valid_channels", [])
         max_components = metadata.get("max_components", 0)
@@ -3727,14 +3742,7 @@ class ExclusionFileSelector(ReviewBase):
 
             # Extract unified channel removals (preferred)
             channel_removals = metadata_section.get("channel_removals", [])
-            if channel_removals:
-                # Build bad_channels list from unified removals
-                bad_channels = [r["channel"] for r in channel_removals]
-            else:
-                # Fallback to legacy bad channels extraction
-                bad_channels = metadata_section.get("step_clean_bad_channels", {}).get(
-                    "bads", []
-                )
+            bad_channels = _bad_channels_from_metadata(metadata_section)
 
             # Extract rejected ICA components
             ica_rejection = metadata_section.get(
@@ -5848,15 +5856,8 @@ class ExclusionFileSelector(ReviewBase):
             channel_removals = metadata_section.get("channel_removals", [])
             if channel_removals and isinstance(channel_removals, list):
                 result["channel_removals"] = channel_removals
-                # Build bad_channels list from removals for backward compatibility
-                result["bad_channels"] = [r["channel"] for r in channel_removals]
-            else:
-                # Fallback to legacy bad channels extraction
-                bad_channels = metadata_section.get("step_clean_bad_channels", {}).get(
-                    "bads", []
-                )
-                if isinstance(bad_channels, list):
-                    result["bad_channels"] = bad_channels
+
+            result["bad_channels"] = _bad_channels_from_metadata(metadata_section)
 
             # Extract rejected ICA components
             ica_rejection = metadata_section.get(

--- a/tests/unit/tools/test_autoclean_exclude.py
+++ b/tests/unit/tools/test_autoclean_exclude.py
@@ -60,11 +60,7 @@ def test_parse_metadata_json_preserves_legacy_bad_channels(tmp_path):
     json_path = tmp_path / "metadata.json"
     json_path.write_text(
         json.dumps(
-            {
-                "metadata": {
-                    "step_clean_bad_channels": {"bads": ["E3", "E1", "E3"]}
-                }
-            }
+            {"metadata": {"step_clean_bad_channels": {"bads": ["E3", "E1", "E3"]}}}
         ),
         encoding="utf-8",
     )

--- a/tests/unit/tools/test_autoclean_exclude.py
+++ b/tests/unit/tools/test_autoclean_exclude.py
@@ -1,0 +1,74 @@
+"""Focused tests for exclusion GUI metadata loading."""
+
+import json
+from copy import deepcopy
+
+from autoclean.tools.autoclean_exclude import (
+    ExclusionFileSelector,
+    _bad_channels_from_metadata,
+    _unique_channels,
+)
+
+
+def test_bad_channels_from_duplicate_removal_reasons_is_unique_and_stable():
+    metadata = {
+        "channel_removals": [
+            {"channel": "E2", "reason": "UNCORRELATED"},
+            {"channel": "E1", "reason": "RANSAC"},
+            {"channel": "E2", "reason": "RANSAC"},
+        ]
+    }
+    original_metadata = deepcopy(metadata)
+
+    assert _bad_channels_from_metadata(metadata) == ["E2", "E1"]
+    assert metadata == original_metadata
+
+
+def test_unique_channels_keeps_saved_selection_unique_and_stable():
+    assert _unique_channels(["E2", "E1", "E2", "E3", "E1"]) == [
+        "E2",
+        "E1",
+        "E3",
+    ]
+
+
+def test_bad_channels_from_legacy_metadata_preserves_nonduplicate_behavior():
+    metadata = {"step_clean_bad_channels": {"bads": ["E3", "E1"]}}
+
+    assert _bad_channels_from_metadata(metadata) == ["E3", "E1"]
+
+
+def test_parse_metadata_json_deduplicates_channels_but_preserves_removals(tmp_path):
+    channel_removals = [
+        {"channel": "E2", "reason": "UNCORRELATED"},
+        {"channel": "E1", "reason": "RANSAC"},
+        {"channel": "E2", "reason": "RANSAC"},
+    ]
+    json_path = tmp_path / "metadata.json"
+    json_path.write_text(
+        json.dumps({"metadata": {"channel_removals": channel_removals}}),
+        encoding="utf-8",
+    )
+
+    result = ExclusionFileSelector._parse_metadata_json(None, json_path)
+
+    assert result["bad_channels"] == ["E2", "E1"]
+    assert result["channel_removals"] == channel_removals
+
+
+def test_parse_metadata_json_preserves_legacy_bad_channels(tmp_path):
+    json_path = tmp_path / "metadata.json"
+    json_path.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "step_clean_bad_channels": {"bads": ["E3", "E1", "E3"]}
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ExclusionFileSelector._parse_metadata_json(None, json_path)
+
+    assert result["bad_channels"] == ["E3", "E1"]


### PR DESCRIPTION
## Summary

- de-duplicate operational bad-channel lists in stable first-seen order
- preserve all original `channel_removals` entries and their distinct reasons
- normalize both metadata parser paths and the reprocess widget boundary
- add focused helper and parser regression coverage

## Root cause

The Exclude reprocess paths converted valid duplicate audit records directly into operational channel selections. A channel flagged for multiple reasons could therefore appear more than once in the GUI and reprocess payload.

## Impact

Each channel now appears once in display and reprocess selections while its complete reason history remains available for audit and explanation.

## Validation

- `git diff --check`: passed
- Python AST parsing: passed
- Cricket independent QA: passed after two correction cycles
- Cipher security/data-integrity review: no findings
- The Boulder exact-diff review: no code findings
- Focused pytest execution is pending: available Python runtimes lack pytest, and uv cache initialization fails with Windows OS error 183

Closes #288