### PR TITLE
fix: isolate run report channel metadata

### DIFF
--- a/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
+++ b/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
@@ -16,7 +16,7 @@
       <dt>Source thread ID</dt><dd>019f42de-12c8-7681-b931-f19e15bdde8d</dd>
       <dt>Local work thread ID</dt><dd>T-2026-08-17-001; CI correction T-2026-08-17-002</dd>
       <dt>Role task thread ID</dt><dd>01a00fb9-7b0d-7a21-8579-a4a014d6435a</dd>
-      <dt>Status</dt><dd>Internal draft; Ruff F401 correction complete; Cricket and CI checks pending</dd>
+      <dt>Status</dt><dd>Internal draft; corrected and verified green on GitHub Actions</dd>
       <dt>Record type</dt><dd>Execution update</dd>
     </dl>
 
@@ -119,12 +119,18 @@
     unused-import finding. After removing that import, Raven reran CI's exact pinned
     Black, isort, and Ruff versions locally; all passed, as recorded above. Cricket's
     final evidence acknowledgment and a GitHub Actions rerun are pending.</p>
+    <p>Authoritative post-correction GitHub Actions run
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32038406434">32038406434</a>
+    passed quality, tests, package, frontend, and docs at code head
+    <code>9ef172ad58bc4c1a8edbaa26001172f15862a4a0</code>. Companion Claude review run
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32038406441">32038406441</a>
+    also passed. Cricket accepted the durable pinned-tool evidence and marked the
+    correction safe for push.</p>
 
     <h2>Next Actions</h2>
     <ol>
-      <li>Cricket performs read-only verification that the final Python diff removes only the unused import.</li>
-      <li>GitHub Actions reruns the exact pinned Black, isort, and Ruff quality checks after a later approved commit/push.</li>
-      <li>Raven coordinates any integration step; merge and publication remain PI-gated.</li>
+      <li>The documentation-only custody commit containing this result must retain green PR-head checks.</li>
+      <li>Raven performs the final mergeability/conflict audit; merge and publication remain PI-gated.</li>
     </ol>
 
     <h2>Publication Boundary</h2>

--- a/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
+++ b/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
@@ -95,10 +95,15 @@
     </ol>
 
     <h2>Publication Boundary</h2>
-    <p>Internal draft only; do not publish. The record contains repository paths, branch
-    and revision identifiers, but no credentials, patient-level data, or scientific
-    results. All test inputs are synthetic. Publication requires Raven review and an
-    explicit approved archive-integration step.</p>
+    <p>Internal project record; not published to the public correspondence archive.
+    Draft GitHub PR
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/pull/291">#291</a>
+    was opened against <code>main</code> from
+    <code>codex/fix-289-isolate-report-channels</code> at reviewed head
+    <code>36608ec5ea2d4f46328a4e588b70d4581246aa26</code>. The PR remains draft,
+    dynamic pytest verification remains pending, and merge remains PI-gated. The
+    record contains no credentials, patient-level data, or scientific results; all
+    test inputs are synthetic.</p>
   </main>
 </body>
 </html>

--- a/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
+++ b/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
@@ -14,9 +14,9 @@
       <dt>Date</dt><dd>2026-08-17</dd>
       <dt>Re</dt><dd>GitHub issue #289, "Run report can show flagged channels from another file"</dd>
       <dt>Source thread ID</dt><dd>019f42de-12c8-7681-b931-f19e15bdde8d</dd>
-      <dt>Local work thread ID</dt><dd>T-2026-08-17-001</dd>
+      <dt>Local work thread ID</dt><dd>T-2026-08-17-001; CI correction T-2026-08-17-002</dd>
       <dt>Role task thread ID</dt><dd>01a00fb9-7b0d-7a21-8579-a4a014d6435a</dd>
-      <dt>Status</dt><dd>Internal draft; independently reviewed; dynamic tests blocked</dd>
+      <dt>Status</dt><dd>Internal draft; formatting-only CI correction complete; Cricket check pending</dd>
       <dt>Record type</dt><dd>Execution update</dd>
     </dl>
 
@@ -48,6 +48,13 @@
     constant used by summary and TSV generation, and applies stable first-seen uniqueness
     within each summary category. A channel recorded under different reasons remains in
     every applicable category. Global <code>removed_channels</code> behavior is unchanged.</p>
