### PR TITLE
Fix: don't count interpolated channels as removed in reports

### DIFF
--- a/src/autoclean/mixins/base.py
+++ b/src/autoclean/mixins/base.py
@@ -283,6 +283,7 @@ class BaseMixin:
         channels: Union[str, list],
         reason: str,
         source_step: str,
+        action: str = "dropped",
     ) -> None:
         """Track channel removal in unified metadata.
 
@@ -297,6 +298,12 @@ class BaseMixin:
                    'RANK', 'MANUAL_EXCLUDE', 'MANUAL_OVERRIDE', 'TEMPLATE_EXCLUDE')
             source_step: Name of the step that removed the channel(s)
                         (e.g., 'drop_eog_channels', 'drop_outer_layer')
+            action: What actually happened to the channel: 'dropped' (physically
+                   removed from the data, the default), 'interpolated' (flagged
+                   bad but reconstructed in place), or 'marked' (flagged bad but
+                   left untouched). Only 'dropped' reduces the channel count --
+                   report generation uses this field to avoid subtracting
+                   interpolated/marked channels from the expected final count.
         """
         if not hasattr(self, "config") or not self.config.get("run_id"):
             return
@@ -337,6 +344,7 @@ class BaseMixin:
                         "channel": channel,
                         "reason": reason,
                         "source_step": source_step,
+                        "action": action,
                         "timestamp": timestamp,
                     }
                 )

--- a/src/autoclean/mixins/base.py
+++ b/src/autoclean/mixins/base.py
@@ -334,7 +334,13 @@ class BaseMixin:
         # Add new removal entries with deduplication
         timestamp = datetime.now().isoformat()
         for channel in channels:
-            # Check if this channel+reason combo already exists
+            # Check if this channel+reason combo already exists. Note: the
+            # dedup key is (channel, reason) only, not action -- if a caller
+            # ever tracks the same channel+reason twice with a different
+            # action in one run, the second call's action is silently
+            # dropped. No current call site does this (each channel+reason
+            # pair is tracked at most once per run), but keep it in mind
+            # before reusing a reason code for a differently-resolved action.
             if not any(
                 r["channel"] == channel and r["reason"] == reason
                 for r in channel_removals

--- a/src/autoclean/mixins/signal_processing/channels.py
+++ b/src/autoclean/mixins/signal_processing/channels.py
@@ -200,6 +200,17 @@ class ChannelsMixin:
                 if cleaning_method is not _UNSET
                 else resolved.cleaning_method
             )
+            # Only "drop" physically removes channels from the data. Both
+            # "interpolate" (reconstructed in place) and an explicit
+            # cleaning_method=None (left marked bad, untouched) keep every
+            # channel in the exported file, so neither should reduce the
+            # expected final channel count.
+            if final_cleaning_method == "drop":
+                removal_action = "dropped"
+            elif final_cleaning_method == "interpolate":
+                removal_action = "interpolated"
+            else:
+                removal_action = "marked"
 
             message(
                 "info",
@@ -313,6 +324,7 @@ class ChannelsMixin:
                         channels=channel,
                         reason="MANUAL_OVERRIDE",
                         source_step="clean_bad_channels",
+                        action=removal_action,
                     )
             else:
                 message("info", f"Detected {len(bads)} bad channels: {bads}")
@@ -323,18 +335,28 @@ class ChannelsMixin:
                         channels=channel,
                         reason="UNCORRELATED",
                         source_step="clean_bad_channels",
+                        action=removal_action,
                     )
                 for channel in deviation_channels:
                     self._track_channel_removal(
                         channels=channel,
                         reason="DEVIATION",
                         source_step="clean_bad_channels",
+                        action=removal_action,
                     )
                 for channel in ransac_channels:
                     self._track_channel_removal(
                         channels=channel,
                         reason="RANSAC",
                         source_step="clean_bad_channels",
+                        action=removal_action,
+                    )
+                if imported_bad_channels:
+                    self._track_channel_removal(
+                        channels=imported_bad_channels,
+                        reason="BAD_CHANNEL_LOG",
+                        source_step="bad_channel_log",
+                        action=removal_action,
                     )
 
             # Update metadata
@@ -443,11 +465,10 @@ class ChannelsMixin:
 
         if applied:
             raw.info["bads"] = list(dict.fromkeys([*raw.info["bads"], *applied]))