+    <p>GitHub Actions run
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32036043439">32036043439</a>
+    reported passing tests, package, frontend, docs, and Claude review checks. Quality job
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32036043439/job/95406640048">95406640048</a>
+    failed only because Black would reformat the two changed Python files. River applied
+    the corresponding whitespace-only layouts; production and test semantics were not
+    changed.</p>
 
     <h2>Scope Limits</h2>
     <p>No data definitions, schemas, scientific or statistical behavior, TSV filenames,
@@ -64,11 +71,14 @@
       <li>Static command: <code>git diff --check</code>; same cwd; elapsed 0.37 s; exit 0; no output.</li>
       <li>Static command: <code>python -B -c "import ast, pathlib; ..."</code>; same cwd; completed during a 1.59 s combined availability probe; AST parsing passed for both modified Python files. The combined probe exited 1 only because neither Black nor isort was discoverable by <code>Get-Command</code>; no formatter ran.</li>
       <li>Modified artifacts: <code>src/autoclean/step_functions/reports.py</code>, <code>tests/unit/reporting/test_reports.py</code>, and this correspondence file.</li>
+      <li>CI correction custody: branch <code>codex/fix-289-isolate-report-channels</code>, clean starting status, repository root as above, HEAD <code>37a3844e68379098facd7fab2cb2601d7aee71bf</code>.</li>
+      <li>Formatting-only proof: AST hashes before and after were identical. <code>reports.py</code>: <code>c16ac9c7d68d41a7ae333c8d388147221dc4e9ecdcd9a60c35c47aa695e7fb5f</code>; <code>test_reports.py</code>: <code>8360129c97f4ba4b58b7f535a13091e7d6a9b741aeffc32f7849c812d1bfa716</code>.</li>
     </ul>
 
     <h2>Conflict Status</h2>
     <p>No conflict flagged. Cricket's two actionable QA findings were accepted and
-    corrected within the approved scope. Flag/Respond/Decide/Document state: not applicable.</p>
+    corrected within the approved scope. GitHub reports PR #291 as mergeable with no
+    conflicts. Flag/Respond/Decide/Document state: not applicable.</p>
 
     <h2>Execution Decision</h2>
     <p>Disposition: implemented within approved scope. Owner: River. Rationale: current
@@ -85,13 +95,15 @@
     retest passed all acceptance criteria. Cipher completed a bounded security and
     data-integrity review with no findings. The Boulder found no code defects and
     classified the change as conditionally ready subject to running the focused reporting
-    tests in a functioning pytest environment.</p>
+    tests in a functioning pytest environment. GitHub Actions subsequently passed the
+    test job; only Black formatting failed. The formatting-only correction preserves
+    identical ASTs, and Cricket's read-only check of this final correction is pending.</p>
 
     <h2>Next Actions</h2>
     <ol>
-      <li>Run the focused <code>TestCreateJsonSummary</code> reporting tests in a functioning pytest environment; stop on any failure.</li>
-      <li>Run named Black/isort check-only validation when the project tools are available.</li>
-      <li>Raven integrates the reviewed branch while preserving the documented dynamic-verification gap; merge and publication remain PI-gated.</li>
+      <li>Cricket performs read-only verification that the final diff is formatting-only; stop on any semantic difference.</li>
+      <li>GitHub Actions reruns the authoritative Black quality check after a later approved commit/push.</li>
+      <li>Raven coordinates any integration step; merge and publication remain PI-gated.</li>
     </ol>
 
     <h2>Publication Boundary</h2>
@@ -99,9 +111,9 @@
     Draft GitHub PR
     <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/pull/291">#291</a>
     was opened against <code>main</code> from
-    <code>codex/fix-289-isolate-report-channels</code> at reviewed head
-    <code>36608ec5ea2d4f46328a4e588b70d4581246aa26</code>. The PR remains draft,
-    dynamic pytest verification remains pending, and merge remains PI-gated. The
+    <code>codex/fix-289-isolate-report-channels</code>. CI correction started from head
+    <code>37a3844e68379098facd7fab2cb2601d7aee71bf</code>. The PR has no conflicts;
+    the formatting correction remains uncommitted and merge remains PI-gated. The
     record contains no credentials, patient-level data, or scientific results; all
     test inputs are synthetic.</p>
   </main>

--- a/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
+++ b/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
@@ -16,7 +16,7 @@
       <dt>Source thread ID</dt><dd>019f42de-12c8-7681-b931-f19e15bdde8d</dd>
       <dt>Local work thread ID</dt><dd>T-2026-08-17-001; CI correction T-2026-08-17-002</dd>
       <dt>Role task thread ID</dt><dd>01a00fb9-7b0d-7a21-8579-a4a014d6435a</dd>
-      <dt>Status</dt><dd>Internal draft; formatting-only CI correction complete; Cricket check pending</dd>
+      <dt>Status</dt><dd>Internal draft; Ruff F401 correction complete; Cricket and CI checks pending</dd>
       <dt>Record type</dt><dd>Execution update</dd>
     </dl>
 
@@ -55,6 +55,14 @@
     failed only because Black would reformat the two changed Python files. River applied
     the corresponding whitespace-only layouts; production and test semantics were not
     changed.</p>
+    <p>Follow-up GitHub Actions run
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32037965820">32037965820</a>
+    reached quality job
+    <a href="https://github.com/cincibrainlab/autocleaneeg_pipeline/actions/runs/32037965820/job/95412025547">95412025547</a>.
+    After Black 25.9.0 and isort 6.0.1 passed, Ruff 0.15.20 reported only
+    <code>F401</code> at <code>tests/unit/reporting/test_reports.py:4</code> because
+    <code>json</code> was imported but unused. River removed only that import; Cricket
+    verification and the authoritative CI rerun remain pending.</p>
 
     <h2>Scope Limits</h2>
     <p>No data definitions, schemas, scientific or statistical behavior, TSV filenames,
@@ -73,6 +81,15 @@
       <li>Modified artifacts: <code>src/autoclean/step_functions/reports.py</code>, <code>tests/unit/reporting/test_reports.py</code>, and this correspondence file.</li>
       <li>CI correction custody: branch <code>codex/fix-289-isolate-report-channels</code>, clean starting status, repository root as above, HEAD <code>37a3844e68379098facd7fab2cb2601d7aee71bf</code>.</li>
       <li>Formatting-only proof: AST hashes before and after were identical. <code>reports.py</code>: <code>c16ac9c7d68d41a7ae333c8d388147221dc4e9ecdcd9a60c35c47aa695e7fb5f</code>; <code>test_reports.py</code>: <code>8360129c97f4ba4b58b7f535a13091e7d6a9b741aeffc32f7849c812d1bfa716</code>.</li>
+      <li>Lint follow-up custody: clean branch <code>codex/fix-289-isolate-report-channels</code> at HEAD <code>9f75dbbc8c7e56a5a6ea780d1c0c28990f8d1987</code>. The approved correction removes the single unused <code>json</code> import and updates this record.</li>
+      <li>Raven exact-tool verification used an isolated temporary uv cache and CI's
+      pinned commands: <code>uvx --from black==25.9.0 black --check
+      src/autoclean/step_functions/reports.py tests/unit/reporting/test_reports.py</code>,
+      exit 0, reported both files unchanged; <code>uvx --from isort==6.0.1 isort
+      --check-only</code> on the same files, exit 0; and <code>uvx --from
+      ruff==0.15.20 ruff check</code> on the same files, exit 0 with
+      <code>All checks passed!</code>. <code>git diff --check</code> also passed.
+      The tools were ephemeral; no project dependency or lockfile changed.</li>
     </ul>
 
     <h2>Conflict Status</h2>
@@ -98,11 +115,15 @@
     tests in a functioning pytest environment. GitHub Actions subsequently passed the
     test job; only Black formatting failed. The formatting-only correction preserves
     identical ASTs, and Cricket's read-only check of this final correction is pending.</p>
+    <p>The next pinned quality run passed Black and isort before Ruff exposed the sole
+    unused-import finding. After removing that import, Raven reran CI's exact pinned
+    Black, isort, and Ruff versions locally; all passed, as recorded above. Cricket's
+    final evidence acknowledgment and a GitHub Actions rerun are pending.</p>
 
     <h2>Next Actions</h2>
     <ol>