-            self._track_channel_removal(
-                channels=applied,
-                reason="BAD_CHANNEL_LOG",
-                source_step="bad_channel_log",
-            )
+            # Not tracked here: the caller (clean_bad_channels) doesn't yet know
+            # whether these channels will end up interpolated or dropped. It
+            # tracks them itself, tagged with the correct action, once the
+            # cleaning method for this run is resolved.
             message("info", f"Applied bad-channel log channels: {applied}")
 
         self._record_bad_channel_log_metadata(

--- a/src/autoclean/step_functions/reports.py
+++ b/src/autoclean/step_functions/reports.py
@@ -1917,29 +1917,27 @@ def generate_bad_channels_tsv(summary_dict: Dict[str, Any]) -> None:
             label = CHANNEL_REMOVAL_REASON_LABELS.get(
                 removal["reason"], removal["reason"]
             )
-            action = removal.get("action", "dropped")
-            channels_to_write.append((label, removal["channel"], action))
+            channels_to_write.append((label, removal["channel"]))
     else:
-        # Fallback: use legacy detection lists (action unknown, assume dropped)
+        # Fallback: use legacy detection lists
         for channel in noisy_channels:
-            channels_to_write.append(("Noisy", channel, "dropped"))
+            channels_to_write.append(("Noisy", channel))
         for channel in uncorrelated_channels:
-            channels_to_write.append(("Uncorrelated", channel, "dropped"))
+            channels_to_write.append(("Uncorrelated", channel))
         for channel in deviation_channels:
-            channels_to_write.append(("Deviation", channel, "dropped"))
+            channels_to_write.append(("Deviation", channel))
         for channel in ransac_channels:
-            channels_to_write.append(("Ransac", channel, "dropped"))
+            channels_to_write.append(("Ransac", channel))
         for channel in bridged_channels:
-            channels_to_write.append(("Bridged", channel, "dropped"))
+            channels_to_write.append(("Bridged", channel))
         for channel in rank_channels:
-            channels_to_write.append(("Rank", channel, "dropped"))
+            channels_to_write.append(("Rank", channel))
 
-    # Write TSV file (adds an "action" column; label/channel stay in the
-    # original first two columns for backward compatibility)
+    # Write TSV file (backward compatible format)
     with flagged_path.open("w", encoding="utf8") as f:
-        f.write("label\tchannel\taction\n")
-        for label, channel, action in channels_to_write:
-            f.write(f"{label}\t{channel}\t{action}\n")
+        f.write("label\tchannel\n")
+        for label, channel in channels_to_write:
+            f.write(f"{label}\t{channel}\n")
 
     summary_dict["flagged_channels_file"] = str(flagged_path)
 

--- a/src/autoclean/step_functions/reports.py
+++ b/src/autoclean/step_functions/reports.py
@@ -1505,19 +1505,31 @@ def create_json_summary(run_id: str, flagged_reasons: list[str] = []) -> dict:
         unified_removals = metadata["channel_removals"]
         unique_bad_channels = []
         unique_interpolated_channels = []
+        unique_marked_channels = []
         for removal in unified_removals:
             # "interpolated" and "marked" channels stay in the exported data
             # (unlike "dropped"), so they don't reduce the expected channel
             # count. Entries predating this field have no "action" and are
-            # treated as "dropped" to preserve prior report behavior.
-            if removal.get("action") in ("interpolated", "marked"):
+            # treated as "dropped" to preserve prior report behavior. Kept as
+            # separate lists (rather than one combined bucket) since they
+            # aren't the same thing: "interpolated" channels are
+            # reconstructed from neighbors, "marked" channels are left
+            # untouched -- collapsing them could read as "this channel's
+            # data was fixed" when it wasn't.
+            action = removal.get("action")
+            if action == "interpolated":
                 if removal["channel"] not in unique_interpolated_channels:
                     unique_interpolated_channels.append(removal["channel"])
+                continue
+            if action == "marked":
+                if removal["channel"] not in unique_marked_channels:
+                    unique_marked_channels.append(removal["channel"])
                 continue
             if removal["channel"] not in unique_bad_channels:
                 unique_bad_channels.append(removal["channel"])
         channel_dict["removed_channels"] = unique_bad_channels
         channel_dict["interpolated_channels"] = unique_interpolated_channels
+        channel_dict["marked_channels"] = unique_marked_channels
     else:
         # Fallback: legacy method using channel_dict values
         bad_channels = [

--- a/src/autoclean/step_functions/reports.py
+++ b/src/autoclean/step_functions/reports.py
@@ -1498,13 +1498,26 @@ def create_json_summary(run_id: str, flagged_reasons: list[str] = []) -> dict:
 
     # Get all removed channels from unified metadata (preferred) or legacy sources
     if "channel_removals" in metadata:
-        # Use unified channel removals for accurate tracking
+        # Use unified channel removals for accurate tracking. Interpolated
+        # channels are reconstructed in place (not physically removed), so
+        # they're excluded here and tracked separately -- otherwise they'd be
+        # double-counted against the final exported channel count.
         unified_removals = metadata["channel_removals"]
         unique_bad_channels = []
+        unique_interpolated_channels = []
         for removal in unified_removals:
+            # "interpolated" and "marked" channels stay in the exported data
+            # (unlike "dropped"), so they don't reduce the expected channel
+            # count. Entries predating this field have no "action" and are
+            # treated as "dropped" to preserve prior report behavior.
+            if removal.get("action") in ("interpolated", "marked"):
+                if removal["channel"] not in unique_interpolated_channels:
+                    unique_interpolated_channels.append(removal["channel"])
+                continue
             if removal["channel"] not in unique_bad_channels:
                 unique_bad_channels.append(removal["channel"])
         channel_dict["removed_channels"] = unique_bad_channels
+        channel_dict["interpolated_channels"] = unique_interpolated_channels
     else:
         # Fallback: legacy method using channel_dict values
         bad_channels = [
@@ -1904,27 +1917,29 @@ def generate_bad_channels_tsv(summary_dict: Dict[str, Any]) -> None:
             label = CHANNEL_REMOVAL_REASON_LABELS.get(
                 removal["reason"], removal["reason"]
             )
-            channels_to_write.append((label, removal["channel"]))
+            action = removal.get("action", "dropped")
+            channels_to_write.append((label, removal["channel"], action))
     else:
-        # Fallback: use legacy detection lists
+        # Fallback: use legacy detection lists (action unknown, assume dropped)
         for channel in noisy_channels:
-            channels_to_write.append(("Noisy", channel))
+            channels_to_write.append(("Noisy", channel, "dropped"))
         for channel in uncorrelated_channels:
-            channels_to_write.append(("Uncorrelated", channel))
+            channels_to_write.append(("Uncorrelated", channel, "dropped"))
         for channel in deviation_channels:
-            channels_to_write.append(("Deviation", channel))
+            channels_to_write.append(("Deviation", channel, "dropped"))
         for channel in ransac_channels:
-            channels_to_write.append(("Ransac", channel))
+            channels_to_write.append(("Ransac", channel, "dropped"))
         for channel in bridged_channels:
-            channels_to_write.append(("Bridged", channel))
+            channels_to_write.append(("Bridged", channel, "dropped"))
         for channel in rank_channels:
-            channels_to_write.append(("Rank", channel))
+            channels_to_write.append(("Rank", channel, "dropped"))
 
-    # Write TSV file (backward compatible format)
+    # Write TSV file (adds an "action" column; label/channel stay in the
+    # original first two columns for backward compatibility)
     with flagged_path.open("w", encoding="utf8") as f:
-        f.write("label\tchannel\n")
-        for label, channel in channels_to_write:
-            f.write(f"{label}\t{channel}\n")
+        f.write("label\tchannel\taction\n")
+        for label, channel, action in channels_to_write:
+            f.write(f"{label}\t{channel}\t{action}\n")
 
     summary_dict["flagged_channels_file"] = str(flagged_path)
 

--- a/tests/unit/mixins/test_channels.py
+++ b/tests/unit/mixins/test_channels.py
@@ -199,6 +199,55 @@ class TestCleanBadChannels:
         # After interpolation with reset_bads=True (default), bads list should be empty
         assert ch_to_mark not in result.info["bads"]
 
+    def test_track_channel_removal_action_matches_cleaning_method(self, task):
+        """Regression test for #292: channels tracked as 'interpolated' when
+        cleaning_method='interpolate', not 'dropped' -- interpolated channels
+        stay in the exported data, so reports must not treat them as removed."""
+        ch_to_mark = task.raw.ch_names[3]
+
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal") as mock_track,
+        ):
+            task.clean_bad_channels(
+                data=task.raw,
+                manual_bad_channels=[ch_to_mark],
+                cleaning_method="interpolate",
+            )
+
+        mock_track.assert_called_once_with(
+            channels=ch_to_mark,
+            reason="MANUAL_OVERRIDE",
+            source_step="clean_bad_channels",
+            action="interpolated",
+        )
+
+    def test_track_channel_removal_action_is_dropped_for_drop_method(self, task):
+        """cleaning_method='drop' physically removes channels, so they should
+        still be tracked as 'dropped'."""
+        ch_to_mark = task.raw.ch_names[3]
+
+        with (
+            patch.object(task, "_update_metadata"),
+            patch.object(task, "_save_raw_result"),
+            patch.object(task, "_update_instance_data"),
+            patch.object(task, "_track_channel_removal") as mock_track,
+        ):
+            task.clean_bad_channels(
+                data=task.raw,
+                manual_bad_channels=[ch_to_mark],
+                cleaning_method="drop",
+            )
+
+        mock_track.assert_called_once_with(
+            channels=ch_to_mark,
+            reason="MANUAL_OVERRIDE",
+            source_step="clean_bad_channels",
+            action="dropped",
+        )
+
     def test_raises_type_error_for_non_raw_input(self, task):
         with pytest.raises(TypeError):
             task.clean_bad_channels(data="not_raw")

--- a/tests/unit/reporting/test_reports.py
+++ b/tests/unit/reporting/test_reports.py
@@ -478,3 +478,65 @@ class TestCreateJsonSummary:
 
         assert result["channel_dict"]["Noisy"] == ["E2"]
         assert result["channel_dict"]["removed_channels"] == ["E2"]
+
+    def test_interpolated_channels_excluded_from_expected_count(self, tmp_path):
+        """Regression test for #292: interpolated channels stay in the export,
+        so they must not be subtracted from the expected channel count (which
+        previously produced a false "channel count mismatch" warning)."""
+        run_record = self._run_record(
+            tmp_path,
+            "current",
+            [
+                {"channel": "E1", "reason": "UNCORRELATED", "action": "interpolated"},
+                {"channel": "E2", "reason": "DEVIATION", "action": "interpolated"},
+            ],
+        )
+        # import_eeg.channelCount is 3; both bad channels were interpolated,
+        # so the exported file should still have all 3 channels.
+        run_record["metadata"]["save_epochs_to_set"] = {
+            "tmin": 0,
+            "tmax": 1,
+            "n_epochs": 1,
+            "n_channels": 3,
+        }
+
+        with patch(
+            "autoclean.step_functions.reports.get_run_record",
+            return_value=run_record,
+        ):
+            result = create_json_summary(run_id="current")
+
+        assert result["channel_dict"]["removed_channels"] == []
+        assert result["channel_dict"]["interpolated_channels"] == ["E1", "E2"]
+        assert result["export_details"]["net_nbchan_post"] == 3
+        assert "channel_count_mismatch" not in result["export_details"]
+
+    def test_channel_count_mismatch_still_detected_for_dropped_channels(
+        self, tmp_path
+    ):
+        """Dropped channels must still be subtracted from the expected count,
+        so a genuine mismatch is still caught."""
+        run_record = self._run_record(
+            tmp_path,
+            "current",
+            [
+                {"channel": "E1", "reason": "MANUAL_EXCLUDE", "action": "dropped"},
+            ],
+        )
+        # 3 total channels, 1 dropped -> exported file should have 2, but we
+        # simulate an exported file that still reports 3 to trigger the check.
+        run_record["metadata"]["save_epochs_to_set"] = {
+            "tmin": 0,
+            "tmax": 1,
+            "n_epochs": 1,
+            "n_channels": 3,
+        }
+
+        with patch(
+            "autoclean.step_functions.reports.get_run_record",
+            return_value=run_record,
+        ):
+            result = create_json_summary(run_id="current")
+
+        assert result["channel_dict"]["removed_channels"] == ["E1"]
+        assert result["export_details"]["channel_count_mismatch"] is True

--- a/tests/unit/reporting/test_reports.py
+++ b/tests/unit/reporting/test_reports.py
@@ -508,7 +508,39 @@ class TestCreateJsonSummary:
 
         assert result["channel_dict"]["removed_channels"] == []
         assert result["channel_dict"]["interpolated_channels"] == ["E1", "E2"]
+        assert result["channel_dict"]["marked_channels"] == []
         assert result["export_details"]["net_nbchan_post"] == 3
+        assert "channel_count_mismatch" not in result["export_details"]
+
+    def test_marked_channels_tracked_separately_from_interpolated(self, tmp_path):
+        """Regression test: 'marked' (flagged bad but neither interpolated nor
+        dropped) and 'interpolated' channels are distinct outcomes and must
+        not be collapsed into one bucket -- a 'marked' channel's data was
+        never touched, unlike an interpolated one."""
+        run_record = self._run_record(
+            tmp_path,
+            "current",
+            [
+                {"channel": "E1", "reason": "UNCORRELATED", "action": "interpolated"},
+                {"channel": "E2", "reason": "DEVIATION", "action": "marked"},
+            ],
+        )
+        run_record["metadata"]["save_epochs_to_set"] = {
+            "tmin": 0,
+            "tmax": 1,
+            "n_epochs": 1,
+            "n_channels": 3,
+        }
+
+        with patch(
+            "autoclean.step_functions.reports.get_run_record",
+            return_value=run_record,
+        ):
+            result = create_json_summary(run_id="current")
+
+        assert result["channel_dict"]["removed_channels"] == []
+        assert result["channel_dict"]["interpolated_channels"] == ["E1"]
+        assert result["channel_dict"]["marked_channels"] == ["E2"]
         assert "channel_count_mismatch" not in result["export_details"]
 
     def test_channel_count_mismatch_still_detected_for_dropped_channels(self, tmp_path):

--- a/tests/unit/reporting/test_reports.py
+++ b/tests/unit/reporting/test_reports.py
@@ -511,9 +511,7 @@ class TestCreateJsonSummary:
         assert result["export_details"]["net_nbchan_post"] == 3
         assert "channel_count_mismatch" not in result["export_details"]
 
-    def test_channel_count_mismatch_still_detected_for_dropped_channels(
-        self, tmp_path
-    ):
+    def test_channel_count_mismatch_still_detected_for_dropped_channels(self, tmp_path):
         """Dropped channels must still be subtracted from the expected count,
         so a genuine mismatch is still caught."""
         run_record = self._run_record(

--- a/tests/unit/test_bad_channel_log_import.py
+++ b/tests/unit/test_bad_channel_log_import.py
@@ -38,12 +38,18 @@ class DummyBadChannelLogTask(ChannelsMixin, BaseMixin):
         channels: Any,
         reason: str,
         source_step: str,
+        action: str = "dropped",
     ) -> None:
         if isinstance(channels, str):
             channels = [channels]
         for channel in channels:
             self.tracked_removals.append(
-                {"channel": channel, "reason": reason, "source_step": source_step}
+                {
+                    "channel": channel,
+                    "reason": reason,
+                    "source_step": source_step,
+                    "action": action,
+                }
             )
 
 

--- a/tests/unit/test_clean_bad_channels_manual_override.py
+++ b/tests/unit/test_clean_bad_channels_manual_override.py
@@ -40,12 +40,18 @@ class DummyManualOverrideTask(ChannelsMixin, BaseMixin):
         channels: Any,
         reason: str,
         source_step: str,
+        action: str = "dropped",
     ) -> None:
         if isinstance(channels, str):
             channels = [channels]
         for channel in channels:
             self.tracked_removals.append(
-                {"channel": channel, "reason": reason, "source_step": source_step}
+                {
+                    "channel": channel,
+                    "reason": reason,
+                    "source_step": source_step,
+                    "action": action,
+                }
             )
 
 
@@ -80,6 +86,9 @@ def test_manual_override_skips_detection(monkeypatch, dummy_raw):
     assert all(
         entry["reason"] == "MANUAL_OVERRIDE"
         and entry["source_step"] == "clean_bad_channels"
+        # cleaning_method=None means channels are left marked bad, neither
+        # interpolated nor dropped, so they must not count as removed.
+        and entry["action"] == "marked"
         for entry in task.tracked_removals
     )
 


### PR DESCRIPTION
## Summary
- `_track_channel_removal` now records an `action` (`dropped` / `interpolated` / `marked`) on each channel-removal entry, set from the resolved `cleaning_method` in `clean_bad_channels`.
- Report generation (`create_json_summary`) only subtracts `dropped` entries from the expected channel count, which eliminates the false "Channel count mismatch" warning previously logged whenever bad channels were interpolated (they stay in the exported file, so they shouldn't reduce the expected count). Interpolated/marked channels are now surfaced separately via `channel_dict["interpolated_channels"]`.
- Fixed the same latent bug in the `bad_channel_log` pathway, which was tagging channels as removed before the cleaning method was even resolved.

Fixes #292

## Test plan
- [x] `black --check` / `isort --check-only` / `ruff check` on changed files — all pass
- [x] `mypy src/autoclean` (advisory) — 1638 pre-existing repo-wide errors, none in changed files
- [x] `pytest tests/unit` — 879 passed, 0 failed (added regression tests for the interpolate/drop/mark action tagging and the report's expected-count calculation)
- [x] Verified the flagged-channels TSV format is unchanged (kept backward compatible per `TestBackwardCompatibility::test_legacy_tsv_format_preserved`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)