-      <li>Cricket performs read-only verification that the final diff is formatting-only; stop on any semantic difference.</li>
-      <li>GitHub Actions reruns the authoritative Black quality check after a later approved commit/push.</li>
+      <li>Cricket performs read-only verification that the final Python diff removes only the unused import.</li>
+      <li>GitHub Actions reruns the exact pinned Black, isort, and Ruff quality checks after a later approved commit/push.</li>
       <li>Raven coordinates any integration step; merge and publication remain PI-gated.</li>
     </ol>
 

--- a/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
+++ b/plans/correspondance/029-issue-289-isolate-run-report-channels-execution.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>029 - Issue 289 isolate run report channels execution</title>
+</head>
+<body>
+  <main>
+    <h1>Correspondence 029: Issue #289 run-report channel isolation</h1>
+    <dl>
+      <dt>From</dt><dd>River - Data Engineer</dd>
+      <dt>To</dt><dd>Raven - Engineering Delivery and Loop Coordinator</dd>
+      <dt>Date</dt><dd>2026-08-17</dd>
+      <dt>Re</dt><dd>GitHub issue #289, "Run report can show flagged channels from another file"</dd>
+      <dt>Source thread ID</dt><dd>019f42de-12c8-7681-b931-f19e15bdde8d</dd>
+      <dt>Local work thread ID</dt><dd>T-2026-08-17-001</dd>
+      <dt>Role task thread ID</dt><dd>01a00fb9-7b0d-7a21-8579-a4a014d6435a</dd>
+      <dt>Status</dt><dd>Internal draft; independently reviewed; dynamic tests blocked</dd>
+      <dt>Record type</dt><dd>Execution update</dd>
+    </dl>
+
+    <h2>Request Summary</h2>
+    <p>PI-approved, Raven-routed implementation to ensure each JSON run summary derives
+    flagged-channel categories from its own run metadata instead of wildcard-selecting a
+    TSV from the shared reports directory. Non-goals were report redesign, schema or
+    filename changes, unrelated cleanup, worktree/branch/PR creation, publication, and
+    environment mutation. The approved files were the reporting implementation, its
+    smallest unit-test surface, and this execution artifact. No specialist consultation
+    was requested or performed.</p>
+
+    <h2>Execution Update</h2>
+    <p><code>create_json_summary</code> no longer scans <code>reports/run_reports</code>
+    or a derivatives-side legacy TSV. It builds backward-compatible report labels from
+    the current run's <code>channel_removals</code> entries using the same reason labels
+    already used by <code>generate_bad_channels_tsv</code>. Existing step-level channel
+    metadata remains available, and the existing stable first-seen deduplication of
+    <code>removed_channels</code> is unchanged.</p>
+    <p>Focused tests call <code>create_json_summary</code> directly and cover a foreign
+    shared TSV, metadata before the current TSV exists, two run-specific channel sets in
+    both processing orders while both TSV artifacts exist, and stable unique removed
+    channels. On the prior implementation, the foreign-TSV and metadata-before-TSV tests
+    fail, and the two-run test fails because sorted wildcard selection supplies the first
+    run's labels to the second run.</p>
+    <p>Cricket's QA pass identified duplicated reason-label mappings and duplicate
+    category entries when the same channel/reason audit event repeats. The correction
+    introduces one plainly named module-level <code>CHANNEL_REMOVAL_REASON_LABELS</code>
+    constant used by summary and TSV generation, and applies stable first-seen uniqueness
+    within each summary category. A channel recorded under different reasons remains in
+    every applicable category. Global <code>removed_channels</code> behavior is unchanged.</p>
+
+    <h2>Scope Limits</h2>
+    <p>No data definitions, schemas, scientific or statistical behavior, TSV filenames,
+    pipeline sequencing, report architecture, dependencies, integration tests, commits,
+    pushes, PRs, external systems, or public archive were changed. Dynamic tests were not
+    run because the delegated environment record states pytest is absent and uv cache
+    initialization fails with OS error 183; the instructions explicitly prohibited uv
+    retries, installation, or environment mutation.</p>
+
+    <h2>Evidence</h2>
+    <ul>
+      <li>Baseline command: <code>git branch --show-current; git status --short; git rev-parse --show-toplevel; git rev-parse HEAD</code>; cwd <code>C:\Users\SYEX8X\Documents\autocleaneeg_pipeline</code>; elapsed 0.80 s; exit 0. Result: branch <code>codex/fix-289-isolate-report-channels</code>, clean status, expected repository root, HEAD <code>e095cc60debf3e0aa4bda7525f2936f7eb0bebe0</code>. Git emitted only a permission warning for the user-level global ignore file.</li>
+      <li>Implementation inspection used <code>rg</code> plus bounded reads of <code>create_json_summary</code>, <code>generate_bad_channels_tsv</code>, and <code>tests/unit/reporting/test_reports.py</code>. The observed sequence and label mapping support metadata as the per-run source of truth.</li>
+      <li>Static command: <code>git diff --check</code>; same cwd; elapsed 0.37 s; exit 0; no output.</li>
+      <li>Static command: <code>python -B -c "import ast, pathlib; ..."</code>; same cwd; completed during a 1.59 s combined availability probe; AST parsing passed for both modified Python files. The combined probe exited 1 only because neither Black nor isort was discoverable by <code>Get-Command</code>; no formatter ran.</li>
+      <li>Modified artifacts: <code>src/autoclean/step_functions/reports.py</code>, <code>tests/unit/reporting/test_reports.py</code>, and this correspondence file.</li>
+    </ul>
+
+    <h2>Conflict Status</h2>
+    <p>No conflict flagged. Cricket's two actionable QA findings were accepted and
+    corrected within the approved scope. Flag/Respond/Decide/Document state: not applicable.</p>
+
+    <h2>Execution Decision</h2>
+    <p>Disposition: implemented within approved scope. Owner: River. Rationale: current
+    run-record metadata is available before TSV generation and cannot leak state across
+    runs; shared-directory artifacts cannot safely identify the current file. Remaining
+    PI gate: Raven-directed independent review and any later commit/push/merge decision.</p>
+
+    <h2>Verification</h2>
+    <p>Maker static verification by River: <code>git diff --check</code> passed and both
+    changed Python files passed AST parsing. Dynamic pytest verification is blocked by
+    the unchanged environment and was deliberately not attempted. Known gap: tests have
+    not executed in this task. Cricket's initial review found the shared-mapping and
+    per-category uniqueness defects; River corrected both, and Cricket's independent
+    retest passed all acceptance criteria. Cipher completed a bounded security and
+    data-integrity review with no findings. The Boulder found no code defects and
+    classified the change as conditionally ready subject to running the focused reporting
+    tests in a functioning pytest environment.</p>
+
+    <h2>Next Actions</h2>
+    <ol>
+      <li>Run the focused <code>TestCreateJsonSummary</code> reporting tests in a functioning pytest environment; stop on any failure.</li>
+      <li>Run named Black/isort check-only validation when the project tools are available.</li>
+      <li>Raven integrates the reviewed branch while preserving the documented dynamic-verification gap; merge and publication remain PI-gated.</li>
+    </ol>
+
+    <h2>Publication Boundary</h2>
+    <p>Internal draft only; do not publish. The record contains repository paths, branch
+    and revision identifiers, but no credentials, patient-level data, or scientific
+    results. All test inputs are synthetic. Publication requires Raven review and an
+    explicit approved archive-integration step.</p>
+  </main>
+</body>
+</html>

--- a/src/autoclean/step_functions/reports.py
+++ b/src/autoclean/step_functions/reports.py
@@ -23,7 +23,7 @@ import os
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import matplotlib
 import pandas as pd
@@ -48,6 +48,19 @@ __all__ = [
     "create_json_summary",
     "generate_bad_channels_tsv",
 ]
+
+CHANNEL_REMOVAL_REASON_LABELS = {
+    "NOISY": "Noisy",
+    "UNCORRELATED": "Uncorrelated",
+    "DEVIATION": "Deviation",
+    "RANSAC": "Ransac",
+    "BRIDGED": "Bridged",
+    "RANK": "Rank",
+    "EOG_DROPPED": "EOG",
+    "OUTER_LAYER": "OuterLayer",
+    "MANUAL_EXCLUDE": "Manual",
+    "TEMPLATE_EXCLUDE": "Template",
+}
 
 # Force matplotlib to use non-interactive backend for async operations
 matplotlib.use("Agg")
@@ -1464,38 +1477,15 @@ def create_json_summary(run_id: str, flagged_reasons: list[str] = []) -> dict:
             "ransac_channels"
         ]
 
-    flagged_chs_path: Optional[Path] = None
-    run_reports_dir = reports_dir / "run_reports"
-    if run_reports_dir.exists():
-        candidates = sorted(run_reports_dir.glob("*flagged_channels.tsv"))
-        if not candidates:
-            candidates = sorted(run_reports_dir.glob("*FlaggedChs.tsv"))
-        if candidates:
-            flagged_chs_path = candidates[0]
-
-    if flagged_chs_path is None:
-        legacy_path = derivatives_dir / "FlaggedChs.tsv"
-        if legacy_path.exists():
-            flagged_chs_path = legacy_path
-
-    if flagged_chs_path and not flagged_chs_path.name.startswith("._"):
-        try:
-            with open(flagged_chs_path, "r", encoding="utf8", errors="strict") as f:
-                # Skip the header line
-                next(f)
-                # Read each line and extract the label and channel name
-                for line in f:
-                    parts = line.strip().split("\t")
-                    if len(parts) == 2:
-                        label, channel = parts
-                        if label not in channel_dict:
-                            channel_dict[label] = []
-                        channel_dict[label].append(channel)
-        except UnicodeDecodeError:
-            message(
-                "warning",
-                f"Skipping flagged-channels file with invalid encoding: {flagged_chs_path.name}",
-            )
+    # Build report labels only from this run's metadata. The flagged-channels TSV is
+    # generated after this summary and the reports directory is shared across runs.
+    for removal in metadata.get("channel_removals", []):
+        label = CHANNEL_REMOVAL_REASON_LABELS.get(
+            removal["reason"], removal["reason"]
+        )
+        category = channel_dict.setdefault(label, [])
+        if removal["channel"] not in category:
+            category.append(removal["channel"])
 
     # Add outer layer dropped channels as a named category in channel_dict
     if "step_drop_outerlayer" in metadata:
@@ -1913,19 +1903,9 @@ def generate_bad_channels_tsv(summary_dict: Dict[str, Any]) -> None:
         # Use unified removals (includes all sources)
         for removal in unified_removals:
             # Map reason codes to TSV labels (backward compatible)
-            reason_map = {
-                "NOISY": "Noisy",
-                "UNCORRELATED": "Uncorrelated",
-                "DEVIATION": "Deviation",
-                "RANSAC": "Ransac",
-                "BRIDGED": "Bridged",
-                "RANK": "Rank",
-                "EOG_DROPPED": "EOG",
-                "OUTER_LAYER": "OuterLayer",
-                "MANUAL_EXCLUDE": "Manual",
-                "TEMPLATE_EXCLUDE": "Template",
-            }
-            label = reason_map.get(removal["reason"], removal["reason"])
+            label = CHANNEL_REMOVAL_REASON_LABELS.get(
+                removal["reason"], removal["reason"]
+            )
             channels_to_write.append((label, removal["channel"]))
     else:
         # Fallback: use legacy detection lists

--- a/src/autoclean/step_functions/reports.py
+++ b/src/autoclean/step_functions/reports.py
@@ -1480,9 +1480,7 @@ def create_json_summary(run_id: str, flagged_reasons: list[str] = []) -> dict:
     # Build report labels only from this run's metadata. The flagged-channels TSV is
     # generated after this summary and the reports directory is shared across runs.
     for removal in metadata.get("channel_removals", []):
-        label = CHANNEL_REMOVAL_REASON_LABELS.get(
-            removal["reason"], removal["reason"]
-        )
+        label = CHANNEL_REMOVAL_REASON_LABELS.get(removal["reason"], removal["reason"])
         category = channel_dict.setdefault(label, [])
         if removal["channel"] not in category:
             category.append(removal["channel"])

--- a/tests/unit/reporting/test_reports.py
+++ b/tests/unit/reporting/test_reports.py
@@ -231,7 +231,9 @@ class TestCreateRunReport:
             return_value=run_record,
         ):
             # Should not raise
-            create_run_report(run_id=run_record["run_id"], autoclean_dict=None, json_summary={})
+            create_run_report(
+                run_id=run_record["run_id"], autoclean_dict=None, json_summary={}
+            )
 
     def test_skips_sections_for_missing_step_prepare_directories(self, tmp_path):
         """Returns when required step_prepare_directories metadata key is missing."""

--- a/tests/unit/reporting/test_reports.py
+++ b/tests/unit/reporting/test_reports.py
@@ -256,6 +256,41 @@ class TestCreateRunReport:
 
 
 class TestCreateJsonSummary:
+    @staticmethod
+    def _run_record(tmp_path, run_id, channel_removals):
+        derivatives_dir = tmp_path / "derivatives" / run_id
+        derivatives_dir.mkdir(parents=True)
+        for directory in ["metadata", "reports", "ica", "exports", "bids"]:
+            (tmp_path / directory).mkdir(exist_ok=True)
+
+        return {
+            "run_id": run_id,
+            "task": "TestTask",
+            "created_at": "2026-08-17 00:00:00",
+            "success": True,
+            "report_file": f"{run_id}_autoclean_report.pdf",
+            "metadata": {
+                "step_create_bids_path": {
+                    "derivatives_dir": str(derivatives_dir),
+                    "bids_subject": run_id,
+                },
+                "step_prepare_directories": {
+                    "bids": str(tmp_path / "bids"),
+                    "metadata": str(tmp_path / "metadata"),
+                    "reports": str(tmp_path / "reports"),
+                    "ica": str(tmp_path / "ica"),
+                    "exports": str(tmp_path / "exports"),
+                },
+                "import_eeg": {
+                    "sampleRate": 500,
+                    "channelCount": 3,
+                    "durationSec": 10,
+                    "unprocessedFile": f"{run_id}.set",
+                },
+                "channel_removals": channel_removals,
+            },
+        }
+
     def test_returns_none_when_no_run_record(self, tmp_path):
         """create_json_summary returns None when run_id not in DB."""
         with patch(
@@ -318,3 +353,127 @@ class TestCreateJsonSummary:
                 result = None
         # The call itself should not crash unhandled — None or dict is acceptable
         assert result is None or isinstance(result, dict)
+
+    def test_ignores_foreign_flagged_channels_tsv(self, tmp_path):
+        """A shared report artifact from another file cannot affect this run."""
+        run_record = self._run_record(
+            tmp_path,
+            "current",
+            [{"channel": "E1", "reason": "NOISY"}],
+        )
+        run_reports = tmp_path / "reports" / "run_reports"
+        run_reports.mkdir()
+        (run_reports / "foreign_flagged_channels.tsv").write_text(
+            "label\tchannel\nNoisy\tE99\n", encoding="utf8"
+        )
+
+        with patch(
+            "autoclean.step_functions.reports.get_run_record",
+            return_value=run_record,
+        ):
+            result = create_json_summary(run_id="current")
+
+        assert result["channel_dict"]["Noisy"] == ["E1"]
+        assert "E99" not in result["channel_dict"]["removed_channels"]
+
+    def test_current_metadata_wins_before_current_tsv_exists(self, tmp_path):
+        """Current removal metadata supplies labels before TSV generation."""
+        run_record = self._run_record(
+            tmp_path,
+            "current",
+            [
+                {"channel": "E2", "reason": "UNCORRELATED"},
+                {"channel": "E3", "reason": "MANUAL_EXCLUDE"},
+            ],
+        )
+
+        with patch(
+            "autoclean.step_functions.reports.get_run_record",
+            return_value=run_record,
+        ):
+            result = create_json_summary(run_id="current")
+
+        assert not (tmp_path / "reports" / "run_reports").exists()
+        assert result["channel_dict"]["Uncorrelated"] == ["E2"]
+        assert result["channel_dict"]["Manual"] == ["E3"]
+
+    @pytest.mark.parametrize("order", [("first", "second"), ("second", "first")])
+    def test_runs_keep_channel_sets_isolated_in_any_order(self, tmp_path, order):
+        """Two summaries sharing a reports directory remain order-independent."""
+        records = {
+            "first": self._run_record(
+                tmp_path,
+                "first",
+                [{"channel": "E1", "reason": "NOISY"}],
+            ),
+            "second": self._run_record(
+                tmp_path,
+                "second",
+                [{"channel": "E2", "reason": "RANSAC"}],
+            ),
+        }
+        run_reports = tmp_path / "reports" / "run_reports"
+        run_reports.mkdir()
+        (run_reports / "first_flagged_channels.tsv").write_text(
+            "label\tchannel\nNoisy\tE1\n", encoding="utf8"
+        )
+        (run_reports / "second_flagged_channels.tsv").write_text(
+            "label\tchannel\nRansac\tE2\n", encoding="utf8"
+        )
+        results = {}
+
+        for run_id in order:
+            with patch(
+                "autoclean.step_functions.reports.get_run_record",
+                return_value=records[run_id],
+            ):
+                results[run_id] = create_json_summary(run_id=run_id)
+
+        assert results["first"]["channel_dict"]["removed_channels"] == ["E1"]
+        assert results["second"]["channel_dict"]["removed_channels"] == ["E2"]
+        assert results["first"]["channel_dict"]["Noisy"] == ["E1"]
+        assert results["second"]["channel_dict"]["Ransac"] == ["E2"]
+        assert "Ransac" not in results["first"]["channel_dict"]
+        assert "Noisy" not in results["second"]["channel_dict"]
+
+    def test_removed_channels_are_unique_and_stable(self, tmp_path):
+        """Repeated audit entries retain order without duplicating removals."""
+        run_record = self._run_record(
+            tmp_path,
+            "current",
+            [
+                {"channel": "E2", "reason": "NOISY"},
+                {"channel": "E1", "reason": "RANSAC"},
+                {"channel": "E2", "reason": "MANUAL_EXCLUDE"},
+            ],
+        )
+
+        with patch(
+            "autoclean.step_functions.reports.get_run_record",
+            return_value=run_record,
+        ):
+            result = create_json_summary(run_id="current")
+
+        assert result["channel_dict"]["removed_channels"] == ["E2", "E1"]
+        assert result["channel_dict"]["Noisy"] == ["E2"]
+        assert result["channel_dict"]["Manual"] == ["E2"]
+
+    def test_category_deduplicates_repeated_channel_and_reason(self, tmp_path):
+        """Repeated same-reason audit entries produce one category item."""
+        run_record = self._run_record(
+            tmp_path,
+            "current",
+            [
+                {"channel": "E2", "reason": "NOISY"},
+                {"channel": "E2", "reason": "NOISY"},
+            ],
+        )
+
+        with patch(
+            "autoclean.step_functions.reports.get_run_record",
+            return_value=run_record,
+        ):
+            result = create_json_summary(run_id="current")
+
+        assert result["channel_dict"]["Noisy"] == ["E2"]
+        assert result["channel_dict"]["removed_channels"] == ["E2"]

--- a/tests/unit/reporting/test_reports.py
+++ b/tests/unit/reporting/test_reports.py
@@ -1,7 +1,6 @@
 """Unit tests for step_functions/reports.py."""
 
 import csv
-import json
 from pathlib import Path
 from unittest.mock import patch
 


### PR DESCRIPTION
## Summary

- stop `create_json_summary` from reading wildcard-selected flagged-channel TSV files
- derive report channel categories only from the current run record
- share the existing reason-to-label mapping with TSV generation
- keep category and global channel lists stable and unique
- add cross-file, ordering, pre-TSV, and de-duplication regression coverage

## Root cause

The current run summary was created before its flagged-channel TSV was generated. Scanning the shared report directory could therefore select only a stale or foreign file and leak another recording's channels into the report.

## Impact

A report's bad-channel content is now isolated to its own run metadata. Batch order and unrelated report artifacts cannot alter the summary.

## Validation

- `git diff --check`: passed
- Python AST parsing: passed
- Cricket independent QA: passed after the shared-mapping and category-uniqueness corrections
- Cipher security/data-integrity review: no findings
- The Boulder exact-diff review: no code findings
- Focused pytest execution is pending: available Python runtimes lack pytest, and uv cache initialization fails with Windows OS error 183

Closes #289